### PR TITLE
[codex] Add environment-aware compose runtimes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,14 +108,18 @@ Current high-value targets:
   - run the local validation path expected before pushing changes
 - `make migrate`
   - apply database migrations from the repo root through the wrapper script
+- `make env-create`
+  - register a local environment with an immutable storage mode and derived local runtime settings
 - `make compose-up`
-  - build and start the Compose baseline with postgres plus db-service
+  - build and start the registered Compose runtime for the selected `PHOTO_ORG_ENVIRONMENT`
 - `make compose-migrate`
-  - rerun database migrations against the Compose baseline without starting the app server
+  - rerun database migrations against the registered Compose runtime for the selected `PHOTO_ORG_ENVIRONMENT`
 - `make compose-down`
-  - stop and remove the Compose baseline
+  - stop and remove the selected environment while preserving named volumes
+- `make compose-down-volumes`
+  - stop and remove the selected environment plus the local Postgres volume
 - `make compose-smoke`
-  - verify the Compose baseline by enqueueing work from the host CLI and processing it through the db-service
+  - verify the selected environment by enqueueing work from the host CLI and processing it through the db-service using that environment's immutable storage mode
 - `make seed-corpus-check`
   - validate the checked-in `seed-corpus/` inventory and manifest
 - `make seed-corpus-load`
@@ -126,15 +130,30 @@ Current high-value targets:
 The `pre-push` target is intentionally scoped to checks that are currently expected to pass on this repo state.
 As broader lint and type-check coverage is cleaned up, that target should expand rather than drift into a second undocumented workflow.
 
-The default local DB-service workflow is Compose-based:
+The default local DB-service workflow is Compose-based and environment-aware.
 
-- `make compose-up` starts postgres and the db-service container
-- `make compose-migrate` reruns schema migration against an existing Compose volume
-- `make compose-down` stops and removes the local Compose stack
-- `make compose-smoke` brings the stack up, enqueues the checked-in seed corpus through the host CLI, processes the queue through the db-service endpoint, and tears the stack back down
+Public local runtime variables are namespaced with `PHOTO_ORG_` so they do not collide with other systems on the same workstation.
+Use `PHOTO_ORG_ENVIRONMENT=<name>` to select a registered local environment, and `make env-create` to create one.
+Environment definitions live under `.local/environments/` and are the authoritative local registry for immutable runtime settings, including storage mode.
+Optionally provide `PHOTO_ORG_ENV_FILE=/path/to/file.env` to load extra configuration for that environment without changing the registry-backed settings.
 
-The Compose baseline publishes Postgres on host port `5432` by default.
-If you need a different port, override `POSTGRES_PORT`, keep `DB_SERVICE_DATABASE_URL` pointed at the `postgres` Compose service, and update the matching host-side `COMPOSE_DATABASE_URL`.
+Examples:
+
+- `make env-create PHOTO_ORG_ENVIRONMENT=dev PHOTO_ORG_ENV_STORAGE_MODE=persistent`
+- `make env-create PHOTO_ORG_ENVIRONMENT=scratch PHOTO_ORG_ENV_STORAGE_MODE=ephemeral`
+- `PHOTO_ORG_ENVIRONMENT=dev make compose-up`
+- `PHOTO_ORG_ENVIRONMENT=alice make compose-up`
+- `PHOTO_ORG_ENVIRONMENT=alice make compose-down`
+- `PHOTO_ORG_ENVIRONMENT=alice PHOTO_ORG_ENV_FILE=.env.alice make compose-migrate`
+
+- `PHOTO_ORG_ENVIRONMENT=<name> make compose-up` starts postgres and the db-service container for that environment
+- `PHOTO_ORG_ENVIRONMENT=<name> make compose-migrate` reruns schema migration against that environment's Compose-managed database
+- `PHOTO_ORG_ENVIRONMENT=<name> make compose-down` stops and removes that environment's local Compose stack while preserving the named Postgres volume for persistent environments
+- `PHOTO_ORG_ENVIRONMENT=<name> make compose-down-volumes` stops and removes that environment's local Compose stack and deletes the named Postgres volume for persistent environments
+- `PHOTO_ORG_ENVIRONMENT=<name> make compose-smoke` brings the stack up, enqueues the checked-in seed corpus through the host CLI, processes the queue through the db-service endpoint, and tears the stack back down using the environment's registered storage mode
+
+At environment creation time, the selected environment derives and records its own Compose project name plus host Postgres and API ports from `PHOTO_ORG_ENVIRONMENT`.
+If you need to override those defaults, provide `PHOTO_ORG_POSTGRES_HOST_PORT`, `PHOTO_ORG_API_HOST_PORT`, `PHOTO_ORG_DB_SERVICE_DATABASE_URL`, and `PHOTO_ORG_COMPOSE_DATABASE_URL` when running `make env-create`.
 
 Generated local artifacts should go under `.local/`.
 

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,55 @@
 UV ?= uv
 COMPOSE ?= docker compose
-COMPOSE_DATABASE_URL ?= postgresql+psycopg://photoorg:photoorg@localhost:5432/photoorg
+LOCAL_DIR := .local
+PHOTO_ORG_ENVIRONMENT ?= dev
+PHOTO_ORG_ENV_FILE ?=
+PHOTO_ORG_ENV_REGISTRY_DIR ?= $(LOCAL_DIR)/environments
+ifneq ($(strip $(PHOTO_ORG_ENV_FILE)),)
+-include $(PHOTO_ORG_ENV_FILE)
+endif
+
+ENVIRONMENT_SLUG := $(shell slug=$$(printf '%s' "$(PHOTO_ORG_ENVIRONMENT)" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$$//'); if [ -n "$$slug" ]; then printf '%s' "$$slug"; else printf 'dev'; fi)
+ENVIRONMENT_HASH := $(shell printf '%s' "$(ENVIRONMENT_SLUG)" | cksum | cut -d' ' -f1)
+PHOTO_ORG_ENV_REGISTRY_FILE := $(PHOTO_ORG_ENV_REGISTRY_DIR)/$(ENVIRONMENT_SLUG).mk
+ifndef PHOTO_ORG_COMPOSE_PROJECT_NAME
+PHOTO_ORG_COMPOSE_PROJECT_NAME := photo-org-$(ENVIRONMENT_SLUG)
+endif
+ifndef PHOTO_ORG_POSTGRES_HOST_PORT
+PHOTO_ORG_POSTGRES_HOST_PORT := $(shell printf '%s' $$((54000 + $(ENVIRONMENT_HASH) % 1000)))
+endif
+ifndef PHOTO_ORG_API_HOST_PORT
+PHOTO_ORG_API_HOST_PORT := $(shell printf '%s' $$((55000 + $(ENVIRONMENT_HASH) % 1000)))
+endif
+ifndef PHOTO_ORG_DB_SERVICE_DATABASE_URL
+PHOTO_ORG_DB_SERVICE_DATABASE_URL := postgresql+psycopg://photoorg:photoorg@postgres:5432/photoorg
+endif
+ifndef PHOTO_ORG_COMPOSE_DATABASE_URL
+PHOTO_ORG_COMPOSE_DATABASE_URL := postgresql+psycopg://photoorg:photoorg@localhost:$(PHOTO_ORG_POSTGRES_HOST_PORT)/photoorg
+endif
+-include $(PHOTO_ORG_ENV_REGISTRY_FILE)
+COMPOSE_ENV_FILE_ARG := $(if $(PHOTO_ORG_ENV_FILE),--env-file $(PHOTO_ORG_ENV_FILE),)
+COMPOSE_BASE := $(COMPOSE) $(COMPOSE_ENV_FILE_ARG) -p $(PHOTO_ORG_COMPOSE_PROJECT_NAME)
+COMPOSE_STACK := $(COMPOSE_BASE) -f compose.yaml $(if $(filter ephemeral,$(PHOTO_ORG_ENV_STORAGE_MODE)),-f compose.ephemeral.yaml)
 PYTHON := .venv/bin/python
 PYTEST := $(PYTHON) -m pytest
 PYTEST_COV_ARGS := --cov --cov-report=term-missing
 RUFF := .venv/bin/ruff
-LOCAL_DIR := .local
 SEED_CORPUS_DB := $(LOCAL_DIR)/seed-corpus/photoorg.db
 SCHEMA_TESTS := apps/api/tests/test_schema_definition.py apps/api/tests/test_migrations.py apps/api/tests/test_ingest.py
 LINT_PATHS := apps/api/alembic apps/api/app/migrations.py apps/api/tests/test_schema_definition.py apps/api/tests/test_migrations.py apps/api/tests/test_ingest.py packages/db-schema/photoorg_db_schema
 
-.PHONY: help sync lint test test-all test-e2e check pre-push migrate compose-up compose-migrate compose-down compose-smoke seed-corpus-check seed-corpus-load
+export PHOTO_ORG_ENVIRONMENT
+export PHOTO_ORG_ENV_FILE
+export PHOTO_ORG_ENV_REGISTRY_DIR
+export PHOTO_ORG_ENV_REGISTRY_FILE
+export PHOTO_ORG_ENV_STORAGE_MODE
+export PHOTO_ORG_COMPOSE_PROJECT_NAME
+export PHOTO_ORG_POSTGRES_HOST_PORT
+export PHOTO_ORG_API_HOST_PORT
+export PHOTO_ORG_DB_SERVICE_DATABASE_URL
+export PHOTO_ORG_COMPOSE_DATABASE_URL
+
+.PHONY: help sync lint test test-all test-e2e check pre-push migrate env-create compose-up compose-migrate compose-down compose-down-volumes compose-smoke seed-corpus-check seed-corpus-load ensure-environment
 
 help:
 	@printf '%s\n' \
@@ -22,10 +61,12 @@ help:
 		'make check     - run lint and the focused test slice' \
 		'make pre-push  - run lint plus the full coverage-enforced test suite' \
 		'make migrate   - apply database migrations through the repo-root wrapper' \
-		'make compose-up - build and start the Compose baseline for postgres plus db-service' \
-		'make compose-migrate - rerun database migrations against the Compose baseline' \
-		'make compose-down - stop and remove the Compose baseline' \
-		'make compose-smoke - verify the Compose baseline with host CLI enqueue plus db-service queue processing' \
+		'make env-create PHOTO_ORG_ENVIRONMENT=<name> PHOTO_ORG_ENV_STORAGE_MODE=<persistent|ephemeral> - register a local environment with immutable storage mode' \
+		'make compose-up PHOTO_ORG_ENVIRONMENT=<name> - build and start the selected registered environment' \
+		'make compose-migrate PHOTO_ORG_ENVIRONMENT=<name> - rerun database migrations for the selected environment' \
+		'make compose-down PHOTO_ORG_ENVIRONMENT=<name> - stop and remove the selected environment while preserving named volumes' \
+		'make compose-down-volumes PHOTO_ORG_ENVIRONMENT=<name> - stop and remove the selected environment plus named volumes' \
+		'make compose-smoke PHOTO_ORG_ENVIRONMENT=<name> - verify the selected registered environment using its immutable storage mode' \
 		'make seed-corpus-check - validate the checked-in seed corpus' \
 		'make seed-corpus-load  - migrate and load the checked-in seed corpus'
 
@@ -51,28 +92,71 @@ pre-push: lint test-all
 migrate:
 	./scripts/photo-org migrate
 
-compose-up:
-	$(COMPOSE) up --build -d
+env-create:
+	@case "$(PHOTO_ORG_ENV_STORAGE_MODE)" in \
+		persistent|ephemeral) ;; \
+		*) printf '%s\n' "PHOTO_ORG_ENV_STORAGE_MODE must be 'persistent' or 'ephemeral'" >&2; exit 1 ;; \
+	esac
+	@mkdir -p "$(PHOTO_ORG_ENV_REGISTRY_DIR)"
+	@candidate="$$(mktemp)"; \
+	printf '%s\n' \
+		"PHOTO_ORG_ENVIRONMENT := $(PHOTO_ORG_ENVIRONMENT)" \
+		"PHOTO_ORG_ENV_STORAGE_MODE := $(PHOTO_ORG_ENV_STORAGE_MODE)" \
+		"PHOTO_ORG_COMPOSE_PROJECT_NAME := $(PHOTO_ORG_COMPOSE_PROJECT_NAME)" \
+		"PHOTO_ORG_POSTGRES_HOST_PORT := $(PHOTO_ORG_POSTGRES_HOST_PORT)" \
+		"PHOTO_ORG_API_HOST_PORT := $(PHOTO_ORG_API_HOST_PORT)" \
+		"PHOTO_ORG_DB_SERVICE_DATABASE_URL := $(PHOTO_ORG_DB_SERVICE_DATABASE_URL)" \
+		"PHOTO_ORG_COMPOSE_DATABASE_URL := $(PHOTO_ORG_COMPOSE_DATABASE_URL)" \
+		> "$$candidate"; \
+	if [ -f "$(PHOTO_ORG_ENV_REGISTRY_FILE)" ]; then \
+		if cmp -s "$$candidate" "$(PHOTO_ORG_ENV_REGISTRY_FILE)"; then \
+			printf '%s\n' "environment already exists: $(PHOTO_ORG_ENVIRONMENT)"; \
+			rm -f "$$candidate"; \
+		else \
+			rm -f "$$candidate"; \
+			printf '%s\n' "environment definition is immutable: $(PHOTO_ORG_ENVIRONMENT)" >&2; \
+			exit 1; \
+		fi; \
+	else \
+		mv "$$candidate" "$(PHOTO_ORG_ENV_REGISTRY_FILE)"; \
+		printf '%s\n' "created environment $(PHOTO_ORG_ENVIRONMENT) at $(PHOTO_ORG_ENV_REGISTRY_FILE)"; \
+	fi
 
-compose-migrate:
-	$(COMPOSE) run --rm db-service python -c "from app.migrations import upgrade_database; upgrade_database()"
+ensure-environment:
+	@if [ ! -f "$(PHOTO_ORG_ENV_REGISTRY_FILE)" ]; then \
+		printf '%s\n' "environment not found: $(PHOTO_ORG_ENVIRONMENT). Run 'make env-create PHOTO_ORG_ENVIRONMENT=$(PHOTO_ORG_ENVIRONMENT) PHOTO_ORG_ENV_STORAGE_MODE=<persistent|ephemeral>' first." >&2; \
+		exit 1; \
+	fi
+	@case "$(PHOTO_ORG_ENV_STORAGE_MODE)" in \
+		persistent|ephemeral) ;; \
+		*) printf '%s\n' "invalid PHOTO_ORG_ENV_STORAGE_MODE for $(PHOTO_ORG_ENVIRONMENT)" >&2; exit 1 ;; \
+	esac
 
-compose-down:
-	$(COMPOSE) down
+compose-up: ensure-environment
+	$(COMPOSE_STACK) up --build -d
 
-compose-smoke:
+compose-migrate: ensure-environment
+	$(COMPOSE_STACK) run --rm db-service python -c "from app.migrations import upgrade_database; upgrade_database()"
+
+compose-down: ensure-environment
+	$(COMPOSE_STACK) down
+
+compose-down-volumes: ensure-environment
+	$(COMPOSE_STACK) down -v
+
+compose-smoke: ensure-environment
 	@set -e; \
-	trap '$(COMPOSE) down -v >/dev/null 2>&1 || true' EXIT; \
-	$(COMPOSE) up --build -d; \
-	until $(COMPOSE) exec -T db-service python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz').read()" >/dev/null 2>&1; do \
-		if $(COMPOSE) ps --status exited --services | grep -q '^db-service$$'; then \
-			$(COMPOSE) logs db-service; \
+	trap '$(COMPOSE_STACK) down -v >/dev/null 2>&1 || true' EXIT; \
+	$(COMPOSE_STACK) up --build -d; \
+	until $(COMPOSE_STACK) exec -T db-service python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz').read()" >/dev/null 2>&1; do \
+		if $(COMPOSE_STACK) ps --status exited --services | grep -q '^db-service$$'; then \
+			$(COMPOSE_STACK) logs db-service; \
 			exit 1; \
 		fi; \
 		sleep 1; \
 	done; \
-	./scripts/photo-org ingest seed-corpus --database-url "$(COMPOSE_DATABASE_URL)"; \
-	processed="$$( $(COMPOSE) exec -T db-service python -c "import json, urllib.request; req = urllib.request.Request('http://localhost:8000/api/v1/internal/ingest-queue/process', data=b'{\"limit\": 1000}', headers={'Content-Type': 'application/json', 'X-Worker-Role': 'ingest-processor'}); print(json.load(urllib.request.urlopen(req))['processed'])" )"; \
+	./scripts/photo-org ingest seed-corpus --database-url "$(PHOTO_ORG_COMPOSE_DATABASE_URL)"; \
+	processed="$$( $(COMPOSE_STACK) exec -T db-service python -c "import json, urllib.request; req = urllib.request.Request('http://localhost:8000/api/v1/internal/ingest-queue/process', data=b'{\"limit\": 1000}', headers={'Content-Type': 'application/json', 'X-Worker-Role': 'ingest-processor'}); print(json.load(urllib.request.urlopen(req))['processed'])" )"; \
 	printf 'processed=%s\n' "$$processed"
 
 seed-corpus-check:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ The intended installation model is:
 - one background worker
 - one PostgreSQL database
 
-The preferred packaging model is Docker Compose, and the default local baseline is the Compose-managed `postgres` plus `db-service` stack.
+The preferred packaging model is Docker Compose, and local operation should support multiple named Photo Organizer environments on one machine.
+Each local environment is an isolated Compose-managed `postgres` plus `db-service` stack selected with `PHOTO_ORG_ENVIRONMENT=<name>`.
+Each environment is created once with an immutable storage mode, either `persistent` or `ephemeral`.
 
 ### Prerequisites
 
@@ -82,14 +84,25 @@ CREATE EXTENSION IF NOT EXISTS vector;
 At a high level, setup should look like this:
 
 1. configure the application environment
-2. start the Compose baseline with `make compose-up`
-3. rerun migrations with `make compose-migrate` if you need to repair an existing Compose volume
-4. open the web interface once the service is healthy
-5. sign in as an admin
-6. add one or more watched folders
-7. let the system ingest the initial corpus
+2. create an environment with `make env-create PHOTO_ORG_ENVIRONMENT=dev PHOTO_ORG_ENV_STORAGE_MODE=persistent`
+3. start it with `PHOTO_ORG_ENVIRONMENT=dev make compose-up`
+4. rerun migrations with `PHOTO_ORG_ENVIRONMENT=dev make compose-migrate` if you need to repair its database
+5. open the web interface once the service is healthy
+6. sign in as an admin
+7. add one or more watched folders
+8. let the system ingest the initial corpus
 
 Once that is done, users should be able to browse, search, and validate faces from the web UI.
+
+For local operations:
+
+- `make env-create PHOTO_ORG_ENVIRONMENT=<name> PHOTO_ORG_ENV_STORAGE_MODE=persistent` registers a persistent environment with its own named Postgres volume
+- `make env-create PHOTO_ORG_ENVIRONMENT=<name> PHOTO_ORG_ENV_STORAGE_MODE=ephemeral` registers an ephemeral environment whose database lives only for the container lifecycle
+- `PHOTO_ORG_ENVIRONMENT=<name> make compose-up` starts the selected registered environment
+- `PHOTO_ORG_ENVIRONMENT=<name> make compose-down` removes containers while preserving a persistent environment's named Postgres volume
+- `PHOTO_ORG_ENVIRONMENT=<name> make compose-down-volumes` removes containers and deletes a persistent environment's local Postgres volume
+- `PHOTO_ORG_ENVIRONMENT=<name> make compose-smoke` verifies the selected environment using its registered storage mode
+- `PHOTO_ORG_ENV_FILE=/path/to/file.env` can be added when you want a local command to load extra environment-specific settings
 
 ## Basic Usage
 

--- a/apps/e2e/tests/test_compose_smoke.py
+++ b/apps/e2e/tests/test_compose_smoke.py
@@ -1,27 +1,145 @@
+import subprocess
 from pathlib import Path
+
+
+def _make_variable(target: str, variable: str, environment: str, *extra_args: str) -> str:
+    completed = subprocess.run(
+        ["make", "-pn", target, f"PHOTO_ORG_ENVIRONMENT={environment}", *extra_args],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    for line in completed.stdout.splitlines():
+        for operator in (" = ", " := "):
+            prefix = f"{variable}{operator}"
+            if line.startswith(prefix):
+                return line[len(prefix):]
+    raise AssertionError(f"missing make variable {variable}")
 
 
 def test_compose_db_service_uses_dedicated_database_url_env_var():
     compose = Path("compose.yaml").read_text(encoding="utf-8")
 
-    assert "DB_SERVICE_DATABASE_URL" in compose
+    assert "PHOTO_ORG_DB_SERVICE_DATABASE_URL" in compose
+    assert "${DB_SERVICE_DATABASE_URL:-" not in compose
     assert "${DATABASE_URL:-" not in compose
+
+
+def test_compose_uses_namespaced_runtime_variables():
+    compose = Path("compose.yaml").read_text(encoding="utf-8")
+
+    assert "PHOTO_ORG_POSTGRES_HOST_PORT" in compose
+    assert "PHOTO_ORG_API_HOST_PORT" in compose
+    assert "POSTGRES_PORT" not in compose
 
 
 def test_makefile_documents_compose_targets():
     makefile = Path("Makefile").read_text(encoding="utf-8")
+    assert "env-create:" in makefile
     assert "compose-up:" in makefile
     assert "compose-migrate:" in makefile
     assert "compose-down:" in makefile
+    assert "compose-down-volumes:" in makefile
+
+
+def test_compose_uses_persistent_postgres_volume_by_default():
+    compose = Path("compose.yaml").read_text(encoding="utf-8")
+
+    assert "/var/lib/postgresql/data" in compose
+
+
+def test_ephemeral_compose_override_exists_for_smoke_workflows():
+    compose_override = Path("compose.ephemeral.yaml")
+
+    assert compose_override.exists()
+    assert compose_override.read_text(encoding="utf-8")
+
+
+def test_make_derives_distinct_runtime_settings_per_environment():
+    alice_project = _make_variable("compose-up", "PHOTO_ORG_COMPOSE_PROJECT_NAME", "alice")
+    bob_project = _make_variable("compose-up", "PHOTO_ORG_COMPOSE_PROJECT_NAME", "bob")
+    alice_pg_port = _make_variable("compose-up", "PHOTO_ORG_POSTGRES_HOST_PORT", "alice")
+    bob_pg_port = _make_variable("compose-up", "PHOTO_ORG_POSTGRES_HOST_PORT", "bob")
+    alice_api_port = _make_variable("compose-up", "PHOTO_ORG_API_HOST_PORT", "alice")
+    bob_api_port = _make_variable("compose-up", "PHOTO_ORG_API_HOST_PORT", "bob")
+
+    assert alice_project == "photo-org-alice"
+    assert bob_project == "photo-org-bob"
+    assert alice_pg_port != bob_pg_port
+    assert alice_api_port != bob_api_port
+
+
+def test_env_create_persists_immutable_storage_mode(tmp_path):
+    registry_dir = tmp_path / "environments"
+
+    created = subprocess.run(
+        [
+            "make",
+            "env-create",
+            "PHOTO_ORG_ENVIRONMENT=Scratch Check",
+            "PHOTO_ORG_ENV_STORAGE_MODE=ephemeral",
+            f"PHOTO_ORG_ENV_REGISTRY_DIR={registry_dir}",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert created.returncode == 0, created.stderr
+
+    registry_file = registry_dir / "scratch-check.mk"
+    assert registry_file.exists()
+    assert "PHOTO_ORG_ENV_STORAGE_MODE := ephemeral" in registry_file.read_text(encoding="utf-8")
+
+    changed = subprocess.run(
+        [
+            "make",
+            "env-create",
+            "PHOTO_ORG_ENVIRONMENT=Scratch Check",
+            "PHOTO_ORG_ENV_STORAGE_MODE=persistent",
+            f"PHOTO_ORG_ENV_REGISTRY_DIR={registry_dir}",
+        ],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    assert changed.returncode != 0
+    assert "immutable" in (changed.stderr + changed.stdout).lower()
+
+
+def test_make_uses_registered_storage_mode_for_compose_selection(tmp_path):
+    registry_dir = tmp_path / "environments"
+    registry_dir.mkdir()
+    (registry_dir / "smoke.mk").write_text("PHOTO_ORG_ENV_STORAGE_MODE := ephemeral\n", encoding="utf-8")
+    (registry_dir / "dev.mk").write_text("PHOTO_ORG_ENV_STORAGE_MODE := persistent\n", encoding="utf-8")
+
+    persistent_stack = _make_variable(
+        "compose-up",
+        "COMPOSE_STACK",
+        "dev",
+        f"PHOTO_ORG_ENV_REGISTRY_DIR={registry_dir}",
+    )
+    ephemeral_stack = _make_variable(
+        "compose-up",
+        "COMPOSE_STACK",
+        "smoke",
+        f"PHOTO_ORG_ENV_REGISTRY_DIR={registry_dir}",
+    )
+
+    assert "-f compose.yaml" in persistent_stack
+    assert "compose.ephemeral.yaml" not in persistent_stack
+    assert "-f compose.yaml" in ephemeral_stack
+    assert "compose.ephemeral.yaml" in ephemeral_stack
 
 
 def test_docs_point_to_compose_workflow():
     readme = Path("README.md").read_text(encoding="utf-8")
     contributing = Path("CONTRIBUTING.md").read_text(encoding="utf-8")
 
-    assert "make compose-up" in readme
+    assert "env-create" in readme
+    assert "env-create" in contributing
+    assert "PHOTO_ORG_ENVIRONMENT" in readme
+    assert "PHOTO_ORG_ENVIRONMENT" in contributing
     assert "compose-up" in contributing
-    assert "compose-migrate" in contributing
 
 
 def test_makefile_documents_compose_smoke_workflow():
@@ -29,6 +147,20 @@ def test_makefile_documents_compose_smoke_workflow():
     contributing = Path("CONTRIBUTING.md").read_text(encoding="utf-8")
 
     assert "compose-smoke:" in makefile
+    assert "compose.ephemeral.yaml" in makefile
     assert "./scripts/photo-org ingest seed-corpus" in makefile
     assert "/api/v1/internal/ingest-queue/process" in makefile
     assert "compose-smoke" in contributing
+
+
+def test_makefile_uses_namespaced_environment_contract():
+    makefile = Path("Makefile").read_text(encoding="utf-8")
+
+    assert "PHOTO_ORG_ENVIRONMENT" in makefile
+    assert "PHOTO_ORG_ENV_FILE" in makefile
+    assert "PHOTO_ORG_ENV_REGISTRY_DIR" in makefile
+    assert "PHOTO_ORG_ENV_STORAGE_MODE" in makefile
+    assert "PHOTO_ORG_POSTGRES_HOST_PORT" in makefile
+    assert "PHOTO_ORG_API_HOST_PORT" in makefile
+    assert "PHOTO_ORG_COMPOSE_DATABASE_URL" in makefile
+    assert "\nCOMPOSE_DATABASE_URL ?=" not in makefile

--- a/compose.ephemeral.yaml
+++ b/compose.ephemeral.yaml
@@ -1,0 +1,6 @@
+services:
+  postgres:
+    volumes:
+      - type: tmpfs
+        target: /var/lib/postgresql/data
+      - ./apps/api/docker/initdb:/docker-entrypoint-initdb.d:ro

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,8 +6,9 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-photoorg}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-photoorg}
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "${PHOTO_ORG_POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
+      - postgres_data:/var/lib/postgresql/data
       - ./apps/api/docker/initdb:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test:
@@ -24,9 +25,12 @@ services:
       context: .
       dockerfile: apps/api/Dockerfile
     environment:
-      DATABASE_URL: ${DB_SERVICE_DATABASE_URL:-postgresql+psycopg://photoorg:photoorg@postgres:5432/photoorg}
+      DATABASE_URL: ${PHOTO_ORG_DB_SERVICE_DATABASE_URL:-postgresql+psycopg://photoorg:photoorg@postgres:5432/photoorg}
     depends_on:
       postgres:
         condition: service_healthy
     ports:
-      - "8000:8000"
+      - "${PHOTO_ORG_API_HOST_PORT:-8000}:8000"
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add a local environment registry with `env-create` so named environments have immutable storage mode and derived runtime settings
- make compose commands load environment-specific runtime settings from `PHOTO_ORG_*` variables and choose persistent vs ephemeral storage from the registered environment definition
- document the new local environment workflow and extend compose contract tests to cover namespaced variables, immutable environment definitions, and registry-driven compose selection

## Validation
- `uv run pytest apps/e2e/tests/test_compose_smoke.py -q`
- `uv run pytest apps/api/tests/test_container_entrypoint.py apps/api/tests/test_migrations.py -q`
- `PHOTO_ORG_ENVIRONMENT=smoke-immutable make compose-smoke`
