### PR TITLE
[codex] Add storage source registration foundation

### DIFF
--- a/apps/api/alembic/versions/20260321_000001_initial_schema.py
+++ b/apps/api/alembic/versions/20260321_000001_initial_schema.py
@@ -51,10 +51,76 @@ def upgrade() -> None:
     op.create_index("idx_photos_sha256", "photos", ["sha256"], unique=False)
 
     op.create_table(
+        "storage_sources",
+        sa.Column("storage_source_id", sa.String(36), primary_key=True),
+        sa.Column("display_name", sa.String(), nullable=False),
+        sa.Column("marker_filename", sa.String(), nullable=False),
+        sa.Column("marker_version", sa.Integer(), nullable=False, server_default=sa.text("1")),
+        sa.Column("availability_state", sa.String(), nullable=False, server_default=sa.text("'unknown'")),
+        sa.Column("last_failure_reason", sa.String(), nullable=True),
+        sa.Column("last_validated_ts", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "created_ts",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_ts",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    op.create_index(
+        "idx_storage_sources_availability_state",
+        "storage_sources",
+        ["availability_state"],
+        unique=False,
+    )
+
+    op.create_table(
+        "storage_source_aliases",
+        sa.Column("storage_source_alias_id", sa.String(36), primary_key=True),
+        sa.Column(
+            "storage_source_id",
+            sa.String(36),
+            sa.ForeignKey("storage_sources.storage_source_id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("alias_path", sa.Text(), nullable=False, unique=True),
+        sa.Column(
+            "created_ts",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_ts",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+    )
+    op.create_index(
+        "idx_storage_source_aliases_source_id",
+        "storage_source_aliases",
+        ["storage_source_id"],
+        unique=False,
+    )
+
+    op.create_table(
         "watched_folders",
         sa.Column("watched_folder_id", sa.String(36), primary_key=True),
         sa.Column("scan_path", sa.Text(), nullable=False, unique=True),
         sa.Column("container_mount_path", sa.Text(), nullable=False, unique=True),
+        sa.Column(
+            "storage_source_id",
+            sa.String(36),
+            sa.ForeignKey("storage_sources.storage_source_id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("relative_path", sa.Text(), nullable=True),
         sa.Column("display_name", sa.String(), nullable=True),
         sa.Column("is_enabled", sa.Integer(), nullable=False, server_default=sa.text("1")),
         sa.Column("availability_state", sa.String(), nullable=False, server_default=sa.text("'active'")),
@@ -62,6 +128,11 @@ def upgrade() -> None:
         sa.Column("last_successful_scan_ts", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.Column("created_ts", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
         sa.Column("updated_ts", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.UniqueConstraint(
+            "storage_source_id",
+            "relative_path",
+            name="uq_watched_folders_source_relative_path",
+        ),
     )
 
     op.create_table(
@@ -228,6 +299,10 @@ def downgrade() -> None:
     op.drop_index("idx_photo_files_photo_id", table_name="photo_files")
     op.drop_table("photo_files")
     op.drop_table("watched_folders")
+    op.drop_index("idx_storage_source_aliases_source_id", table_name="storage_source_aliases")
+    op.drop_table("storage_source_aliases")
+    op.drop_index("idx_storage_sources_availability_state", table_name="storage_sources")
+    op.drop_table("storage_sources")
     op.drop_index("idx_photos_sha256", table_name="photos")
     op.drop_index("idx_photos_shot_ts", table_name="photos")
     op.drop_table("photos")

--- a/apps/api/app/services/source_registration.py
+++ b/apps/api/app/services/source_registration.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from app.storage import create_db_engine
+from app.services.storage_sources import (
+    StorageSourceConflictError,
+    attach_storage_source_alias,
+    create_storage_source,
+    get_storage_source_by_marker_id,
+)
+
+
+MARKER_FILENAME = ".photo-org-source.json"
+MARKER_VERSION = 1
+
+
+class SourceRegistrationError(RuntimeError):
+    pass
+
+
+def register_storage_source(
+    *,
+    database_url: str | Path | None,
+    root_path: str | Path,
+    alias_path: str | Path | None = None,
+    display_name: str | None = None,
+) -> dict[str, object]:
+    root = Path(root_path).expanduser().resolve()
+    if not root.exists():
+        raise SourceRegistrationError(f"storage source root does not exist: {root}")
+    if not root.is_dir():
+        raise SourceRegistrationError(f"storage source root is not a directory: {root}")
+
+    alias = str(alias_path) if alias_path is not None else str(root)
+    now = datetime.now(tz=UTC)
+    engine = create_db_engine(database_url)
+    marker = read_source_marker(root)
+
+    try:
+        with engine.begin() as connection:
+            if marker is None:
+                source = create_storage_source(
+                    connection,
+                    display_name=display_name or root.name,
+                    marker_filename=MARKER_FILENAME,
+                    marker_version=MARKER_VERSION,
+                    now=now,
+                )
+                write_source_marker(root, storage_source_id=str(source["storage_source_id"]))
+            else:
+                if marker.get("marker_version") != MARKER_VERSION:
+                    raise SourceRegistrationError(
+                        f"unsupported marker version: {marker.get('marker_version')}"
+                    )
+                source = get_storage_source_by_marker_id(
+                    connection,
+                    str(marker["storage_source_id"]),
+                )
+                if source is None:
+                    raise SourceRegistrationError(
+                        f"marker file references unknown storage source: {marker['storage_source_id']}"
+                    )
+
+            attach_storage_source_alias(
+                connection,
+                storage_source_id=str(source["storage_source_id"]),
+                alias_path=alias,
+                now=now,
+            )
+            return source
+    except StorageSourceConflictError as exc:
+        raise SourceRegistrationError(str(exc)) from exc
+    finally:
+        engine.dispose()
+
+
+def read_source_marker(root: Path) -> dict[str, object] | None:
+    marker_path = root / MARKER_FILENAME
+    if not marker_path.is_file():
+        return None
+    return json.loads(marker_path.read_text())
+
+
+def write_source_marker(root: Path, *, storage_source_id: str) -> None:
+    marker_path = root / MARKER_FILENAME
+    payload = {
+        "storage_source_id": storage_source_id,
+        "marker_version": MARKER_VERSION,
+    }
+    marker_path.write_text(json.dumps(payload, indent=2, sort_keys=True))

--- a/apps/api/app/services/storage_sources.py
+++ b/apps/api/app/services/storage_sources.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import insert, select, update
+from sqlalchemy.engine import Connection
+
+from app.storage import storage_source_aliases, storage_sources
+
+
+class StorageSourceConflictError(RuntimeError):
+    pass
+
+
+def create_storage_source(
+    connection: Connection,
+    *,
+    display_name: str,
+    marker_filename: str,
+    marker_version: int,
+    now: datetime,
+) -> dict[str, object]:
+    storage_source_id = str(uuid4())
+    values = {
+        "storage_source_id": storage_source_id,
+        "display_name": display_name,
+        "marker_filename": marker_filename,
+        "marker_version": marker_version,
+        "availability_state": "unknown",
+        "last_failure_reason": None,
+        "last_validated_ts": None,
+        "created_ts": now,
+        "updated_ts": now,
+    }
+    connection.execute(insert(storage_sources).values(**values))
+    return values
+
+
+def get_storage_source_by_marker_id(
+    connection: Connection,
+    storage_source_id: str,
+) -> dict[str, object] | None:
+    return connection.execute(
+        select(storage_sources).where(storage_sources.c.storage_source_id == storage_source_id)
+    ).mappings().first()
+
+
+def attach_storage_source_alias(
+    connection: Connection,
+    *,
+    storage_source_id: str,
+    alias_path: str,
+    now: datetime,
+) -> dict[str, object]:
+    existing = connection.execute(
+        select(storage_source_aliases).where(storage_source_aliases.c.alias_path == alias_path)
+    ).mappings().first()
+    if existing is not None:
+        if existing["storage_source_id"] != storage_source_id:
+            raise StorageSourceConflictError(
+                f"alias_path {alias_path!r} already belongs to storage_source_id "
+                f"{existing['storage_source_id']}"
+            )
+        connection.execute(
+            update(storage_source_aliases)
+            .where(storage_source_aliases.c.storage_source_alias_id == existing["storage_source_alias_id"])
+            .values(updated_ts=now)
+        )
+        return {
+            **existing,
+            "updated_ts": now,
+        }
+
+    values = {
+        "storage_source_alias_id": str(uuid4()),
+        "storage_source_id": storage_source_id,
+        "alias_path": alias_path,
+        "created_ts": now,
+        "updated_ts": now,
+    }
+    connection.execute(insert(storage_source_aliases).values(**values))
+    return values
+
+
+def list_storage_source_aliases(
+    connection: Connection,
+    storage_source_id: str,
+) -> list[dict[str, object]]:
+    return list(
+        connection.execute(
+            select(storage_source_aliases)
+            .where(storage_source_aliases.c.storage_source_id == storage_source_id)
+            .order_by(storage_source_aliases.c.alias_path)
+        ).mappings()
+    )
+
+
+def update_storage_source_availability(
+    connection: Connection,
+    *,
+    storage_source_id: str,
+    availability_state: str,
+    last_failure_reason: str | None,
+    now: datetime,
+) -> None:
+    connection.execute(
+        update(storage_sources)
+        .where(storage_sources.c.storage_source_id == storage_source_id)
+        .values(
+            availability_state=availability_state,
+            last_failure_reason=last_failure_reason,
+            last_validated_ts=now,
+            updated_ts=now,
+        )
+    )

--- a/apps/api/app/storage.py
+++ b/apps/api/app/storage.py
@@ -11,6 +11,8 @@ from photoorg_db_schema import (
     photo_files,
     photo_tags,
     photos,
+    storage_source_aliases,
+    storage_sources,
     watched_folders,
 )
 from app.db.config import DEFAULT_DATABASE_URL, DEFAULT_SQLITE_PATH, resolve_database_url

--- a/apps/api/tests/test_schema_definition.py
+++ b/apps/api/tests/test_schema_definition.py
@@ -1,6 +1,6 @@
 from sqlalchemy import create_engine, inspect
 
-from photoorg_db_schema import ingest_queue, ingest_run_files, metadata
+from photoorg_db_schema import ingest_queue, ingest_run_files, metadata, storage_source_aliases, storage_sources
 
 
 def test_phase_zero_schema_exposes_expected_tables():
@@ -11,6 +11,8 @@ def test_phase_zero_schema_exposes_expected_tables():
         "people",
         "face_labels",
         "watched_folders",
+        "storage_sources",
+        "storage_source_aliases",
         "ingest_runs",
         "ingest_queue",
         "ingest_run_files",
@@ -27,17 +29,37 @@ def test_ingest_run_files_is_publicly_exported_from_shared_schema():
     assert ingest_run_files is metadata.tables["ingest_run_files"]
 
 
+def test_storage_source_tables_are_publicly_exported_from_shared_schema():
+    assert storage_sources is metadata.tables["storage_sources"]
+    assert storage_source_aliases is metadata.tables["storage_source_aliases"]
+
+
 def test_phase_zero_schema_applies_core_constraints():
     photos = metadata.tables["photos"]
     photo_files = metadata.tables["photo_files"]
     faces = metadata.tables["faces"]
     watched_folders = metadata.tables["watched_folders"]
+    storage_sources = metadata.tables["storage_sources"]
+    storage_source_aliases = metadata.tables["storage_source_aliases"]
     ingest_queue = metadata.tables["ingest_queue"]
     ingest_run_files = metadata.tables["ingest_run_files"]
 
     assert photos.c.sha256.unique is True
     assert watched_folders.c.scan_path.unique is True
     assert watched_folders.c.container_mount_path.unique is True
+    assert watched_folders.c.storage_source_id.nullable is True
+    assert watched_folders.c.relative_path.nullable is True
+    assert [fk.column.table.name for fk in watched_folders.c.storage_source_id.foreign_keys] == [
+        "storage_sources"
+    ]
+    assert storage_sources.c.marker_filename.nullable is False
+    assert storage_sources.c.marker_version.nullable is False
+    assert str(storage_sources.c.marker_version.server_default.arg) == "1"
+    assert str(storage_sources.c.availability_state.server_default.arg) == "'unknown'"
+    assert storage_source_aliases.c.alias_path.unique is True
+    assert [fk.column.table.name for fk in storage_source_aliases.c.storage_source_id.foreign_keys] == [
+        "storage_sources"
+    ]
     assert [fk.column.table.name for fk in photo_files.c.photo_id.foreign_keys] == ["photos"]
     assert [fk.column.table.name for fk in faces.c.photo_id.foreign_keys] == ["photos"]
     assert ingest_queue.c.idempotency_key.unique is True
@@ -62,12 +84,30 @@ def test_ingest_run_files_indexes_are_defined_in_shared_metadata():
         "idx_ingest_run_files_run_id_outcome",
     } <= {index.name for index in ingest_run_files.indexes}
 
+
+def test_storage_source_indexes_are_defined_in_shared_metadata():
+    watched_folders = metadata.tables["watched_folders"]
+    storage_sources = metadata.tables["storage_sources"]
+    storage_source_aliases = metadata.tables["storage_source_aliases"]
+
+    assert {"uq_watched_folders_source_relative_path"} <= {
+        constraint.name for constraint in watched_folders.constraints if constraint.name is not None
+    }
+    assert {"idx_storage_sources_availability_state"} <= {index.name for index in storage_sources.indexes}
+    assert {"idx_storage_source_aliases_source_id"} <= {
+        index.name for index in storage_source_aliases.indexes
+    }
+
 def test_shared_metadata_defines_phase_zero_tables(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'schema.db'}", future=True)
     metadata.create_all(engine)
 
     tables = set(inspect(engine).get_table_names())
     ingest_run_files_indexes = {index["name"] for index in inspect(engine).get_indexes("ingest_run_files")}
+    storage_sources_indexes = {index["name"] for index in inspect(engine).get_indexes("storage_sources")}
+    storage_source_alias_indexes = {
+        index["name"] for index in inspect(engine).get_indexes("storage_source_aliases")
+    }
 
     assert {
         "photos",
@@ -76,6 +116,8 @@ def test_shared_metadata_defines_phase_zero_tables(tmp_path):
         "people",
         "face_labels",
         "watched_folders",
+        "storage_sources",
+        "storage_source_aliases",
         "ingest_runs",
         "ingest_queue",
         "ingest_run_files",
@@ -85,3 +127,5 @@ def test_shared_metadata_defines_phase_zero_tables(tmp_path):
         "idx_ingest_run_files_ingest_queue_id",
         "idx_ingest_run_files_run_id_outcome",
     } <= ingest_run_files_indexes
+    assert {"idx_storage_sources_availability_state"} <= storage_sources_indexes
+    assert {"idx_storage_source_aliases_source_id"} <= storage_source_alias_indexes

--- a/apps/api/tests/test_source_registration.py
+++ b/apps/api/tests/test_source_registration.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import create_engine, select
+
+from app.migrations import upgrade_database
+from app.storage import storage_source_aliases, storage_sources
+
+
+def test_register_storage_source_creates_marker_and_alias_record(tmp_path):
+    from app.services.source_registration import MARKER_FILENAME, register_storage_source
+
+    database_url = f"sqlite:///{tmp_path / 'register-source.db'}"
+    upgrade_database(database_url)
+    root = tmp_path / "family-share"
+    root.mkdir()
+
+    registered = register_storage_source(
+        database_url=database_url,
+        root_path=root,
+        alias_path="//nas/family-share",
+        display_name="Family Share",
+    )
+
+    marker_path = root / MARKER_FILENAME
+
+    assert registered["display_name"] == "Family Share"
+    assert marker_path.is_file()
+
+    marker = json.loads(marker_path.read_text())
+
+    assert marker == {
+        "storage_source_id": registered["storage_source_id"],
+        "marker_version": 1,
+    }
+
+    engine = create_engine(database_url, future=True)
+    with engine.connect() as connection:
+        source_row = connection.execute(
+            select(storage_sources).where(
+                storage_sources.c.storage_source_id == registered["storage_source_id"]
+            )
+        ).mappings().one()
+        alias_rows = connection.execute(
+            select(storage_source_aliases).where(
+                storage_source_aliases.c.storage_source_id == registered["storage_source_id"]
+            )
+        ).mappings().all()
+
+    assert source_row["display_name"] == "Family Share"
+    assert alias_rows[0]["alias_path"] == "//nas/family-share"
+
+
+def test_register_storage_source_reuses_existing_source_when_marker_matches(tmp_path):
+    from app.services.source_registration import register_storage_source
+
+    database_url = f"sqlite:///{tmp_path / 'register-source-existing.db'}"
+    upgrade_database(database_url)
+    root = tmp_path / "family-share"
+    root.mkdir()
+
+    first = register_storage_source(
+        database_url=database_url,
+        root_path=root,
+        alias_path="//nas/family-share",
+        display_name="Family Share",
+    )
+    second = register_storage_source(
+        database_url=database_url,
+        root_path=root,
+        alias_path="smb://family.local/family-share",
+        display_name="Ignored Alias Name",
+    )
+
+    assert second["storage_source_id"] == first["storage_source_id"]
+
+    engine = create_engine(database_url, future=True)
+    with engine.connect() as connection:
+        alias_rows = connection.execute(
+            select(storage_source_aliases.c.alias_path).where(
+                storage_source_aliases.c.storage_source_id == first["storage_source_id"]
+            )
+        ).scalars().all()
+
+    assert alias_rows == ["//nas/family-share", "smb://family.local/family-share"]
+
+
+def test_register_storage_source_rejects_unknown_marker_identity(tmp_path):
+    from app.services.source_registration import MARKER_FILENAME, SourceRegistrationError, register_storage_source
+
+    database_url = f"sqlite:///{tmp_path / 'register-source-conflict.db'}"
+    upgrade_database(database_url)
+    root = tmp_path / "family-share"
+    root.mkdir()
+    (root / MARKER_FILENAME).write_text(
+        json.dumps({"storage_source_id": "missing-source-id", "marker_version": 1})
+    )
+
+    try:
+        register_storage_source(
+            database_url=database_url,
+            root_path=root,
+            alias_path="//nas/family-share",
+            display_name="Family Share",
+        )
+    except SourceRegistrationError as exc:
+        assert "unknown storage source" in str(exc)
+    else:
+        raise AssertionError("expected unknown marker identity failure")

--- a/apps/api/tests/test_storage_sources.py
+++ b/apps/api/tests/test_storage_sources.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import create_engine, select
+
+from app.migrations import upgrade_database
+
+
+def test_storage_source_repository_persists_sources_aliases_and_availability(tmp_path):
+    from app.services.storage_sources import (
+        attach_storage_source_alias,
+        create_storage_source,
+        get_storage_source_by_marker_id,
+        list_storage_source_aliases,
+        update_storage_source_availability,
+    )
+
+    database_url = f"sqlite:///{tmp_path / 'storage-sources.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 3, 28, 18, 0, tzinfo=UTC)
+
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Family NAS",
+            marker_filename=".photo-org-source.json",
+            marker_version=1,
+            now=now,
+        )
+        alias = attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path="//nas/family",
+            now=now,
+        )
+        update_storage_source_availability(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            availability_state="active",
+            last_failure_reason=None,
+            now=now,
+        )
+        loaded = get_storage_source_by_marker_id(connection, source["storage_source_id"])
+        aliases = list_storage_source_aliases(connection, source["storage_source_id"])
+
+    assert alias["alias_path"] == "//nas/family"
+    assert loaded is not None
+    assert loaded["display_name"] == "Family NAS"
+    assert loaded["availability_state"] == "active"
+    assert [row["alias_path"] for row in aliases] == [alias["alias_path"]]
+    assert [row["storage_source_id"] for row in aliases] == [source["storage_source_id"]]
+
+
+def test_storage_source_alias_rejects_conflict_with_different_source(tmp_path):
+    from app.services.storage_sources import (
+        StorageSourceConflictError,
+        attach_storage_source_alias,
+        create_storage_source,
+    )
+
+    database_url = f"sqlite:///{tmp_path / 'storage-sources-conflict.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 3, 28, 18, 30, tzinfo=UTC)
+
+    with engine.begin() as connection:
+        source_a = create_storage_source(
+            connection,
+            display_name="Family NAS",
+            marker_filename=".photo-org-source.json",
+            marker_version=1,
+            now=now,
+        )
+        source_b = create_storage_source(
+            connection,
+            display_name="Travel Drive",
+            marker_filename=".photo-org-source.json",
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source_a["storage_source_id"],
+            alias_path="//nas/family",
+            now=now,
+        )
+
+        try:
+            attach_storage_source_alias(
+                connection,
+                storage_source_id=source_b["storage_source_id"],
+                alias_path="//nas/family",
+                now=now,
+            )
+        except StorageSourceConflictError as exc:
+            assert "already belongs to storage_source_id" in str(exc)
+        else:
+            raise AssertionError("expected alias conflict")

--- a/packages/db-schema/photoorg_db_schema/__init__.py
+++ b/packages/db-schema/photoorg_db_schema/__init__.py
@@ -11,6 +11,8 @@ from .schema import (
     photo_files,
     photo_tags,
     photos,
+    storage_source_aliases,
+    storage_sources,
     watched_folders,
     configure_embedding_column,
 )
@@ -29,5 +31,7 @@ __all__ = [
     "photo_files",
     "photo_tags",
     "photos",
+    "storage_source_aliases",
+    "storage_sources",
     "watched_folders",
 ]

--- a/packages/db-schema/photoorg_db_schema/schema.py
+++ b/packages/db-schema/photoorg_db_schema/schema.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     String,
     Table,
     Text,
+    UniqueConstraint,
     text,
 )
 from sqlalchemy.engine import Connection, Engine
@@ -69,12 +70,47 @@ photos = Table(
     Column("faces_detected_ts", TIMESTAMP(timezone=True)),
 )
 
+storage_sources = Table(
+    "storage_sources",
+    metadata,
+    Column("storage_source_id", String(36), primary_key=True),
+    Column("display_name", String, nullable=False),
+    Column("marker_filename", String, nullable=False),
+    Column("marker_version", Integer, nullable=False, server_default=text("1")),
+    Column("availability_state", String, nullable=False, server_default=text("'unknown'")),
+    Column("last_failure_reason", String),
+    Column("last_validated_ts", TIMESTAMP(timezone=True)),
+    Column("created_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    Column("updated_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+)
+
+storage_source_aliases = Table(
+    "storage_source_aliases",
+    metadata,
+    Column("storage_source_alias_id", String(36), primary_key=True),
+    Column(
+        "storage_source_id",
+        String(36),
+        ForeignKey("storage_sources.storage_source_id", ondelete="CASCADE"),
+        nullable=False,
+    ),
+    Column("alias_path", Text, nullable=False, unique=True),
+    Column("created_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    Column("updated_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+)
+
 watched_folders = Table(
     "watched_folders",
     metadata,
     Column("watched_folder_id", String(36), primary_key=True),
     Column("scan_path", Text, nullable=False, unique=True),
     Column("container_mount_path", Text, nullable=False, unique=True),
+    Column(
+        "storage_source_id",
+        String(36),
+        ForeignKey("storage_sources.storage_source_id", ondelete="SET NULL"),
+    ),
+    Column("relative_path", Text),
     Column("display_name", String),
     Column("is_enabled", Integer, nullable=False, server_default=text("1")),
     Column("availability_state", String, nullable=False, server_default=text("'active'")),
@@ -82,6 +118,7 @@ watched_folders = Table(
     Column("last_successful_scan_ts", TIMESTAMP(timezone=True)),
     Column("created_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     Column("updated_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    UniqueConstraint("storage_source_id", "relative_path", name="uq_watched_folders_source_relative_path"),
 )
 
 photo_files = Table(
@@ -207,6 +244,8 @@ ingest_queue = Table(
 
 Index("idx_photos_shot_ts", photos.c.shot_ts)
 Index("idx_photos_sha256", photos.c.sha256)
+Index("idx_storage_sources_availability_state", storage_sources.c.availability_state)
+Index("idx_storage_source_aliases_source_id", storage_source_aliases.c.storage_source_id)
 Index("idx_faces_photo_id", faces.c.photo_id)
 Index("idx_photo_files_photo_id", photo_files.c.photo_id)
 Index("idx_photo_tags_photo_id", photo_tags.c.photo_id)


### PR DESCRIPTION
@codex
## Summary

Add the issue #86 foundation for storage source registration and marker-file identity.

## What Changed

- add `storage_sources` and `storage_source_aliases` to the shared schema and initial migration
- extend `watched_folders` with transitional `storage_source_id` and `relative_path` fields
- add storage-source repository helpers for source creation, alias attachment, and availability updates
- add source registration orchestration that writes a versioned marker file, reuses an existing source when the marker matches, and rejects unknown marker identities
- add focused schema, migration, and service-layer tests for the new behavior

## Why

Phase 1 is moving from free-form watched-folder path registration to centrally managed storage sources. This PR lands the durable identity and registration pieces without pulling ingest or CLI migration into the same story.

## Validation

- `make pre-push`
- `uv run python -m pytest apps/api/tests/test_schema_definition.py apps/api/tests/test_migrations.py apps/api/tests/test_storage_sources.py apps/api/tests/test_source_registration.py -q`

## Impact

This is the persistence and registration foundation for issue #86. Source-aware ingest, reconciliation, and operator-facing workflows remain follow-up slices.