### PR TITLE
feat(infra): add root make workflow targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,31 @@ That pipeline should include:
 
 Validation should be fast enough for normal developer use but strict enough to prevent obvious regressions from reaching the main branch.
 
+## Preferred Local Commands
+
+The repo has a workspace-level `pyproject.toml` plus package-level `pyproject.toml` files under `apps/` and `packages/`.
+Contributors should prefer the root `Makefile` so the common sync, lint, and test commands run through one documented path.
+
+Current high-value targets:
+
+- `make sync`
+  - install or refresh the root dev/test environment with `uv`
+- `make lint`
+  - run the currently enforced Ruff checks for the Phase 0 schema and migration surfaces
+- `make test`
+  - run the focused schema, migration, and ingest pytest slice
+- `make test-all`
+  - run the full `apps/api/tests` pytest suite
+- `make check`
+  - run `lint` and the focused `test` slice
+- `make pre-push`
+  - run the local validation path expected before pushing changes
+- `make migrate`
+  - apply database migrations from the repo root through the wrapper script
+
+The `pre-push` target is intentionally scoped to checks that are currently expected to pass on this repo state.
+As broader lint and type-check coverage is cleaned up, that target should expand rather than drift into a second undocumented workflow.
+
 ### Automated Version Updates
 
 Packaging and release workflows should update versions automatically in a controlled way rather than relying on manual edits scattered across the repo.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+UV ?= uv
+PYTHON := .venv/bin/python
+PYTEST := $(PYTHON) -m pytest
+RUFF := .venv/bin/ruff
+SCHEMA_TESTS := apps/api/tests/test_schema_definition.py apps/api/tests/test_migrations.py apps/api/tests/test_ingest.py
+LINT_PATHS := apps/api/alembic apps/api/app/migrations.py apps/api/tests/test_schema_definition.py apps/api/tests/test_migrations.py apps/api/tests/test_ingest.py packages/db-schema/photoorg_db_schema
+
+.PHONY: help sync lint test test-all check pre-push migrate
+
+help:
+	@printf '%s\n' \
+		'make sync      - install/update the root dev and test environment' \
+		'make lint      - run the currently enforced ruff checks for Phase 0 schema/tooling surfaces' \
+		'make test      - run the current schema/migration/ingest verification slice' \
+		'make test-all  - run the full apps/api pytest suite' \
+		'make check     - run lint and the focused test slice' \
+		'make pre-push  - run the local validation path expected before push' \
+		'make migrate   - apply database migrations through the repo-root wrapper'
+
+sync:
+	$(UV) sync --group dev --group test
+
+lint:
+	$(RUFF) check $(LINT_PATHS)
+
+test:
+	$(PYTEST) $(SCHEMA_TESTS)
+
+test-all:
+	$(PYTEST) apps/api/tests
+
+check: lint test
+
+pre-push: check
+
+migrate:
+	./scripts/photo-org migrate

--- a/apps/api/tests/test_migrations.py
+++ b/apps/api/tests/test_migrations.py
@@ -1,6 +1,4 @@
 from pathlib import Path
-
-import pytest
 from sqlalchemy import create_engine, inspect, select
 
 from app.processing.ingest import ingest_directory


### PR DESCRIPTION
## Summary
- add a root Makefile with documented sync, lint, test, check, pre-push, and migrate targets
- tighten the contributor workflow documentation around the preferred root-level command path
- keep the initial pre-push scope honest by targeting the currently clean schema and migration surfaces

Closes #69

## Test Plan
- make lint
- make test
- make pre-push