### PR TITLE
[codex] Fix Docker db-service database URL resolution

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -2,5 +2,5 @@ POSTGRES_DB=photoorg
 POSTGRES_USER=photoorg
 POSTGRES_PASSWORD=photoorg
 POSTGRES_PORT=5432
-DATABASE_URL=postgresql+psycopg://photoorg:photoorg@postgres:5432/photoorg
+DB_SERVICE_DATABASE_URL=postgresql+psycopg://photoorg:photoorg@postgres:5432/photoorg
 COMPOSE_DATABASE_URL=postgresql+psycopg://photoorg:photoorg@localhost:5432/photoorg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ The default local DB-service workflow is Compose-based:
 - `make compose-smoke` brings the stack up, enqueues the checked-in seed corpus through the host CLI, processes the queue through the db-service endpoint, and tears the stack back down
 
 The Compose baseline publishes Postgres on host port `5432` by default.
-If you need a different port, override `POSTGRES_PORT` and the matching `COMPOSE_DATABASE_URL`.
+If you need a different port, override `POSTGRES_PORT`, keep `DB_SERVICE_DATABASE_URL` pointed at the `postgres` Compose service, and update the matching host-side `COMPOSE_DATABASE_URL`.
 
 Generated local artifacts should go under `.local/`.
 

--- a/apps/e2e/tests/test_compose_smoke.py
+++ b/apps/e2e/tests/test_compose_smoke.py
@@ -1,6 +1,13 @@
 from pathlib import Path
 
 
+def test_compose_db_service_uses_dedicated_database_url_env_var():
+    compose = Path("compose.yaml").read_text(encoding="utf-8")
+
+    assert "DB_SERVICE_DATABASE_URL" in compose
+    assert "${DATABASE_URL:-" not in compose
+
+
 def test_makefile_documents_compose_targets():
     makefile = Path("Makefile").read_text(encoding="utf-8")
     assert "compose-up:" in makefile

--- a/compose.yaml
+++ b/compose.yaml
@@ -24,7 +24,7 @@ services:
       context: .
       dockerfile: apps/api/Dockerfile
     environment:
-      DATABASE_URL: ${DATABASE_URL:-postgresql+psycopg://photoorg:photoorg@postgres:5432/photoorg}
+      DATABASE_URL: ${DB_SERVICE_DATABASE_URL:-postgresql+psycopg://photoorg:photoorg@postgres:5432/photoorg}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## What changed
- stop the `db-service` container from inheriting the host shell `DATABASE_URL`
- introduce `DB_SERVICE_DATABASE_URL` for the container-side Compose configuration
- update the compose example and contributor docs to keep container and host DSNs separate
- add a regression test that prevents `compose.yaml` from falling back to `${DATABASE_URL:-...}` again

## Why this changed
The Docker service was failing to start because Compose interpolated a host-level `DATABASE_URL` pointing at `localhost:5432` into the container. Inside the container, `localhost` resolves to the container itself, not the `postgres` service, so migrations failed with connection refused.

## Impact
- `db-service` now connects to the Compose `postgres` service by default
- host-side tools can still use `COMPOSE_DATABASE_URL` to reach the published Postgres port
- the failure mode is covered by an automated regression test

## Validation
- `uv run pytest apps/e2e/tests/test_compose_smoke.py -q`
- `DATABASE_URL=postgresql+psycopg://photoorg@localhost:5432/photoorg docker compose config` resolves container `DATABASE_URL` to `postgresql+psycopg://photoorg:photoorg@postgres:5432/photoorg`
