### PR TITLE
[codex] Add storage source polling loop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,8 @@ Current high-value targets:
   - validate the checked-in `seed-corpus/` inventory and manifest
 - `make seed-corpus-load`
   - migrate and load the checked-in `seed-corpus/` into the local development database
+- `uv run python -m app.cli poll-storage-sources --database-url <url>`
+  - poll enabled registered storage sources, validate each source marker, and reconcile watched folders through the central polling loop
 - `uv run python apps/api/scripts/generate_openapi.py`
   - regenerate `apps/api/openapi/spec.yaml` from the current FastAPI app
 
@@ -209,6 +211,9 @@ Synthetic fixtures remain preferred for unit tests and BDD scenarios. The checke
 
 For missing-file reconciliation verification, run `uv run python -m pytest apps/api/tests/test_ingest.py -q`.
 That targeted suite exercises a temporary watched-folder fixture and simulated time so contributors can verify `active`, `missing`, `deleted`, and recovery transitions without bringing up the full worker stack.
+
+For the source-aware central polling loop, register a storage source plus watched folder first, then run `uv run python -m app.cli poll-storage-sources --database-url <url>`.
+That command validates the source marker before scanning, surfaces source-aware failures in its exit code and stdout, and reconciles only enabled watched folders attached to registered storage sources.
 
 ### Automated Version Updates
 

--- a/apps/api/app/cli.py
+++ b/apps/api/app/cli.py
@@ -4,6 +4,7 @@ import argparse
 
 from app.dev.seed_corpus import load_seed_corpus_into_database, validate_seed_corpus
 from app.migrations import upgrade_database
+from app.processing.ingest import poll_registered_storage_sources
 from app.storage import resolve_database_url
 
 
@@ -12,6 +13,16 @@ def build_parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
     migrate_parser = subparsers.add_parser("migrate", help="Apply database migrations")
     migrate_parser.add_argument(
+        "--database-url",
+        default=None,
+        help="SQLAlchemy database URL. Defaults to DATABASE_URL.",
+    )
+
+    poll_parser = subparsers.add_parser(
+        "poll-storage-sources",
+        help="Poll enabled registered storage sources and reconcile their watched folders",
+    )
+    poll_parser.add_argument(
         "--database-url",
         default=None,
         help="SQLAlchemy database URL. Defaults to DATABASE_URL.",
@@ -52,6 +63,16 @@ def main(argv: list[str] | None = None) -> int:
         print(f"database_url={resolve_database_url(args.database_url)}")
         print("migration=head")
         return 0
+    if args.command == "poll-storage-sources":
+        result = poll_registered_storage_sources(database_url=args.database_url)
+        print(f"database_url={resolve_database_url(args.database_url)}")
+        print(f"scanned={result.scanned}")
+        print(f"inserted={result.inserted}")
+        print(f"updated={result.updated}")
+        print(f"errors={len(result.errors)}")
+        for error in result.errors:
+            print(error)
+        return 1 if result.errors else 0
     if args.command == "seed-corpus":
         if args.seed_corpus_command == "validate":
             report = validate_seed_corpus()

--- a/apps/api/app/processing/ingest.py
+++ b/apps/api/app/processing/ingest.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
 import hashlib
-from datetime import UTC, datetime
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from stat import S_ISDIR
 from typing import Iterable, Protocol
 from uuid import NAMESPACE_URL, uuid5
 
-from sqlalchemy import delete, func, insert, select, update
+from sqlalchemy import delete, insert, select, update
 from sqlalchemy.engine import Connection
 
 from app.db.config import resolve_missing_file_grace_period_days
+from app.db.ingest_runs import IngestRunStore
 from app.db.queue import IngestQueueStore
 from app.path_contract import (
     build_canonical_photo_path,
@@ -28,8 +29,9 @@ from app.services.file_reconciliation import (
     utc_now,
 )
 from app.processing.metadata import extract_image_metadata, stat_timestamp_to_iso
+from app.services.source_registration import SourceRegistrationError, read_source_marker
 from app.services.thumbnails import generate_thumbnail
-from app.storage import create_db_engine, faces, photos
+from app.storage import create_db_engine, faces, photos, storage_source_aliases, watched_folders
 
 
 SUPPORTED_EXTENSIONS = {".heic", ".heif", ".jpeg", ".jpg", ".png"}
@@ -72,6 +74,30 @@ class IngestResult:
     inserted: int = 0
     updated: int = 0
     errors: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class RegisteredWatchedFolderTarget:
+    storage_source_id: str
+    watched_folder_id: str
+    container_mount_path: str
+    relative_path: str | None
+
+
+@dataclass(frozen=True)
+class RegisteredStorageSourceTarget:
+    storage_source_id: str
+    alias_paths: tuple[str, ...]
+    watched_folders: tuple[RegisteredWatchedFolderTarget, ...]
+
+
+@dataclass(frozen=True)
+class WatchedFolderPollOutcome:
+    scanned: int
+    inserted: int
+    updated: int
+    error_messages: tuple[str, ...]
+    status: str
 
 
 def ingest_directory(
@@ -121,26 +147,6 @@ def reconcile_directory(
     at = now if now is not None else utc_now()
     grace_period_days = resolve_missing_file_grace_period_days(missing_file_grace_period_days)
 
-    try:
-        _validate_scan_root(source_root)
-        scanned_paths = list(iter_photo_files(source_root))
-    except OSError as exc:
-        engine = create_db_engine(database_url)
-        with engine.begin() as connection:
-            watched_folder_id = ensure_watched_folder_exists(
-                connection,
-                scan_path=source_root.as_posix(),
-                container_mount_path=canonical_root,
-                now=at,
-            )
-            record_watched_folder_scan_failure(
-                connection,
-                watched_folder_id=watched_folder_id,
-                reason=_classify_root_scan_failure(exc),
-                now=at,
-            )
-        return result
-
     engine = create_db_engine(database_url)
     with engine.begin() as connection:
         watched_folder_id = ensure_watched_folder_exists(
@@ -149,66 +155,92 @@ def reconcile_directory(
             container_mount_path=canonical_root,
             now=at,
         )
-        record_watched_folder_scan_success(
+        outcome = _reconcile_watched_folder_root(
             connection,
             watched_folder_id=watched_folder_id,
+            source_root=source_root,
+            canonical_root=canonical_root,
             now=at,
+            missing_file_grace_period_days=grace_period_days,
         )
-        observed_relative_paths: set[str] = set()
-        touched_photo_ids: set[str] = set()
+        result.scanned += outcome.scanned
+        result.inserted += outcome.inserted
+        result.updated += outcome.updated
+        result.errors.extend(outcome.error_messages)
 
-        for photo_path in scanned_paths:
-            result.scanned += 1
-            relative_path = relative_photo_path(source_root, photo_path)
-            record = build_photo_record(
-                photo_path,
-                canonical_path=build_canonical_photo_path(canonical_root, relative_path),
-            )
-            try:
-                thumbnail = generate_thumbnail(photo_path)
-            except Exception as exc:
-                result.errors.append(f"{photo_path}: thumbnail generation failed: {exc}")
-            else:
-                record = PhotoRecord(
-                    **{
-                        **record.__dict__,
-                        "thumbnail_jpeg": thumbnail.jpeg_bytes,
-                        "thumbnail_mime_type": thumbnail.mime_type,
-                        "thumbnail_width": thumbnail.width,
-                        "thumbnail_height": thumbnail.height,
-                    }
+    return result
+
+
+def poll_registered_storage_sources(
+    database_url: str | Path | None = None,
+    *,
+    now: datetime | None = None,
+    missing_file_grace_period_days: int | None = None,
+) -> IngestResult:
+    result = IngestResult()
+    at = now if now is not None else utc_now()
+    grace_period_days = resolve_missing_file_grace_period_days(missing_file_grace_period_days)
+    engine = create_db_engine(database_url)
+    run_store = IngestRunStore(database_url)
+
+    with engine.begin() as connection:
+        targets = _load_registered_storage_source_targets(connection)
+
+    for source_target in targets:
+        reason, detail, alias_root = _validate_registered_source_target(
+            storage_source_id=source_target.storage_source_id,
+            alias_paths=source_target.alias_paths,
+        )
+        if reason is not None:
+            with engine.begin() as connection:
+                for target in source_target.watched_folders:
+                    record_watched_folder_scan_failure(
+                        connection,
+                        watched_folder_id=target.watched_folder_id,
+                        reason=reason,
+                        now=at,
+                    )
+                    _record_ingest_run(
+                        run_store,
+                        connection=connection,
+                        watched_folder_id=target.watched_folder_id,
+                        status="failed",
+                        files_seen=0,
+                        files_created=0,
+                        files_updated=0,
+                        error_messages=(detail,),
+                    )
+            result.errors.append(f"storage_source:{source_target.storage_source_id}: {detail}")
+            continue
+
+        with engine.begin() as connection:
+            for target in source_target.watched_folders:
+                scan_root = _resolve_registered_scan_root(
+                    alias_root=alias_root,
+                    relative_path=target.relative_path,
                 )
-            observed_relative_paths.add(relative_path)
-            created = upsert_photo(connection, record)
-            if created:
-                result.inserted += 1
-            else:
-                result.updated += 1
-            touched_photo_ids.add(
-                activate_observed_file(
+                outcome = _reconcile_watched_folder_root(
                     connection,
-                    watched_folder_id=watched_folder_id,
-                    photo_id=record.photo_id,
-                    relative_path=relative_path,
-                    filename=photo_path.name,
-                    extension=record.ext,
-                    filesize=record.filesize,
-                    created_ts=record.created_ts,
-                    modified_ts=record.modified_ts,
+                    watched_folder_id=target.watched_folder_id,
+                    source_root=scan_root,
+                    canonical_root=target.container_mount_path,
                     now=at,
+                    missing_file_grace_period_days=grace_period_days,
                 )
-            )
-
-        touched_photo_ids.update(
-            reconcile_watched_folder(
-                connection,
-                watched_folder_id=watched_folder_id,
-                observed_relative_paths=observed_relative_paths,
-                now=at,
-                missing_file_grace_period_days=grace_period_days,
-            )
-        )
-        refresh_photo_deleted_timestamps(connection, photo_ids=touched_photo_ids, now=at)
+                result.scanned += outcome.scanned
+                result.inserted += outcome.inserted
+                result.updated += outcome.updated
+                result.errors.extend(outcome.error_messages)
+                _record_ingest_run(
+                    run_store,
+                    connection=connection,
+                    watched_folder_id=target.watched_folder_id,
+                    status=outcome.status,
+                    files_seen=outcome.scanned,
+                    files_created=outcome.inserted,
+                    files_updated=outcome.updated,
+                    error_messages=outcome.error_messages,
+                )
 
     return result
 
@@ -230,6 +262,247 @@ def iter_photo_files(root: Path) -> Iterable[Path]:
     for path in sorted(root.rglob("*")):
         if path.is_file() and path.suffix.lower() in SUPPORTED_EXTENSIONS:
             yield path
+
+
+def _reconcile_watched_folder_root(
+    connection: Connection,
+    *,
+    watched_folder_id: str,
+    source_root: Path,
+    canonical_root: str,
+    now: datetime,
+    missing_file_grace_period_days: int,
+) -> WatchedFolderPollOutcome:
+    scanned = 0
+    inserted = 0
+    updated_count = 0
+    error_messages: list[str] = []
+    try:
+        _validate_scan_root(source_root)
+        scanned_paths = list(iter_photo_files(source_root))
+    except OSError as exc:
+        record_watched_folder_scan_failure(
+            connection,
+            watched_folder_id=watched_folder_id,
+            reason=_classify_root_scan_failure(exc),
+            now=now,
+        )
+        return WatchedFolderPollOutcome(
+            scanned=0,
+            inserted=0,
+            updated=0,
+            error_messages=(),
+            status="failed",
+        )
+
+    record_watched_folder_scan_success(
+        connection,
+        watched_folder_id=watched_folder_id,
+        now=now,
+    )
+    observed_relative_paths: set[str] = set()
+    touched_photo_ids: set[str] = set()
+
+    for photo_path in scanned_paths:
+        scanned += 1
+        relative_path = relative_photo_path(source_root, photo_path)
+        record = build_photo_record(
+            photo_path,
+            canonical_path=build_canonical_photo_path(canonical_root, relative_path),
+        )
+        try:
+            thumbnail = generate_thumbnail(photo_path)
+        except Exception as exc:
+            error_messages.append(f"{photo_path}: thumbnail generation failed: {exc}")
+        else:
+            record = PhotoRecord(
+                **{
+                    **record.__dict__,
+                    "thumbnail_jpeg": thumbnail.jpeg_bytes,
+                    "thumbnail_mime_type": thumbnail.mime_type,
+                    "thumbnail_width": thumbnail.width,
+                    "thumbnail_height": thumbnail.height,
+                }
+            )
+        observed_relative_paths.add(relative_path)
+        created = upsert_photo(connection, record)
+        if created:
+            inserted += 1
+        else:
+            updated_count += 1
+        touched_photo_ids.add(
+            activate_observed_file(
+                connection,
+                watched_folder_id=watched_folder_id,
+                photo_id=record.photo_id,
+                relative_path=relative_path,
+                filename=photo_path.name,
+                extension=record.ext,
+                filesize=record.filesize,
+                created_ts=record.created_ts,
+                modified_ts=record.modified_ts,
+                now=now,
+            )
+        )
+
+    touched_photo_ids.update(
+        reconcile_watched_folder(
+            connection,
+            watched_folder_id=watched_folder_id,
+            observed_relative_paths=observed_relative_paths,
+            now=now,
+            missing_file_grace_period_days=missing_file_grace_period_days,
+        )
+    )
+    refresh_photo_deleted_timestamps(connection, photo_ids=touched_photo_ids, now=now)
+    return WatchedFolderPollOutcome(
+        scanned=scanned,
+        inserted=inserted,
+        updated=updated_count,
+        error_messages=tuple(error_messages),
+        status="completed",
+    )
+
+
+def _load_registered_storage_source_targets(
+    connection: Connection,
+) -> list[RegisteredStorageSourceTarget]:
+    aliases_by_source: dict[str, list[str]] = {}
+    for row in connection.execute(
+        select(
+            storage_source_aliases.c.storage_source_id,
+            storage_source_aliases.c.alias_path,
+        ).order_by(
+            storage_source_aliases.c.storage_source_id,
+            storage_source_aliases.c.alias_path,
+        )
+    ).mappings():
+        aliases_by_source.setdefault(row["storage_source_id"], []).append(row["alias_path"])
+
+    watched_folders_by_source: dict[str, list[RegisteredWatchedFolderTarget]] = {}
+    for row in connection.execute(
+        select(
+            watched_folders.c.storage_source_id,
+            watched_folders.c.watched_folder_id,
+            watched_folders.c.container_mount_path,
+            watched_folders.c.relative_path,
+        )
+        .where(
+            watched_folders.c.is_enabled == 1,
+            watched_folders.c.storage_source_id.is_not(None),
+        )
+        .order_by(
+            watched_folders.c.storage_source_id,
+            watched_folders.c.relative_path,
+            watched_folders.c.watched_folder_id,
+        )
+    ).mappings():
+        watched_folders_by_source.setdefault(row["storage_source_id"], []).append(
+            RegisteredWatchedFolderTarget(
+                storage_source_id=row["storage_source_id"],
+                watched_folder_id=row["watched_folder_id"],
+                container_mount_path=row["container_mount_path"],
+                relative_path=row["relative_path"],
+            )
+        )
+
+    return [
+        RegisteredStorageSourceTarget(
+            storage_source_id=storage_source_id,
+            alias_paths=tuple(aliases_by_source.get(storage_source_id, [])),
+            watched_folders=tuple(source_watched_folders),
+        )
+        for storage_source_id, source_watched_folders in watched_folders_by_source.items()
+    ]
+
+
+def _validate_registered_source_target(
+    *,
+    storage_source_id: str,
+    alias_paths: tuple[str, ...],
+) -> tuple[str | None, str | None, Path | None]:
+    if not alias_paths:
+        return "alias_missing", "no registered alias is available for polling", None
+
+    first_failure: tuple[str, str] | None = None
+    for alias_path in alias_paths:
+        alias_root = Path(alias_path).expanduser().resolve()
+        try:
+            _validate_scan_root(alias_root)
+            marker = read_source_marker(alias_root)
+        except OSError as exc:
+            failure = (_classify_source_failure(exc), _describe_source_failure(exc))
+        except SourceRegistrationError as exc:
+            failure = ("marker_invalid", str(exc))
+        else:
+            if marker is None:
+                failure = ("marker_missing", "storage source marker file is missing")
+            elif str(marker["storage_source_id"]) != storage_source_id:
+                failure = ("marker_mismatch", "marker file does not match expected storage source")
+            else:
+                return None, None, alias_root
+        if first_failure is None:
+            first_failure = failure
+
+    assert first_failure is not None
+    return first_failure[0], first_failure[1], None
+
+
+def _resolve_registered_scan_root(*, alias_root: Path, relative_path: str | None) -> Path:
+    if relative_path in {None, "."}:
+        return alias_root
+    return alias_root / relative_path
+
+
+def _classify_source_failure(exc: OSError) -> str:
+    if isinstance(exc, PermissionError):
+        return "source_permission_denied"
+    if isinstance(exc, (FileNotFoundError, NotADirectoryError)):
+        return "source_unreachable"
+    return "source_io_error"
+
+
+def _describe_source_failure(exc: OSError) -> str:
+    if isinstance(exc, PermissionError):
+        return "storage source root is not readable"
+    if isinstance(exc, (FileNotFoundError, NotADirectoryError)):
+        return "storage source root is unavailable"
+    return f"storage source validation failed: {exc}"
+
+
+def _record_ingest_run(
+    run_store: IngestRunStore,
+    *,
+    connection: Connection,
+    watched_folder_id: str,
+    status: str,
+    files_seen: int,
+    files_created: int,
+    files_updated: int,
+    error_messages: tuple[str, ...],
+) -> None:
+    ingest_run_id = run_store.create_run(
+        watched_folder_id=watched_folder_id,
+        connection=connection,
+    )
+    run_store.finalize_run(
+        ingest_run_id,
+        status=status,
+        files_seen=files_seen,
+        files_created=files_created,
+        files_updated=files_updated,
+        error_count=len(error_messages),
+        error_summary=_error_summary(error_messages),
+        connection=connection,
+    )
+
+
+def _error_summary(error_messages: tuple[str, ...]) -> str | None:
+    if not error_messages:
+        return None
+    return error_messages[0]
+
+
 def build_photo_record(path: Path, *, canonical_path: str) -> PhotoRecord:
     stat = path.stat()
     image_metadata = extract_image_metadata(path)
@@ -392,6 +665,8 @@ def _sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
 def _parse_timestamp(value: str | None) -> datetime | None:
     if value is None:
         return None

--- a/apps/api/tests/test_cli.py
+++ b/apps/api/tests/test_cli.py
@@ -2,12 +2,18 @@ import os
 import shutil
 import subprocess
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+from sqlalchemy import create_engine, select
 
 from app.cli import main
 from app.migrations import upgrade_database
+from app.services.source_registration import MARKER_FILENAME
+from app.services.storage_sources import attach_storage_source_alias, create_storage_source
+from app.services.watched_folders import create_watched_folder
+from app.storage import photos, storage_sources
 
 
 def _resolve_seed_corpus_dir(start: Path | None = None) -> Path:
@@ -98,3 +104,102 @@ def test_cli_module_executes_main_when_run_with_dash_m(tmp_path):
     assert result.returncode == 0
     assert f"database_url={db_url}" in result.stdout
     assert "migration=head" in result.stdout
+
+
+def test_poll_storage_sources_cli_scans_registered_watched_folders(monkeypatch, tmp_path, capsys):
+    monkeypatch.chdir(tmp_path)
+    _use_supported_cli_runtime(monkeypatch)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'cli-poll-storage-sources.db'}"
+    upgrade_database(db_url)
+    _seed_registered_storage_source_with_watched_folder(
+        db_url,
+        root_path=staged_corpus_dir,
+        watched_path=staged_corpus_dir,
+        display_name="Seed Corpus",
+        now=datetime(2026, 3, 28, 22, 15, tzinfo=UTC),
+    )
+
+    exit_code = main(["poll-storage-sources", "--database-url", db_url])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "scanned=6" in output
+    assert "inserted=6" in output
+    assert "updated=0" in output
+    assert "errors=0" in output
+
+    engine = create_engine(db_url, future=True)
+    with engine.connect() as connection:
+        assert connection.execute(select(photos.c.photo_id)).first() is not None
+
+
+def test_poll_storage_sources_cli_returns_nonzero_when_source_validation_fails(
+    monkeypatch, tmp_path, capsys
+):
+    monkeypatch.chdir(tmp_path)
+    _use_supported_cli_runtime(monkeypatch)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'cli-poll-storage-sources-error.db'}"
+    upgrade_database(db_url)
+    source_id = _seed_registered_storage_source_with_watched_folder(
+        db_url,
+        root_path=staged_corpus_dir,
+        watched_path=staged_corpus_dir,
+        display_name="Seed Corpus",
+        now=datetime(2026, 3, 28, 22, 20, tzinfo=UTC),
+    )
+    (staged_corpus_dir / MARKER_FILENAME).unlink()
+
+    exit_code = main(["poll-storage-sources", "--database-url", db_url])
+    output = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "errors=1" in output
+    assert f"storage_source:{source_id}: storage source marker file is missing" in output
+
+    engine = create_engine(db_url, future=True)
+    with engine.connect() as connection:
+        source = connection.execute(
+            select(storage_sources).where(storage_sources.c.storage_source_id == source_id)
+        ).mappings().one()
+    assert source["last_failure_reason"] == "marker_missing"
+
+
+def _seed_registered_storage_source_with_watched_folder(
+    database_url: str,
+    *,
+    root_path: Path,
+    watched_path: Path,
+    display_name: str,
+    now: datetime,
+) -> str:
+    root = root_path.resolve()
+    watched = watched_path.resolve()
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name=display_name,
+            marker_filename=MARKER_FILENAME,
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            now=now,
+        )
+        (root / MARKER_FILENAME).write_text(
+            f'{{"storage_source_id":"{source["storage_source_id"]}","marker_version":1}}'
+        )
+        create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            watched_path=watched.as_posix(),
+            display_name=display_name,
+            now=now,
+        )
+    return str(source["storage_source_id"])

--- a/apps/api/tests/test_ingest.py
+++ b/apps/api/tests/test_ingest.py
@@ -9,14 +9,21 @@ from sqlalchemy import create_engine, event, func, insert, select
 from app.db.queue import IngestQueueStore
 from app.migrations import upgrade_database
 from app.processing import ingest as ingest_module
-from app.processing.ingest import ingest_directory, reconcile_directory
+from app.processing.ingest import (
+    ingest_directory,
+    poll_registered_storage_sources,
+    reconcile_directory,
+)
 from app.services.file_reconciliation import (
     activate_observed_file,
     reconcile_watched_folder,
     refresh_photo_deleted_timestamps,
 )
-from app.services.storage_sources import create_storage_source
+from app.services.source_registration import MARKER_FILENAME
+from app.services.storage_sources import attach_storage_source_alias, create_storage_source
+from app.services.watched_folders import create_watched_folder
 from app.storage import faces, photo_files, photos, storage_sources, watched_folders
+from photoorg_db_schema import ingest_runs
 
 
 def _resolve_seed_corpus_dir(start: Path | None = None) -> Path:
@@ -652,6 +659,266 @@ def test_reconcile_directory_reports_thumbnail_failures_without_marking_source_u
     assert photo["thumbnail_jpeg"] is None
 
 
+def test_poll_registered_storage_sources_scans_enabled_registered_watched_folders(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'poll-storage-sources.db'}"
+    upgrade_database(db_url)
+
+    now = datetime(2026, 3, 28, 21, 0, tzinfo=UTC)
+    source_id, watched_folder_id = seed_registered_storage_source_with_watched_folder(
+        db_url,
+        root_path=staged_corpus_dir,
+        watched_path=staged_corpus_dir,
+        display_name="Seed Corpus",
+        now=now,
+    )
+
+    result = poll_registered_storage_sources(database_url=db_url, now=now)
+
+    assert result.scanned == 6
+    assert result.inserted == 6
+    assert result.updated == 0
+    assert result.errors == []
+
+    watched_folder = load_watched_folder_by_id(db_url, watched_folder_id)
+    assert watched_folder["availability_state"] == "active"
+    assert watched_folder["last_failure_reason"] is None
+    assert watched_folder["last_successful_scan_ts"] == now
+
+    source = load_storage_source_row(db_url, source_id)
+    assert source["availability_state"] == "active"
+    assert source["last_failure_reason"] is None
+    assert source["last_validated_ts"] == now
+
+    photo = load_photo_row(
+        db_url,
+        f"{staged_corpus_dir.as_posix()}/family-events/birthday-park/birthday_park_001.jpg",
+    )
+    assert photo["thumbnail_mime_type"] == "image/jpeg"
+
+
+def test_poll_registered_storage_sources_aborts_reconciliation_on_marker_mismatch(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'poll-storage-sources-marker-mismatch.db'}"
+    upgrade_database(db_url)
+
+    healthy_now = datetime(2026, 3, 28, 21, 30, tzinfo=UTC)
+    source_id, watched_folder_id = seed_registered_storage_source_with_watched_folder(
+        db_url,
+        root_path=staged_corpus_dir,
+        watched_path=staged_corpus_dir,
+        display_name="Seed Corpus",
+        now=healthy_now,
+    )
+
+    first_result = poll_registered_storage_sources(database_url=db_url, now=healthy_now)
+    assert first_result.errors == []
+
+    missing_path = staged_corpus_dir / "family-events" / "birthday-park" / "birthday_park_006.jpg"
+    missing_path.unlink()
+    (staged_corpus_dir / MARKER_FILENAME).write_text(
+        '{"storage_source_id":"unexpected-source","marker_version":1}'
+    )
+
+    failed_now = healthy_now + timedelta(minutes=5)
+    failed_result = poll_registered_storage_sources(database_url=db_url, now=failed_now)
+
+    assert failed_result.scanned == 0
+    assert failed_result.inserted == 0
+    assert failed_result.updated == 0
+    assert failed_result.errors == [
+        f"storage_source:{source_id}: marker file does not match expected storage source"
+    ]
+
+    source = load_storage_source_row(db_url, source_id)
+    assert source["availability_state"] == "unreachable"
+    assert source["last_failure_reason"] == "marker_mismatch"
+    assert source["last_validated_ts"] == failed_now
+
+    watched_folder = load_watched_folder_by_id(db_url, watched_folder_id)
+    assert watched_folder["availability_state"] == "unreachable"
+    assert watched_folder["last_failure_reason"] == "marker_mismatch"
+    assert watched_folder["last_successful_scan_ts"] == healthy_now
+
+    photo_file = load_photo_file_row(
+        db_url,
+        "family-events/birthday-park/birthday_park_006.jpg",
+    )
+    assert photo_file["lifecycle_state"] == "active"
+    assert photo_file["missing_ts"] is None
+    assert photo_file["deleted_ts"] is None
+
+
+def test_poll_registered_storage_sources_reports_missing_marker_file(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'poll-storage-sources-marker-missing.db'}"
+    upgrade_database(db_url)
+
+    now = datetime(2026, 3, 28, 21, 45, tzinfo=UTC)
+    source_id, watched_folder_id = seed_registered_storage_source_with_watched_folder(
+        db_url,
+        root_path=staged_corpus_dir,
+        watched_path=staged_corpus_dir,
+        display_name="Seed Corpus",
+        now=now,
+    )
+    (staged_corpus_dir / MARKER_FILENAME).unlink()
+
+    result = poll_registered_storage_sources(database_url=db_url, now=now)
+
+    assert result.scanned == 0
+    assert result.errors == [f"storage_source:{source_id}: storage source marker file is missing"]
+
+    source = load_storage_source_row(db_url, source_id)
+    assert source["availability_state"] == "unreachable"
+    assert source["last_failure_reason"] == "marker_missing"
+    assert source["last_validated_ts"] == now
+
+    watched_folder = load_watched_folder_by_id(db_url, watched_folder_id)
+    assert watched_folder["availability_state"] == "unreachable"
+    assert watched_folder["last_failure_reason"] == "marker_missing"
+
+
+def test_poll_registered_storage_sources_reports_unreachable_source_root(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'poll-storage-sources-root-unreachable.db'}"
+    upgrade_database(db_url)
+
+    now = datetime(2026, 3, 28, 22, 0, tzinfo=UTC)
+    source_id, watched_folder_id = seed_registered_storage_source_with_watched_folder(
+        db_url,
+        root_path=staged_corpus_dir,
+        watched_path=staged_corpus_dir,
+        display_name="Seed Corpus",
+        now=now,
+    )
+    shutil.rmtree(staged_corpus_dir)
+
+    result = poll_registered_storage_sources(database_url=db_url, now=now)
+
+    assert result.scanned == 0
+    assert result.errors == [f"storage_source:{source_id}: storage source root is unavailable"]
+
+    source = load_storage_source_row(db_url, source_id)
+    assert source["availability_state"] == "unreachable"
+    assert source["last_failure_reason"] == "source_unreachable"
+    assert source["last_validated_ts"] == now
+
+    watched_folder = load_watched_folder_by_id(db_url, watched_folder_id)
+    assert watched_folder["availability_state"] == "unreachable"
+    assert watched_folder["last_failure_reason"] == "source_unreachable"
+
+
+def test_poll_registered_storage_sources_falls_back_to_later_alias_when_first_is_unreachable(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    missing_alias_root = tmp_path / "missing-alias-root"
+    db_url = f"sqlite:///{tmp_path / 'poll-storage-sources-alias-fallback.db'}"
+    upgrade_database(db_url)
+
+    now = datetime(2026, 3, 28, 22, 30, tzinfo=UTC)
+    source_id, watched_folder_id = seed_registered_storage_source_with_watched_folder(
+        db_url,
+        root_path=staged_corpus_dir,
+        watched_path=staged_corpus_dir,
+        display_name="Seed Corpus",
+        now=now,
+        alias_paths=(missing_alias_root.as_posix(), staged_corpus_dir.as_posix()),
+    )
+
+    result = poll_registered_storage_sources(database_url=db_url, now=now)
+
+    assert result.scanned == 6
+    assert result.errors == []
+
+    source = load_storage_source_row(db_url, source_id)
+    assert source["availability_state"] == "active"
+    assert source["last_failure_reason"] is None
+
+    watched_folder = load_watched_folder_by_id(db_url, watched_folder_id)
+    assert watched_folder["availability_state"] == "active"
+    assert watched_folder["last_successful_scan_ts"] == now
+
+
+def test_poll_registered_storage_sources_records_ingest_run_for_successful_scan(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'poll-storage-sources-ingest-run-success.db'}"
+    upgrade_database(db_url)
+
+    now = datetime(2026, 3, 28, 22, 45, tzinfo=UTC)
+    _, watched_folder_id = seed_registered_storage_source_with_watched_folder(
+        db_url,
+        root_path=staged_corpus_dir,
+        watched_path=staged_corpus_dir,
+        display_name="Seed Corpus",
+        now=now,
+    )
+
+    result = poll_registered_storage_sources(database_url=db_url, now=now)
+
+    assert result.scanned == 6
+
+    run_rows = load_ingest_runs(database_url=db_url)
+    assert len(run_rows) == 1
+    assert run_rows[0]["watched_folder_id"] == watched_folder_id
+    assert run_rows[0]["status"] == "completed"
+    assert run_rows[0]["files_seen"] == 6
+    assert run_rows[0]["files_created"] == 6
+    assert run_rows[0]["files_updated"] == 0
+    assert run_rows[0]["error_count"] == 0
+    assert run_rows[0]["error_summary"] is None
+
+
+def test_poll_registered_storage_sources_records_ingest_run_for_source_validation_failure(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'poll-storage-sources-ingest-run-failure.db'}"
+    upgrade_database(db_url)
+
+    now = datetime(2026, 3, 28, 23, 0, tzinfo=UTC)
+    source_id, watched_folder_id = seed_registered_storage_source_with_watched_folder(
+        db_url,
+        root_path=staged_corpus_dir,
+        watched_path=staged_corpus_dir,
+        display_name="Seed Corpus",
+        now=now,
+    )
+    (staged_corpus_dir / MARKER_FILENAME).unlink()
+
+    result = poll_registered_storage_sources(database_url=db_url, now=now)
+
+    assert result.errors == [f"storage_source:{source_id}: storage source marker file is missing"]
+
+    run_rows = load_ingest_runs(database_url=db_url)
+    assert len(run_rows) == 1
+    assert run_rows[0]["watched_folder_id"] == watched_folder_id
+    assert run_rows[0]["status"] == "failed"
+    assert run_rows[0]["files_seen"] == 0
+    assert run_rows[0]["files_created"] == 0
+    assert run_rows[0]["files_updated"] == 0
+    assert run_rows[0]["error_count"] == 1
+    assert run_rows[0]["error_summary"] == "storage source marker file is missing"
+
+
 def test_upsert_photo_skips_thumbnail_lookup_when_record_has_fresh_thumbnail(tmp_path):
     database_url = f"sqlite:///{tmp_path / 'upsert-photo-thumbnail-fast-path.db'}"
     upgrade_database(database_url)
@@ -831,6 +1098,22 @@ def load_watched_folder_row(database_url: str, container_mount_path: str) -> dic
     return payload
 
 
+def load_watched_folder_by_id(database_url: str, watched_folder_id: str) -> dict:
+    engine = create_engine(database_url, future=True)
+    with engine.connect() as connection:
+        row = connection.execute(
+            select(watched_folders).where(
+                watched_folders.c.watched_folder_id == watched_folder_id
+            )
+        ).mappings().one()
+    payload = dict(row)
+    for key in ("created_ts", "updated_ts", "last_successful_scan_ts"):
+        value = payload.get(key)
+        if isinstance(value, datetime) and value.tzinfo is None:
+            payload[key] = value.replace(tzinfo=UTC)
+    return payload
+
+
 def load_pending_queue_count(database_url: str) -> int:
     store = IngestQueueStore(database_url)
     return len(store.list_pending())
@@ -886,6 +1169,23 @@ def load_storage_source_row(database_url: str, storage_source_id: str) -> dict:
     return payload
 
 
+def load_ingest_runs(database_url: str) -> list[dict]:
+    engine = create_engine(database_url, future=True)
+    with engine.connect() as connection:
+        rows = connection.execute(
+            select(ingest_runs).order_by(ingest_runs.c.started_ts, ingest_runs.c.ingest_run_id)
+        ).mappings()
+    payloads: list[dict] = []
+    for row in rows:
+        payload = dict(row)
+        for key in ("started_ts", "completed_ts"):
+            value = payload.get(key)
+            if isinstance(value, datetime) and value.tzinfo is None:
+                payload[key] = value.replace(tzinfo=UTC)
+        payloads.append(payload)
+    return payloads
+
+
 def seed_linked_storage_source(
     database_url: str,
     *,
@@ -921,6 +1221,47 @@ def seed_linked_storage_source(
             )
         )
     return str(source["storage_source_id"])
+
+
+def seed_registered_storage_source_with_watched_folder(
+    database_url: str,
+    *,
+    root_path: Path,
+    watched_path: Path,
+    display_name: str,
+    now: datetime,
+    alias_paths: tuple[str, ...] | None = None,
+) -> tuple[str, str]:
+    root = root_path.resolve()
+    watched = watched_path.resolve()
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name=display_name,
+            marker_filename=MARKER_FILENAME,
+            marker_version=1,
+            now=now,
+        )
+        for alias_path in alias_paths or (root.as_posix(),):
+            attach_storage_source_alias(
+                connection,
+                storage_source_id=source["storage_source_id"],
+                alias_path=alias_path,
+                now=now,
+            )
+        (root / MARKER_FILENAME).write_text(
+            f'{{"storage_source_id":"{source["storage_source_id"]}","marker_version":1}}'
+        )
+        watched_folder = create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            watched_path=watched.as_posix(),
+            display_name=display_name,
+            now=now,
+        )
+    return str(source["storage_source_id"]), str(watched_folder["watched_folder_id"])
 
 
 def seed_photo_with_file_instances(database_url: str) -> None:


### PR DESCRIPTION
Closes #22

## Summary
- add a central polling pass for enabled registered storage sources and watched folders
- validate source markers before scanning, with alias fallback and source-aware failure handling
- expose `poll-storage-sources` as a CLI verification path and document it for contributors
- record `ingest_runs` headers for successful and failed watched-folder polling passes

## Validation
- `uv run python -m pytest apps/api/tests/test_storage_sources.py apps/api/tests/test_source_registration.py apps/api/tests/test_ingest.py apps/api/tests/test_cli.py apps/api/tests/test_ingest_queue_processor.py -q`
- `uv run ruff check apps/api/app/processing/ingest.py apps/api/app/cli.py apps/api/tests/test_ingest.py apps/api/tests/test_cli.py CONTRIBUTING.md`

## Notes
- `@codex` implemented the central polling slice in this branch.
- This keeps the worker contract as a repeatable polling pass rather than introducing a separate long-running daemon runtime in this issue.