### PR TITLE
feat(api): reconcile missing file lifecycle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,6 +185,9 @@ The default local seed-corpus load target writes its generated SQLite database u
 
 Synthetic fixtures remain preferred for unit tests and BDD scenarios. The checked-in corpus is the fixed real-file dataset for the end-to-end workflow.
 
+For missing-file reconciliation verification, run `uv run python -m pytest apps/api/tests/test_ingest.py -q`.
+That targeted suite exercises a temporary watched-folder fixture and simulated time so contributors can verify `active`, `missing`, `deleted`, and recovery transitions without bringing up the full worker stack.
+
 ### Automated Version Updates
 
 Packaging and release workflows should update versions automatically in a controlled way rather than relying on manual edits scattered across the repo.

--- a/apps/api/app/db/config.py
+++ b/apps/api/app/db/config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 DEFAULT_SQLITE_PATH = Path("apps/api/photoorg.db").resolve()
 DEFAULT_DATABASE_URL = f"sqlite:///{DEFAULT_SQLITE_PATH}"
+DEFAULT_MISSING_FILE_GRACE_PERIOD_DAYS = 1
 
 
 def resolve_database_url(database_url: str | Path | None = None) -> str:
@@ -18,3 +19,16 @@ def resolve_database_url(database_url: str | Path | None = None) -> str:
     if "://" in text_value:
         return text_value
     return f"sqlite:///{Path(text_value).expanduser().resolve()}"
+
+
+def resolve_missing_file_grace_period_days(value: int | None = None) -> int:
+    if value is None:
+        value = int(
+            os.getenv(
+                "MISSING_FILE_GRACE_PERIOD_DAYS",
+                str(DEFAULT_MISSING_FILE_GRACE_PERIOD_DAYS),
+            )
+        )
+    if value < 0:
+        raise ValueError("missing file grace period days must be non-negative")
+    return value

--- a/apps/api/app/processing/ingest.py
+++ b/apps/api/app/processing/ingest.py
@@ -10,7 +10,15 @@ from uuid import NAMESPACE_URL, uuid5
 from sqlalchemy import delete, func, insert, select, update
 from sqlalchemy.engine import Connection
 
+from app.db.config import resolve_missing_file_grace_period_days
 from app.db.queue import IngestQueueStore
+from app.services.file_reconciliation import (
+    activate_observed_file,
+    ensure_watched_folder,
+    refresh_photo_deleted_timestamps,
+    reconcile_watched_folder,
+    utc_now,
+)
 from app.processing.metadata import extract_image_metadata, stat_timestamp_to_iso
 from app.storage import create_db_engine, faces, photos
 
@@ -76,6 +84,67 @@ def ingest_directory(
             result.enqueued += 1
         except Exception as exc:
             result.errors.append(f"{photo_path}: {exc}")
+
+    return result
+
+
+def reconcile_directory(
+    root: str | Path,
+    database_url: str | Path | None = None,
+    *,
+    now: datetime | None = None,
+    missing_file_grace_period_days: int | None = None,
+) -> IngestResult:
+    source_root = Path(root).expanduser().resolve()
+    result = IngestResult()
+    at = now if now is not None else utc_now()
+    grace_period_days = resolve_missing_file_grace_period_days(missing_file_grace_period_days)
+
+    engine = create_db_engine(database_url)
+    with engine.begin() as connection:
+        watched_folder_id = ensure_watched_folder(
+            connection,
+            root_path=_display_path(source_root),
+            now=at,
+        )
+        observed_relative_paths: set[str] = set()
+        touched_photo_ids: set[str] = set()
+
+        for photo_path in iter_photo_files(source_root):
+            result.scanned += 1
+            record = build_photo_record(photo_path)
+            relative_path = _display_path(photo_path)
+            observed_relative_paths.add(relative_path)
+            created = upsert_photo(connection, record)
+            if created:
+                result.inserted += 1
+            else:
+                result.updated += 1
+            touched_photo_ids.add(
+                activate_observed_file(
+                    connection,
+                    watched_folder_id=watched_folder_id,
+                    photo_id=record.photo_id,
+                    relative_path=relative_path,
+                    filename=photo_path.name,
+                    extension=record.ext,
+                    filesize=record.filesize,
+                    created_ts=record.created_ts,
+                    modified_ts=record.modified_ts,
+                    now=at,
+                )
+            )
+
+        touched_photo_ids.update(
+            reconcile_watched_folder(
+                connection,
+                watched_folder_id=watched_folder_id,
+                observed_relative_paths=observed_relative_paths,
+                now=at,
+                missing_file_grace_period_days=grace_period_days,
+            )
+        )
+        refresh_photo_deleted_timestamps(connection, photo_ids=touched_photo_ids, now=at)
 
     return result
 

--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -71,7 +71,7 @@ class PhotosRepository:
 
     def _apply_filters(self, query: Select, filters: SearchFilters, text_query: Optional[str] = None) -> Select:
         """Apply all filters to the query."""
-        where_conditions = []
+        where_conditions = [self.photos.c.deleted_ts.is_(None)]
         
         # Date filters
         if filters.date:

--- a/apps/api/app/services/file_reconciliation.py
+++ b/apps/api/app/services/file_reconciliation.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import NAMESPACE_URL, uuid5
+
+from sqlalchemy import insert, select, update
+from sqlalchemy.engine import Connection
+
+from app.storage import photo_files, photos, watched_folders
+
+
+def ensure_watched_folder(
+    connection: Connection,
+    *,
+    root_path: str,
+    now: datetime,
+) -> str:
+    watched_folder_id = str(uuid5(NAMESPACE_URL, f"watched-folder:{root_path}"))
+    row = connection.execute(
+        select(watched_folders.c.watched_folder_id).where(
+            watched_folders.c.watched_folder_id == watched_folder_id
+        )
+    ).first()
+    if row is None:
+        connection.execute(
+            insert(watched_folders).values(
+                watched_folder_id=watched_folder_id,
+                root_path=root_path,
+                display_name=root_path,
+                is_enabled=1,
+                availability_state="active",
+                last_failure_reason=None,
+                last_successful_scan_ts=now,
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        return watched_folder_id
+
+    connection.execute(
+        update(watched_folders)
+        .where(watched_folders.c.watched_folder_id == watched_folder_id)
+        .values(
+            availability_state="active",
+            last_failure_reason=None,
+            last_successful_scan_ts=now,
+            updated_ts=now,
+        )
+    )
+    return watched_folder_id
+
+
+def activate_observed_file(
+    connection: Connection,
+    *,
+    watched_folder_id: str,
+    photo_id: str,
+    relative_path: str,
+    filename: str,
+    extension: str | None,
+    filesize: int,
+    created_ts: datetime,
+    modified_ts: datetime,
+    now: datetime,
+) -> str:
+    photo_file_id = str(uuid5(NAMESPACE_URL, f"photo-file:{watched_folder_id}:{relative_path}"))
+    row = connection.execute(
+        select(photo_files.c.photo_file_id).where(
+            photo_files.c.photo_file_id == photo_file_id
+        )
+    ).first()
+    values = {
+        "photo_id": photo_id,
+        "watched_folder_id": watched_folder_id,
+        "relative_path": relative_path,
+        "filename": filename,
+        "extension": extension,
+        "filesize": filesize,
+        "created_ts": created_ts,
+        "modified_ts": modified_ts,
+        "last_seen_ts": now,
+        "missing_ts": None,
+        "deleted_ts": None,
+        "lifecycle_state": "active",
+        "absence_reason": None,
+    }
+    if row is None:
+        connection.execute(
+            insert(photo_files).values(
+                photo_file_id=photo_file_id,
+                first_seen_ts=now,
+                **values,
+            )
+        )
+    else:
+        connection.execute(
+            update(photo_files)
+            .where(photo_files.c.photo_file_id == photo_file_id)
+            .values(**values)
+        )
+    return photo_id
+
+
+def reconcile_watched_folder(
+    connection: Connection,
+    *,
+    watched_folder_id: str,
+    observed_relative_paths: set[str],
+    now: datetime,
+    missing_file_grace_period_days: int,
+) -> set[str]:
+    touched_photo_ids: set[str] = set()
+    rows = connection.execute(
+        select(
+            photo_files.c.photo_file_id,
+            photo_files.c.photo_id,
+            photo_files.c.relative_path,
+            photo_files.c.missing_ts,
+            photo_files.c.lifecycle_state,
+        ).where(photo_files.c.watched_folder_id == watched_folder_id)
+    ).mappings()
+
+    for row in rows:
+        if row["relative_path"] in observed_relative_paths:
+            touched_photo_ids.add(row["photo_id"])
+            continue
+
+        touched_photo_ids.add(row["photo_id"])
+        if row["lifecycle_state"] == "active":
+            connection.execute(
+                update(photo_files)
+                .where(photo_files.c.photo_file_id == row["photo_file_id"])
+                .values(
+                    lifecycle_state="missing",
+                    missing_ts=now,
+                    deleted_ts=None,
+                    absence_reason="path_removed",
+                )
+            )
+            if missing_file_grace_period_days != 0:
+                continue
+
+        if row["lifecycle_state"] == "missing" or missing_file_grace_period_days == 0:
+            missing_ts = normalize_timestamp(row["missing_ts"] or now)
+            if missing_file_grace_period_days == 0 or (
+                missing_ts + timedelta(days=missing_file_grace_period_days) <= now
+            ):
+                connection.execute(
+                    update(photo_files)
+                    .where(photo_files.c.photo_file_id == row["photo_file_id"])
+                    .values(
+                        lifecycle_state="deleted",
+                        missing_ts=missing_ts,
+                        deleted_ts=now,
+                        absence_reason="path_removed",
+                    )
+                )
+
+    return touched_photo_ids
+
+
+def refresh_photo_deleted_timestamps(
+    connection: Connection,
+    *,
+    photo_ids: set[str],
+    now: datetime,
+) -> None:
+    for photo_id in photo_ids:
+        file_rows = connection.execute(
+            select(photo_files.c.lifecycle_state).where(photo_files.c.photo_id == photo_id)
+        ).all()
+        if not file_rows:
+            connection.execute(
+                update(photos)
+                .where(photos.c.photo_id == photo_id)
+                .values(deleted_ts=None)
+            )
+            continue
+
+        all_deleted = all(row[0] == "deleted" for row in file_rows)
+        connection.execute(
+            update(photos)
+            .where(photos.c.photo_id == photo_id)
+            .values(deleted_ts=now if all_deleted else None)
+        )
+
+
+def utc_now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def normalize_timestamp(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)

--- a/apps/api/tests/test_ingest.py
+++ b/apps/api/tests/test_ingest.py
@@ -1,13 +1,19 @@
+from datetime import UTC, datetime, timedelta
 import shutil
 from pathlib import Path
 
 import pytest
-from sqlalchemy import create_engine, func, select
+from sqlalchemy import create_engine, func, insert, select
 
 from app.db.queue import IngestQueueStore
 from app.migrations import upgrade_database
-from app.processing.ingest import ingest_directory
-from app.storage import faces, photos
+from app.processing.ingest import ingest_directory, reconcile_directory
+from app.services.file_reconciliation import (
+    activate_observed_file,
+    reconcile_watched_folder,
+    refresh_photo_deleted_timestamps,
+)
+from app.storage import faces, photo_files, photos
 
 
 def _resolve_seed_corpus_dir(start: Path | None = None) -> Path:
@@ -176,6 +182,146 @@ def test_upgrade_database_creates_search_tables(tmp_path):
     assert {"photos", "faces", "photo_tags", "people", "face_labels"} <= tables
 
 
+def test_reconcile_directory_marks_absent_files_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'reconcile-missing.db'}"
+    upgrade_database(db_url)
+
+    reconcile_directory(staged_corpus_dir, database_url=db_url)
+
+    missing_path = staged_corpus_dir / "family-events" / "birthday-park" / "birthday_park_006.jpg"
+    missing_path.unlink()
+
+    reconcile_directory(staged_corpus_dir, database_url=db_url)
+
+    row = load_photo_file_row(
+        db_url,
+        "seed-corpus/family-events/birthday-park/birthday_park_006.jpg",
+    )
+    assert row["lifecycle_state"] == "missing"
+    assert row["missing_ts"] is not None
+    assert row["deleted_ts"] is None
+
+
+def test_reconcile_directory_deletes_missing_file_after_grace_period(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'reconcile-grace.db'}"
+    upgrade_database(db_url)
+
+    now = datetime(2026, 3, 24, tzinfo=UTC)
+    reconcile_directory(staged_corpus_dir, database_url=db_url, now=now)
+
+    missing_path = staged_corpus_dir / "family-events" / "birthday-park" / "birthday_park_006.jpg"
+    missing_path.unlink()
+
+    reconcile_directory(staged_corpus_dir, database_url=db_url, now=now)
+    reconcile_directory(
+        staged_corpus_dir,
+        database_url=db_url,
+        now=now + timedelta(days=1, seconds=1),
+    )
+
+    row = load_photo_file_row(
+        db_url,
+        "seed-corpus/family-events/birthday-park/birthday_park_006.jpg",
+    )
+    assert row["lifecycle_state"] == "deleted"
+    assert row["missing_ts"] == now
+    assert row["deleted_ts"] == now + timedelta(days=1, seconds=1)
+
+
+def test_reconcile_directory_with_zero_day_grace_immediately_deletes_missing_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'reconcile-zero-grace.db'}"
+    upgrade_database(db_url)
+
+    now = datetime(2026, 3, 24, tzinfo=UTC)
+    reconcile_directory(
+        staged_corpus_dir,
+        database_url=db_url,
+        now=now,
+        missing_file_grace_period_days=0,
+    )
+
+    missing_path = staged_corpus_dir / "family-events" / "birthday-park" / "birthday_park_006.jpg"
+    missing_path.unlink()
+
+    reconcile_directory(
+        staged_corpus_dir,
+        database_url=db_url,
+        now=now,
+        missing_file_grace_period_days=0,
+    )
+
+    row = load_photo_file_row(
+        db_url,
+        "seed-corpus/family-events/birthday-park/birthday_park_006.jpg",
+    )
+    assert row["lifecycle_state"] == "deleted"
+    assert row["missing_ts"] == now
+    assert row["deleted_ts"] == now
+
+
+def test_photo_is_soft_deleted_only_when_all_file_instances_are_deleted(tmp_path):
+    database_url = f"sqlite:///{tmp_path / 'photo-soft-delete.db'}"
+    upgrade_database(database_url)
+    seed_photo_with_file_instances(database_url)
+
+    now = datetime(2026, 3, 24, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        touched_photo_ids = reconcile_watched_folder(
+            connection,
+            watched_folder_id="watched-folder-1",
+            observed_relative_paths={"seed-corpus/family-events/birthday-park/birthday_park_001.jpg"},
+            now=now,
+            missing_file_grace_period_days=0,
+        )
+        refresh_photo_deleted_timestamps(connection, photo_ids=touched_photo_ids, now=now)
+
+    assert load_photo_deleted_ts(database_url, "photo-1") is None
+
+    with engine.begin() as connection:
+        touched_photo_ids = reconcile_watched_folder(
+            connection,
+            watched_folder_id="watched-folder-1",
+            observed_relative_paths=set(),
+            now=now,
+            missing_file_grace_period_days=0,
+        )
+        refresh_photo_deleted_timestamps(connection, photo_ids=touched_photo_ids, now=now)
+
+    assert load_photo_deleted_ts(database_url, "photo-1") == now
+
+
+def test_reappearing_file_clears_parent_photo_deleted_timestamp(tmp_path):
+    database_url = f"sqlite:///{tmp_path / 'photo-recover.db'}"
+    upgrade_database(database_url)
+    now = datetime(2026, 3, 24, tzinfo=UTC)
+    seed_deleted_photo_with_file_instance(database_url, deleted_ts=now)
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        activate_observed_file(
+            connection,
+            watched_folder_id="watched-folder-1",
+            photo_id="photo-1",
+            relative_path="seed-corpus/family-events/birthday-park/birthday_park_001.jpg",
+            filename="birthday_park_001.jpg",
+            extension="jpg",
+            filesize=100,
+            created_ts=now,
+            modified_ts=now,
+            now=now,
+        )
+        refresh_photo_deleted_timestamps(connection, photo_ids={"photo-1"}, now=now)
+
+    assert load_photo_deleted_ts(database_url, "photo-1") is None
+
+
 def load_photo_count(database_url: str) -> int:
     engine = create_engine(database_url, future=True)
     with engine.connect() as connection:
@@ -196,6 +342,150 @@ def load_face_count(database_url: str) -> int:
     engine = create_engine(database_url, future=True)
     with engine.connect() as connection:
         return connection.execute(select(func.count()).select_from(faces)).scalar_one()
+
+
+def load_photo_file_row(database_url: str, relative_path: str) -> dict:
+    engine = create_engine(database_url, future=True)
+    with engine.connect() as connection:
+        row = connection.execute(
+            select(photo_files).where(photo_files.c.relative_path == relative_path)
+        ).mappings().one()
+    payload = dict(row)
+    for key in ("created_ts", "modified_ts", "first_seen_ts", "last_seen_ts", "missing_ts", "deleted_ts"):
+        value = payload.get(key)
+        if isinstance(value, datetime) and value.tzinfo is None:
+            payload[key] = value.replace(tzinfo=UTC)
+    return payload
+
+
+def load_photo_deleted_ts(database_url: str, photo_id: str) -> datetime | None:
+    engine = create_engine(database_url, future=True)
+    with engine.connect() as connection:
+        deleted_ts = connection.execute(
+            select(photos.c.deleted_ts).where(photos.c.photo_id == photo_id)
+        ).scalar_one()
+    if isinstance(deleted_ts, datetime) and deleted_ts.tzinfo is None:
+        return deleted_ts.replace(tzinfo=UTC)
+    return deleted_ts
+
+
+def seed_photo_with_file_instances(database_url: str) -> None:
+    now = datetime(2026, 3, 24, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                path="seed-corpus/family-events/birthday-park/birthday_park_001.jpg",
+                sha256="a" * 64,
+                phash=None,
+                filesize=100,
+                ext="jpg",
+                created_ts=now,
+                modified_ts=now,
+                shot_ts=None,
+                shot_ts_source=None,
+                camera_make=None,
+                camera_model=None,
+                software=None,
+                orientation=None,
+                gps_latitude=None,
+                gps_longitude=None,
+                gps_altitude=None,
+                updated_ts=now,
+                deleted_ts=None,
+                faces_count=0,
+                faces_detected_ts=None,
+            )
+        )
+        connection.execute(
+            insert(photo_files),
+            [
+                {
+                    "photo_file_id": "photo-file-1",
+                    "photo_id": "photo-1",
+                    "watched_folder_id": "watched-folder-1",
+                    "relative_path": "seed-corpus/family-events/birthday-park/birthday_park_001.jpg",
+                    "filename": "birthday_park_001.jpg",
+                    "extension": "jpg",
+                    "filesize": 100,
+                    "created_ts": now,
+                    "modified_ts": now,
+                    "first_seen_ts": now,
+                    "last_seen_ts": now,
+                    "missing_ts": None,
+                    "deleted_ts": None,
+                    "lifecycle_state": "active",
+                    "absence_reason": None,
+                },
+                {
+                    "photo_file_id": "photo-file-2",
+                    "photo_id": "photo-1",
+                    "watched_folder_id": "watched-folder-1",
+                    "relative_path": "seed-corpus/family-events/birthday-park/birthday_park_002.jpeg",
+                    "filename": "birthday_park_002.jpeg",
+                    "extension": "jpeg",
+                    "filesize": 100,
+                    "created_ts": now,
+                    "modified_ts": now,
+                    "first_seen_ts": now,
+                    "last_seen_ts": now,
+                    "missing_ts": None,
+                    "deleted_ts": None,
+                    "lifecycle_state": "active",
+                    "absence_reason": None,
+                },
+            ],
+        )
+
+
+def seed_deleted_photo_with_file_instance(database_url: str, *, deleted_ts: datetime) -> None:
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                path="seed-corpus/family-events/birthday-park/birthday_park_001.jpg",
+                sha256="b" * 64,
+                phash=None,
+                filesize=100,
+                ext="jpg",
+                created_ts=deleted_ts,
+                modified_ts=deleted_ts,
+                shot_ts=None,
+                shot_ts_source=None,
+                camera_make=None,
+                camera_model=None,
+                software=None,
+                orientation=None,
+                gps_latitude=None,
+                gps_longitude=None,
+                gps_altitude=None,
+                updated_ts=deleted_ts,
+                deleted_ts=deleted_ts,
+                faces_count=0,
+                faces_detected_ts=None,
+            )
+        )
+        connection.execute(
+            insert(photo_files).values(
+                photo_file_id="photo-file-1",
+                photo_id="photo-1",
+                watched_folder_id="watched-folder-1",
+                relative_path="seed-corpus/family-events/birthday-park/birthday_park_001.jpg",
+                filename="birthday_park_001.jpg",
+                extension="jpg",
+                filesize=100,
+                created_ts=deleted_ts,
+                modified_ts=deleted_ts,
+                first_seen_ts=deleted_ts,
+                last_seen_ts=deleted_ts,
+                missing_ts=deleted_ts,
+                deleted_ts=deleted_ts,
+                lifecycle_state="deleted",
+                absence_reason="path_removed",
+            )
+        )
 
 
 class UnusedFaceDetector:

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -7,12 +7,18 @@ the repository and facet computation services.
 
 import pytest
 from unittest.mock import Mock
-from datetime import datetime
+from datetime import UTC, datetime
 
+from sqlalchemy import create_engine, insert
+from sqlalchemy.orm import Session
+
+from app.migrations import upgrade_database
+from app.repositories.photos_repo import PhotosRepository
 from app.services.search_service import SearchService
 from app.schemas.search_request import SearchRequest, SearchFilters, SortSpec, PageSpec, DateFilter
 from app.schemas.search_response import SearchResponse, Hits, PhotoHit
 from app.core.enums import FilesizeRange
+from app.storage import photos
 
 
 class TestSearchServiceExecution:
@@ -365,3 +371,141 @@ class TestSearchServiceIntegration:
                 page=page_spec,
                 text_query=None
             )
+
+
+class TestPhotosRepositorySoftDeleteFiltering:
+    def test_search_repository_excludes_soft_deleted_photos_by_default(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-soft-delete.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 3, 24, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "active-photo",
+                        "path": "photos/active-photo.jpg",
+                        "sha256": "a" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "deleted-photo",
+                        "path": "photos/deleted-photo.jpg",
+                        "sha256": "b" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": now,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, cursor = repo.search_photos(
+                filters=SearchFilters(),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["active-photo"]
+        assert total == 1
+        assert cursor is not None
+
+    def test_get_filtered_photo_ids_excludes_soft_deleted_photos(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-filtered-ids.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 3, 24, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "active-photo",
+                        "path": "photos/active-photo.jpg",
+                        "sha256": "c" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "deleted-photo",
+                        "path": "photos/deleted-photo.jpg",
+                        "sha256": "d" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": now,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            photo_ids = repo.get_filtered_photo_ids(SearchFilters())
+
+        assert photo_ids == ["active-photo"]

--- a/apps/api/tests/test_seed_corpus_manifest.py
+++ b/apps/api/tests/test_seed_corpus_manifest.py
@@ -45,6 +45,8 @@ def test_seed_corpus_docs_reference_make_targets_and_fixture_boundary():
     assert "make seed-corpus-check" in contributing
     assert "make seed-corpus-load" in contributing
     assert "make test-e2e" in contributing
+    assert "missing-file reconciliation" in contributing
+    assert "`uv run python -m pytest apps/api/tests/test_ingest.py -q`" in contributing
     assert "Generated local artifacts should go under `.local/`." in contributing
     assert "Compose-based stack startup is not yet the supported baseline contributor workflow." in contributing
     assert "For contributor setup and validation commands, see [CONTRIBUTING.md](CONTRIBUTING.md)." in readme

--- a/docs/superpowers/plans/2026-03-24-missing-file-lifecycle.md
+++ b/docs/superpowers/plans/2026-03-24-missing-file-lifecycle.md
@@ -1,0 +1,330 @@
+# Missing File Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement conservative file-instance missing and soft-delete reconciliation with a global grace period, and exclude logically deleted photos from default search results.
+
+**Architecture:** Add a dedicated reconciliation service around `photo_files` so healthy watched-folder scans can update lifecycle state independently from queue transport concerns. Keep `photos` as the logical parent record, derive `photos.deleted_ts` from related file-instance state, and thread a global grace-period config through the reconciliation path.
+
+**Tech Stack:** Python, SQLAlchemy Core, FastAPI app modules, pytest, SQLite-backed migration tests
+
+---
+
+### Task 1: Add Failing Tests For Reconciliation Lifecycle Rules
+
+**Files:**
+- Modify: `apps/api/tests/test_ingest.py`
+- Reference: `apps/api/app/processing/ingest.py`
+- Reference: `apps/api/app/storage.py`
+
+- [ ] **Step 1: Write the failing reconciliation lifecycle tests**
+
+```python
+def test_reconcile_directory_marks_absent_files_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    staged_root = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'reconcile-missing.db'}"
+    upgrade_database(db_url)
+
+    reconcile_directory(staged_root, database_url=db_url)
+    target = staged_root / "family-events" / "birthday-park" / "birthday_park_006.jpg"
+    target.unlink()
+
+    reconcile_directory(staged_root, database_url=db_url)
+
+    row = load_photo_file_row(db_url, "seed-corpus/family-events/birthday-park/birthday_park_006.jpg")
+    assert row["lifecycle_state"] == "missing"
+    assert row["missing_ts"] is not None
+    assert row["deleted_ts"] is None
+
+
+def test_reconcile_directory_deletes_missing_file_after_grace_period(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    staged_root = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'reconcile-deleted.db'}"
+    upgrade_database(db_url)
+
+    first_seen = datetime(2026, 3, 24, tzinfo=UTC)
+    reconcile_directory(staged_root, database_url=db_url, now=first_seen)
+    target = staged_root / "family-events" / "birthday-park" / "birthday_park_006.jpg"
+    target.unlink()
+
+    reconcile_directory(staged_root, database_url=db_url, now=first_seen)
+    reconcile_directory(
+        staged_root,
+        database_url=db_url,
+        now=first_seen + timedelta(days=1, seconds=1),
+    )
+
+    row = load_photo_file_row(db_url, "seed-corpus/family-events/birthday-park/birthday_park_006.jpg")
+    assert row["lifecycle_state"] == "deleted"
+    assert row["deleted_ts"] is not None
+```
+
+- [ ] **Step 2: Run the targeted lifecycle tests to verify they fail**
+
+Run: `PYTHONPATH=apps/api uv run pytest apps/api/tests/test_ingest.py -q`
+Expected: FAIL because `reconcile_directory()` and `photo_files` lifecycle persistence do not exist yet.
+
+- [ ] **Step 3: Add any small test helpers needed for `photo_files` inspection**
+
+Add minimal helpers to `apps/api/tests/test_ingest.py` for:
+
+- reading `photo_files` rows by relative path
+- reading `photos.deleted_ts`
+- controlling reconciliation timestamps in tests
+
+Do not implement reconciliation logic yet.
+
+- [ ] **Step 4: Re-run the targeted lifecycle tests to verify the intended RED state**
+
+Run: `PYTHONPATH=apps/api uv run pytest apps/api/tests/test_ingest.py -q`
+Expected: FAIL specifically on missing reconciliation behavior rather than helper or import errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/tests/test_ingest.py
+git commit -m "test(api): define missing file lifecycle expectations"
+```
+
+### Task 2: Implement The Reconciliation Service And Global Grace-Period Config
+
+**Files:**
+- Modify: `apps/api/app/db/config.py`
+- Modify: `apps/api/app/processing/ingest.py`
+- Modify: `apps/api/app/storage.py`
+- Create: `apps/api/app/services/file_reconciliation.py`
+- Test: `apps/api/tests/test_ingest.py`
+
+- [ ] **Step 1: Write one focused failing test for zero-day grace period**
+
+```python
+def test_reconcile_directory_with_zero_day_grace_immediately_deletes_missing_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    staged_root = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'reconcile-zero-grace.db'}"
+    upgrade_database(db_url)
+
+    now = datetime(2026, 3, 24, tzinfo=UTC)
+    reconcile_directory(staged_root, database_url=db_url, now=now, missing_file_grace_period_days=0)
+    target = staged_root / "family-events" / "birthday-park" / "birthday_park_006.jpg"
+    target.unlink()
+
+    reconcile_directory(staged_root, database_url=db_url, now=now, missing_file_grace_period_days=0)
+
+    row = load_photo_file_row(db_url, "seed-corpus/family-events/birthday-park/birthday_park_006.jpg")
+    assert row["lifecycle_state"] == "deleted"
+```
+
+- [ ] **Step 2: Run the zero-grace test to verify it fails**
+
+Run: `PYTHONPATH=apps/api uv run pytest apps/api/tests/test_ingest.py::test_reconcile_directory_with_zero_day_grace_immediately_deletes_missing_file -q`
+Expected: FAIL because the grace-period config and reconciliation policy are not implemented.
+
+- [ ] **Step 3: Implement minimal reconciliation and config support**
+
+Implement:
+
+- `resolve_missing_file_grace_period_days()` in `apps/api/app/db/config.py`
+- `file_reconciliation.py` with focused functions for:
+  - activating observed file rows
+  - marking absent rows missing
+  - promoting eligible missing rows to deleted
+  - recomputing parent `photos.deleted_ts`
+- `reconcile_directory()` in `apps/api/app/processing/ingest.py` to:
+  - enumerate supported files
+  - ensure observed files have `photos` and `photo_files` records
+  - pass the observed relative-path set plus timestamp into the reconciliation service
+- `app/storage.py` exports needed by the new service for `photo_files` access
+
+Keep the implementation minimal:
+
+- use one watched-root scope identified by the directory path being reconciled
+- create or reuse one `watched_folders` row for that root
+- clear `missing_ts`, `deleted_ts`, and `absence_reason` on reappearance
+- treat `0` grace days as immediate deletion in the same healthy pass
+
+- [ ] **Step 4: Run the lifecycle-focused ingest tests to verify they pass**
+
+Run: `PYTHONPATH=apps/api uv run pytest apps/api/tests/test_ingest.py -q`
+Expected: PASS for the new reconciliation lifecycle tests and existing ingest queue tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/db/config.py apps/api/app/processing/ingest.py apps/api/app/services/file_reconciliation.py apps/api/app/storage.py apps/api/tests/test_ingest.py
+git commit -m "feat(api): reconcile missing files conservatively"
+```
+
+### Task 3: Add Failing Tests For Logical Photo Soft Delete And Recovery
+
+**Files:**
+- Modify: `apps/api/tests/test_ingest.py`
+- Reference: `apps/api/app/services/file_reconciliation.py`
+
+- [ ] **Step 1: Write the failing logical-photo lifecycle tests**
+
+```python
+def test_photo_is_soft_deleted_only_when_all_file_instances_are_deleted(tmp_path):
+    database_url = f"sqlite:///{tmp_path / 'photo-soft-delete.db'}"
+    upgrade_database(database_url)
+
+    seed_photo_with_two_file_instances(database_url)
+    now = datetime(2026, 3, 24, tzinfo=UTC)
+
+    reconcile_photo_file_states(
+        database_url,
+        observed_paths={"watched/photo-a.jpg"},
+        missing_file_grace_period_days=0,
+        now=now,
+    )
+
+    assert load_photo_deleted_ts(database_url, "photo-1") is None
+
+
+def test_reappearing_file_clears_parent_photo_deleted_timestamp(tmp_path):
+    database_url = f"sqlite:///{tmp_path / 'photo-recover.db'}"
+    upgrade_database(database_url)
+
+    seed_deleted_photo_with_file_instance(database_url)
+
+    reconcile_photo_file_states(
+        database_url,
+        observed_paths={"watched/photo-a.jpg"},
+        missing_file_grace_period_days=0,
+        now=datetime(2026, 3, 24, tzinfo=UTC),
+    )
+
+    assert load_photo_deleted_ts(database_url, "photo-1") is None
+```
+
+- [ ] **Step 2: Run the focused logical-photo tests to verify they fail**
+
+Run: `PYTHONPATH=apps/api uv run pytest apps/api/tests/test_ingest.py -q`
+Expected: FAIL because parent `photos.deleted_ts` is not yet derived consistently from `photo_files`.
+
+- [ ] **Step 3: Implement minimal parent-photo soft-delete aggregation**
+
+Update the reconciliation service so:
+
+- parent photo deletion is recomputed for every photo touched by observed or absent file-instance changes
+- `photos.deleted_ts` is set only when all related file instances are `deleted`
+- `photos.deleted_ts` is cleared if any related file instance returns to `active` or `missing`
+
+Keep the aggregation local to the reconciliation module rather than duplicating it elsewhere.
+
+- [ ] **Step 4: Re-run the focused ingest tests to verify logical-photo behavior passes**
+
+Run: `PYTHONPATH=apps/api uv run pytest apps/api/tests/test_ingest.py -q`
+Expected: PASS for the logical-photo deletion and recovery scenarios.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/services/file_reconciliation.py apps/api/tests/test_ingest.py
+git commit -m "feat(api): derive logical photo soft deletes from file state"
+```
+
+### Task 4: Filter Soft-Deleted Photos Out Of Default Search Results
+
+**Files:**
+- Modify: `apps/api/tests/test_search_service.py`
+- Modify: `apps/api/tests/test_main.py`
+- Modify: `apps/api/app/repositories/photos_repo.py`
+- Test: `apps/api/tests/test_search_service.py`
+- Test: `apps/api/tests/test_main.py`
+
+- [ ] **Step 1: Write the failing search coverage**
+
+```python
+def test_search_repository_excludes_soft_deleted_photos_by_default(session):
+    repo = PhotosRepository(session)
+    seed_search_photo(session, photo_id="active-photo", deleted_ts=None)
+    seed_search_photo(session, photo_id="deleted-photo", deleted_ts=datetime(2026, 3, 24, tzinfo=UTC))
+
+    items, total, cursor = repo.search_photos(
+        filters=SearchFilters(),
+        sort=SortSpec(by="shot_ts", dir="desc"),
+        page=PageSpec(limit=50),
+    )
+
+    assert [item["photo_id"] for item in items] == ["active-photo"]
+    assert total == 1
+```
+
+- [ ] **Step 2: Run the targeted search tests to verify they fail**
+
+Run: `PYTHONPATH=apps/api uv run pytest apps/api/tests/test_search_service.py apps/api/tests/test_main.py -q`
+Expected: FAIL because default repository queries still include photos where `deleted_ts` is non-null.
+
+- [ ] **Step 3: Implement the minimal repository filter**
+
+Update `PhotosRepository` so:
+
+- the base search query excludes `photos.deleted_ts IS NOT NULL`
+- filtered photo ID queries for facets exclude soft-deleted photos too
+
+Do not add a user-facing override in this issue.
+
+- [ ] **Step 4: Re-run the targeted search tests to verify they pass**
+
+Run: `PYTHONPATH=apps/api uv run pytest apps/api/tests/test_search_service.py apps/api/tests/test_main.py -q`
+Expected: PASS with deleted photos omitted from default results and counts.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/repositories/photos_repo.py apps/api/tests/test_search_service.py apps/api/tests/test_main.py
+git commit -m "feat(api): hide soft deleted photos from search"
+```
+
+### Task 5: Add A Repeatable End-To-End Verification Path And Finish Validation
+
+**Files:**
+- Modify: `apps/api/tests/test_ingest.py`
+- Modify: `CONTRIBUTING.md`
+- Reference: `docs/superpowers/specs/2026-03-24-missing-file-lifecycle-design.md`
+
+- [ ] **Step 1: Write the failing documentation or end-to-end verification assertion**
+
+```python
+def test_contributing_mentions_missing_file_reconciliation_verification_path():
+    contributing = Path("CONTRIBUTING.md").read_text()
+
+    assert "missing-file reconciliation" in contributing
+    assert "PYTHONPATH=apps/api uv run pytest apps/api/tests/test_ingest.py -q" in contributing
+```
+
+- [ ] **Step 2: Run the focused verification tests to verify they fail**
+
+Run: `PYTHONPATH=apps/api uv run pytest apps/api/tests/test_ingest.py apps/api/tests/test_seed_corpus_manifest.py -q`
+Expected: FAIL because the verification path is not documented yet.
+
+- [ ] **Step 3: Add the minimal contributor-facing verification note**
+
+Document in `CONTRIBUTING.md`:
+
+- the targeted pytest command that exercises missing-file lifecycle behavior
+- that the test uses a temporary watched-folder fixture and simulated time to verify missing, deleted, and recovery transitions
+
+Do not add broader worker-operation documentation in this issue.
+
+- [ ] **Step 4: Run the full validation slice**
+
+Run:
+
+- `PYTHONPATH=apps/api uv run pytest apps/api/tests/test_ingest.py -q`
+- `PYTHONPATH=apps/api uv run pytest apps/api/tests/test_search_service.py apps/api/tests/test_main.py -q`
+
+Expected:
+
+- PASS for the reconciliation and search suites
+- PASS for the representative watched-folder verification path
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CONTRIBUTING.md apps/api/tests/test_ingest.py apps/api/tests/test_search_service.py apps/api/tests/test_main.py
+git commit -m "docs(api): document missing file lifecycle verification"
+```

--- a/docs/superpowers/specs/2026-03-24-missing-file-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-03-24-missing-file-lifecycle-design.md
@@ -1,0 +1,247 @@
+# Missing File Lifecycle Design
+
+Date: 2026-03-24
+Issue: #25
+
+## Context
+
+Issue `#25` covers the conservative missing-file lifecycle described by ADR-0007 and the root-health distinction described by ADR-0009.
+
+The shared schema already includes the core file lifecycle fields:
+
+- `photo_files.last_seen_ts`
+- `photo_files.missing_ts`
+- `photo_files.deleted_ts`
+- `photo_files.lifecycle_state`
+- `photo_files.absence_reason`
+- `photos.deleted_ts`
+
+The current implementation does not use those fields yet.
+
+Today the ingest path:
+
+- scans a directory and enqueues `photo_metadata` payloads
+- processes queue rows into `photos`
+- treats `photos.path` as the active write target
+- does not reconcile absent files over time
+- does not update `photo_files`
+- does not soft-delete logical photos when all file instances disappear
+
+That leaves the accepted ADRs unimplemented even though the schema can support them.
+
+## Decision
+
+Implement issue `#25` as a reconciliation-focused backend slice centered on `photo_files`.
+
+The implementation should:
+
+- introduce a dedicated reconciliation service that owns file-instance lifecycle transitions
+- use a global missing-file grace period in days, default `1`
+- mark absent files `missing` on the first healthy reconciliation pass
+- advance `missing` files to `deleted` once the grace period has elapsed
+- return reappearing files to `active` and clear temporary absence markers
+- soft-delete a logical photo only when all of its file instances are `deleted`
+- clear `photos.deleted_ts` again if any related file instance becomes non-deleted
+- exclude soft-deleted logical photos from default search results
+
+## Approaches Considered
+
+### Recommended: Dedicated Reconciliation Service Around `photo_files`
+
+Add a focused service that receives:
+
+- the watched root identity or root path
+- the set of observed file paths from a healthy scan
+- the current timestamp
+- the global grace-period setting
+
+That service performs file-instance lifecycle updates and then recomputes parent photo deletion state.
+
+Why this is the target:
+
+- keeps lifecycle policy in one place instead of scattering it through queue and search code
+- matches the existing schema, which already distinguishes logical photos from file instances
+- keeps the current queue-processing slice usable while allowing a later worker scan flow to reuse the same reconciliation logic
+- makes later watched-folder availability handling easier because reconciliation already has an explicit service boundary
+
+### Alternative: Extend `upsert_photo()` To Own Missing-File Behavior
+
+This would place reconciliation rules in the existing transitional `photos.path` write flow. It reduces the number of new modules, but it mixes file-instance lifecycle policy into a legacy compatibility path and makes future worker-side scan orchestration harder to reason about.
+
+### Alternative: Derive Photo Deletion Lazily In Read Queries Only
+
+This would avoid some write-time updates, but it pushes core lifecycle semantics into every consumer. The resulting state would be less auditable and harder to inspect operationally, so it is not recommended.
+
+## Design
+
+### Configuration
+
+Use a global configuration value for missing-file deletion grace period:
+
+- environment-backed
+- integer number of days
+- default `1`
+- value `0` means no grace period and allows immediate promotion from `missing` to `deleted` during a healthy reconciliation pass
+
+This issue does not introduce per-folder overrides.
+
+### Reconciliation Boundary
+
+Add a backend reconciliation service dedicated to file lifecycle policy.
+
+Inputs:
+
+- watched folder identifier or watched root path
+- observed paths from a healthy scan
+- reconciliation timestamp
+- grace-period days
+
+Responsibilities:
+
+- upsert or reactivate observed file instances
+- mark absent active file instances as `missing`
+- advance eligible missing file instances to `deleted`
+- reactivate reappearing file instances
+- recompute `photos.deleted_ts` for affected parent photos
+
+This service should be reusable from:
+
+- a representative local watched-folder reconciliation path implemented for this issue
+- later worker-triggered scan flows
+
+### File-Instance Lifecycle Rules
+
+For a healthy scan of a watched root:
+
+1. Every observed file belonging to the root is treated as currently reachable evidence.
+2. If a matching `photo_files` row exists in `active`, `missing`, or `deleted` state, it is updated to:
+   - `lifecycle_state = "active"`
+   - `last_seen_ts = now`
+   - `missing_ts = null`
+   - `deleted_ts = null`
+   - `absence_reason = null`
+3. If no matching `photo_files` row exists, create one in `active` state and associate it with the correct logical photo and watched folder.
+4. Any existing `photo_files` row for that watched folder that was not observed during the healthy scan transitions as follows:
+   - `active -> missing`
+   - set `missing_ts = now` if it was previously null
+   - keep `deleted_ts = null`
+   - set `absence_reason` to a conservative path-level reason such as `path_removed`
+5. A row already in `missing` state becomes `deleted` only when:
+   - the watched root is healthy for the current pass
+   - the file is still absent
+   - either `grace_period_days = 0` or `missing_ts + grace_period_days <= now`
+6. When a row becomes `deleted`:
+   - set `lifecycle_state = "deleted"`
+   - set `deleted_ts = now`
+   - preserve the original `missing_ts`
+
+This issue does not need a richer reason taxonomy than the existing `absence_reason` field can support. It should store enough information to distinguish an ordinary missing-path observation from later unreachable-root behavior.
+
+### Logical Photo Soft Delete Rules
+
+Logical photo deletion remains derived from file-instance lifecycle state.
+
+Rules:
+
+- a photo remains active while any related `photo_files` row is not `deleted`
+- a photo becomes soft-deleted only when all related `photo_files` rows are `deleted`
+- when a photo becomes soft-deleted, set `photos.deleted_ts = now`
+- if any related file instance later returns to `active` or `missing`, clear `photos.deleted_ts`
+
+This keeps soft deletion conservative and reversible.
+
+### Search Behavior
+
+Default search results should exclude soft-deleted logical photos by filtering on:
+
+- `photos.deleted_ts IS NULL`
+
+Photos with missing-but-not-deleted file instances should still appear in search.
+
+This issue does not add new admin or UI surfaces for lifecycle visibility.
+
+### Representative Workflow For This Issue
+
+The implementation should prove the lifecycle behavior through a watched-folder reconciliation path that can be exercised locally.
+
+The representative path should:
+
+- accept a watched folder root
+- enumerate supported files under that root
+- build or refresh the corresponding ingest/domain records for observed files
+- call the reconciliation service with the observed set
+
+This can remain a backend or CLI-oriented workflow for now. The issue does not need a finished production worker service as long as the reconciliation behavior is real and repeatable.
+
+### Relationship To Unreachable Storage
+
+ADR-0009 requires the system to distinguish unreachable roots from file deletion. This issue should stay compatible with that direction without attempting to complete the whole watched-folder health feature.
+
+For issue `#25`:
+
+- healthy-scan behavior is in scope
+- conservative missing-to-deleted transitions are in scope
+- full watched-folder unreachable diagnosis is not in scope
+
+The reconciliation service should therefore be designed so a future caller can suppress missing/deleted advancement when the watched root is not healthy.
+
+## Testing Strategy
+
+Follow TDD during implementation.
+
+### Lifecycle Coverage
+
+Add tests that verify:
+
+- an observed file creates or refreshes an `active` `photo_files` row
+- a previously active but absent file becomes `missing`
+- a missing file that reappears returns to `active` and clears absence markers
+- a zero-day grace period allows immediate `missing -> deleted` advancement during a healthy reconciliation pass
+- a missing file does not become `deleted` before the grace period expires
+- a missing file becomes `deleted` after the grace period expires on a later healthy reconciliation pass
+
+### Logical Photo Coverage
+
+Add tests that verify:
+
+- a photo is not soft-deleted while any related file instance remains active or missing
+- a photo is soft-deleted when all related file instances are deleted
+- a soft-deleted photo becomes active again if a related file instance reappears
+
+### Search Coverage
+
+Add tests that verify:
+
+- default search excludes rows where `photos.deleted_ts` is non-null
+- photos with only missing file instances remain searchable
+
+### Representative Verification Path
+
+Add an automated test or a repeatable local command that:
+
+- sets up a temporary watched folder
+- runs reconciliation with files present
+- removes or hides a file
+- reruns reconciliation before and after the grace window
+- confirms the final file and photo lifecycle state
+
+## Non-Goals
+
+This issue does not attempt to:
+
+- implement the full watched-folder management API
+- complete root-unreachable diagnosis and reporting
+- add new UI for missing or deleted file visibility
+- remove the transitional `photos.path` compatibility field
+- redesign ingest queue transport behavior
+
+## Implementation Notes
+
+The implementation should preserve the existing architecture:
+
+- keep route handlers thin
+- keep lifecycle policy in a dedicated backend service
+- keep persistence details in focused DB modules or repositories
+- avoid duplicating lifecycle rules between reconciliation and search
+
+Where the current code still writes transitional compatibility fields on `photos`, those writes may remain for now, but `photo_files` should become the source of truth for missing/deleted lifecycle state.


### PR DESCRIPTION
## Summary
- add watched-folder file reconciliation with configurable missing-file grace-period handling, including `0` for immediate deletion
- derive logical photo soft deletes from `photo_files` lifecycle state and exclude soft-deleted photos from default search results
- add regression coverage and contributor verification notes for missing-file reconciliation

## Test Plan
- [x] `uv run python -m pytest apps/api/tests/test_seed_corpus_manifest.py -q`
- [x] `uv run python -m pytest apps/api/tests/test_ingest.py -q`
- [x] `uv run python -m pytest apps/api/tests/test_search_service.py -q`