### PR TITLE
[codex] make file reconciliation source-aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Each environment is created once with an immutable storage mode, either `persist
 - a PostgreSQL database with the `vector` extension enabled
 - access from the server to the folders that contain the photo library
 
-The server still needs runtime access to the photo library, but watched-folder registration is now modeled under registered storage sources. Operators should register a source root first, then add watched folders relative to that source boundary instead of treating container mount paths as the user-facing identity contract.
+The server still needs runtime access to the photo library, but watched-folder registration is now modeled under registered storage sources. Operators should register a source root first, then add watched folders relative to that source boundary instead of treating container mount paths as the user-facing identity contract. Source-backed ingest and reconciliation now derive canonical file identity from the registered storage source plus source-relative paths, not from deployment-specific mount spellings.
 
 If you already have PostgreSQL running separately, the application can use that existing database instead of starting another one.
 

--- a/apps/api/alembic/versions/20260321_000001_initial_schema.py
+++ b/apps/api/alembic/versions/20260321_000001_initial_schema.py
@@ -117,7 +117,6 @@ def upgrade() -> None:
         "watched_folders",
         sa.Column("watched_folder_id", sa.String(36), primary_key=True),
         sa.Column("scan_path", sa.Text(), nullable=False, unique=True),
-        sa.Column("container_mount_path", sa.Text(), nullable=False, unique=True),
         sa.Column(
             "storage_source_id",
             sa.String(36),

--- a/apps/api/app/dev/seed_corpus.py
+++ b/apps/api/app/dev/seed_corpus.py
@@ -67,7 +67,6 @@ def load_seed_corpus_into_database(
     ingest_result = ingest_directory(
         resolve_seed_corpus_root(),
         database_url=database_url,
-        container_mount_path=resolve_seed_corpus_root(),
     )
 
     return {

--- a/apps/api/app/path_contract.py
+++ b/apps/api/app/path_contract.py
@@ -4,11 +4,11 @@ import posixpath
 from pathlib import Path
 
 
-def normalize_container_mount_path(path: str | Path) -> str:
+def normalize_absolute_path_root(path: str | Path) -> str:
     raw = str(path).replace("\\", "/")
     normalized = posixpath.normpath(raw)
     if not normalized.startswith("/"):
-        raise ValueError("container mount path must be absolute")
+        raise ValueError("path root must be absolute")
     return normalized
 
 
@@ -26,7 +26,14 @@ def normalize_relative_path(path: str) -> str:
     return normalized
 
 
-def build_canonical_photo_path(container_mount_path: str | Path, relative_path: str) -> str:
-    mount_root = normalize_container_mount_path(container_mount_path)
+def build_rooted_photo_path(path_root: str | Path, relative_path: str) -> str:
+    mount_root = normalize_absolute_path_root(path_root)
     normalized_relative = normalize_relative_path(relative_path)
     return posixpath.normpath(posixpath.join(mount_root, normalized_relative))
+
+
+def build_source_aware_photo_path(storage_source_id: str, relative_path: str) -> str:
+    normalized_relative = normalize_relative_path(relative_path)
+    return posixpath.normpath(
+        posixpath.join("/storage-sources", storage_source_id, normalized_relative)
+    )

--- a/apps/api/app/processing/ingest.py
+++ b/apps/api/app/processing/ingest.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import hashlib
+import posixpath
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from stat import S_ISDIR
-from typing import Iterable, Protocol
+from typing import Callable, Iterable, Protocol
 from uuid import NAMESPACE_URL, uuid5
 
 from sqlalchemy import delete, insert, select, update
@@ -15,8 +16,8 @@ from app.db.config import resolve_missing_file_grace_period_days
 from app.db.ingest_runs import IngestRunStore
 from app.db.queue import IngestQueueStore
 from app.path_contract import (
-    build_canonical_photo_path,
-    normalize_container_mount_path,
+    build_rooted_photo_path,
+    build_source_aware_photo_path,
     relative_photo_path,
 )
 from app.services.file_reconciliation import (
@@ -80,7 +81,6 @@ class IngestResult:
 class RegisteredWatchedFolderTarget:
     storage_source_id: str
     watched_folder_id: str
-    container_mount_path: str
     relative_path: str | None
 
 
@@ -104,11 +104,9 @@ def ingest_directory(
     root: str | Path,
     database_url: str | Path | None = None,
     *,
-    container_mount_path: str | Path | None = None,
     face_detector: FaceDetector | None = None,
 ) -> IngestResult:
     source_root = Path(root).expanduser().resolve()
-    canonical_root = normalize_container_mount_path(container_mount_path or source_root)
     result = IngestResult()
 
     queue_store = IngestQueueStore(database_url)
@@ -119,7 +117,7 @@ def ingest_directory(
             payload = build_ingest_submission(
                 photo_path,
                 scan_root=source_root,
-                container_mount_path=canonical_root,
+                path_root=source_root,
             )
             queue_store.enqueue(
                 payload_type="photo_metadata",
@@ -137,12 +135,10 @@ def reconcile_directory(
     root: str | Path,
     database_url: str | Path | None = None,
     *,
-    container_mount_path: str | Path | None = None,
     now: datetime | None = None,
     missing_file_grace_period_days: int | None = None,
 ) -> IngestResult:
     source_root = Path(root).expanduser().resolve()
-    canonical_root = normalize_container_mount_path(container_mount_path or source_root)
     result = IngestResult()
     at = now if now is not None else utc_now()
     grace_period_days = resolve_missing_file_grace_period_days(missing_file_grace_period_days)
@@ -152,14 +148,16 @@ def reconcile_directory(
         watched_folder_id = ensure_watched_folder_exists(
             connection,
             scan_path=source_root.as_posix(),
-            container_mount_path=canonical_root,
             now=at,
         )
         outcome = _reconcile_watched_folder_root(
             connection,
             watched_folder_id=watched_folder_id,
             source_root=source_root,
-            canonical_root=canonical_root,
+            canonical_path_for_relative_path=lambda relative_path: build_rooted_photo_path(
+                source_root,
+                relative_path,
+            ),
             now=at,
             missing_file_grace_period_days=grace_period_days,
         )
@@ -223,7 +221,10 @@ def poll_registered_storage_sources(
                     connection,
                     watched_folder_id=target.watched_folder_id,
                     source_root=scan_root,
-                    canonical_root=target.container_mount_path,
+                    canonical_path_for_relative_path=_registered_source_path_builder(
+                        storage_source_id=source_target.storage_source_id,
+                        watched_folder_relative_path=target.relative_path,
+                    ),
                     now=at,
                     missing_file_grace_period_days=grace_period_days,
                 )
@@ -269,7 +270,7 @@ def _reconcile_watched_folder_root(
     *,
     watched_folder_id: str,
     source_root: Path,
-    canonical_root: str,
+    canonical_path_for_relative_path: Callable[[str], str],
     now: datetime,
     missing_file_grace_period_days: int,
 ) -> WatchedFolderPollOutcome:
@@ -308,7 +309,7 @@ def _reconcile_watched_folder_root(
         relative_path = relative_photo_path(source_root, photo_path)
         record = build_photo_record(
             photo_path,
-            canonical_path=build_canonical_photo_path(canonical_root, relative_path),
+            canonical_path=canonical_path_for_relative_path(relative_path),
         )
         try:
             thumbnail = generate_thumbnail(photo_path)
@@ -384,7 +385,6 @@ def _load_registered_storage_source_targets(
         select(
             watched_folders.c.storage_source_id,
             watched_folders.c.watched_folder_id,
-            watched_folders.c.container_mount_path,
             watched_folders.c.relative_path,
         )
         .where(
@@ -401,7 +401,6 @@ def _load_registered_storage_source_targets(
             RegisteredWatchedFolderTarget(
                 storage_source_id=row["storage_source_id"],
                 watched_folder_id=row["watched_folder_id"],
-                container_mount_path=row["container_mount_path"],
                 relative_path=row["relative_path"],
             )
         )
@@ -452,6 +451,23 @@ def _resolve_registered_scan_root(*, alias_root: Path, relative_path: str | None
     if relative_path in {None, "."}:
         return alias_root
     return alias_root / relative_path
+
+
+def _registered_source_path_builder(
+    *,
+    storage_source_id: str,
+    watched_folder_relative_path: str | None,
+) -> Callable[[str], str]:
+    def build(relative_path: str) -> str:
+        source_relative_parts = [
+            part
+            for part in (watched_folder_relative_path, relative_path)
+            if part not in {None, ".", ""}
+        ]
+        source_relative_path = posixpath.normpath(posixpath.join(*source_relative_parts))
+        return build_source_aware_photo_path(storage_source_id, source_relative_path)
+
+    return build
 
 
 def _classify_source_failure(exc: OSError) -> str:
@@ -533,12 +549,12 @@ def build_ingest_submission(
     path: Path,
     *,
     scan_root: Path,
-    container_mount_path: str | Path,
+    path_root: str | Path,
 ) -> dict:
     relative_path = relative_photo_path(scan_root, path)
     record = build_photo_record(
         path,
-        canonical_path=build_canonical_photo_path(container_mount_path, relative_path),
+        canonical_path=build_rooted_photo_path(path_root, relative_path),
     )
     payload = {
         "photo_id": record.photo_id,

--- a/apps/api/app/routers/storage_sources.py
+++ b/apps/api/app/routers/storage_sources.py
@@ -54,7 +54,6 @@ class WatchedFolderResponse(BaseModel):
     watched_folder_id: str
     storage_source_id: str | None = None
     scan_path: str
-    container_mount_path: str
     relative_path: str | None = None
     display_name: str | None = None
     is_enabled: int

--- a/apps/api/app/services/file_reconciliation.py
+++ b/apps/api/app/services/file_reconciliation.py
@@ -6,7 +6,6 @@ from uuid import NAMESPACE_URL, uuid5
 from sqlalchemy import insert, select, update
 from sqlalchemy.engine import Connection
 
-from app.path_contract import normalize_container_mount_path
 from app.storage import photo_files, photos, storage_sources, watched_folders
 
 
@@ -18,10 +17,8 @@ def ensure_watched_folder_exists(
     connection: Connection,
     *,
     scan_path: str,
-    container_mount_path: str,
     now: datetime,
 ) -> str:
-    normalized_mount_path = normalize_container_mount_path(container_mount_path)
     watched_folder_id = _watched_folder_id_for_scan_path(scan_path)
     row = connection.execute(
         select(watched_folders.c.watched_folder_id).where(
@@ -33,8 +30,7 @@ def ensure_watched_folder_exists(
             insert(watched_folders).values(
                 watched_folder_id=watched_folder_id,
                 scan_path=scan_path,
-                container_mount_path=normalized_mount_path,
-                display_name=normalized_mount_path,
+                display_name=scan_path,
                 is_enabled=1,
                 availability_state="active",
                 last_failure_reason=None,
@@ -48,10 +44,7 @@ def ensure_watched_folder_exists(
     connection.execute(
         update(watched_folders)
         .where(watched_folders.c.watched_folder_id == watched_folder_id)
-        .values(
-            container_mount_path=normalized_mount_path,
-            updated_ts=now,
-        )
+        .values(updated_ts=now)
     )
     return watched_folder_id
 
@@ -128,13 +121,11 @@ def ensure_watched_folder(
     connection: Connection,
     *,
     scan_path: str,
-    container_mount_path: str,
     now: datetime,
 ) -> str:
     watched_folder_id = ensure_watched_folder_exists(
         connection,
         scan_path=scan_path,
-        container_mount_path=container_mount_path,
         now=now,
     )
     record_watched_folder_scan_success(

--- a/apps/api/app/services/watched_folders.py
+++ b/apps/api/app/services/watched_folders.py
@@ -50,7 +50,6 @@ def create_watched_folder(
     values = {
         "storage_source_id": storage_source_id,
         "scan_path": normalized_watched_path,
-        "container_mount_path": normalized_watched_path,
         "relative_path": relative_path,
         "display_name": display_name or PurePosixPath(relative_path).name or relative_path,
         "is_enabled": 1,

--- a/apps/api/openapi/spec.yaml
+++ b/apps/api/openapi/spec.yaml
@@ -369,9 +369,6 @@ components:
         scan_path:
           type: string
           title: Scan Path
-        container_mount_path:
-          type: string
-          title: Container Mount Path
         relative_path:
           anyOf:
           - type: string
@@ -403,7 +400,6 @@ components:
       required:
       - watched_folder_id
       - scan_path
-      - container_mount_path
       - is_enabled
       - availability_state
       title: WatchedFolderResponse

--- a/apps/api/tests/test_ingest.py
+++ b/apps/api/tests/test_ingest.py
@@ -1,10 +1,11 @@
 from datetime import UTC, datetime, timedelta
+import posixpath
 import shutil
 from pathlib import Path
 from uuid import NAMESPACE_URL, uuid5
 
 import pytest
-from sqlalchemy import create_engine, event, func, insert, select
+from sqlalchemy import create_engine, event, func, insert, select, update
 
 from app.db.queue import IngestQueueStore
 from app.migrations import upgrade_database
@@ -44,7 +45,6 @@ SEED_CORPUS_SUBSET_PATHS = (
     "seed-corpus/family-events/birthday-park/birthday_park_005.jpg",
     "seed-corpus/family-events/birthday-park/birthday_park_006.jpg",
 )
-SEED_CORPUS_CONTAINER_PATH = "/photos/seed-corpus"
 SEED_CORPUS_RELATIVE_SUBSET_PATHS = tuple(
     asset_path.removeprefix("seed-corpus/") for asset_path in SEED_CORPUS_SUBSET_PATHS
 )
@@ -86,7 +86,6 @@ def test_ingest_directory_loads_sample_photos_into_queue(tmp_path, monkeypatch):
     result = ingest_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
     )
 
     assert result.scanned == 6
@@ -99,7 +98,7 @@ def test_ingest_directory_loads_sample_photos_into_queue(tmp_path, monkeypatch):
 
     assert len(rows) == 6
     assert all(row.payload_type == "photo_metadata" for row in rows)
-    assert all(row.payload_json["path"].startswith(f"{SEED_CORPUS_CONTAINER_PATH}/") for row in rows)
+    assert all(row.payload_json["path"].startswith(f"{staged_corpus_dir.as_posix()}/") for row in rows)
     assert {row.payload_json["ext"] for row in rows} == {"jpg", "jpeg", "png", "heic"}
     assert all(row.payload_json["filesize"] > 0 for row in rows)
     assert all(len(row.payload_json["sha256"]) == 64 for row in rows)
@@ -123,7 +122,6 @@ def test_ingest_directory_enqueues_records_without_writing_photos_table(tmp_path
     result = ingest_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
     )
 
     assert result.scanned == 6
@@ -141,12 +139,10 @@ def test_ingest_directory_is_idempotent_for_existing_paths(tmp_path, monkeypatch
     first_run = ingest_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
     )
     second_run = ingest_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
     )
 
     assert first_run.enqueued == 6
@@ -167,7 +163,6 @@ def test_ingest_directory_keeps_domain_tables_unwritten_when_detector_is_enabled
     result = ingest_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         face_detector=UnusedFaceDetector(),
     )
 
@@ -187,7 +182,6 @@ def test_ingest_directory_keeps_queue_only_behavior(tmp_path, monkeypatch):
     result = ingest_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
     )
 
     assert result.errors == []
@@ -217,7 +211,6 @@ def test_reconcile_directory_marks_absent_files_missing(tmp_path, monkeypatch):
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
     )
 
     missing_path = staged_corpus_dir / "family-events" / "birthday-park" / "birthday_park_006.jpg"
@@ -226,7 +219,6 @@ def test_reconcile_directory_marks_absent_files_missing(tmp_path, monkeypatch):
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
     )
 
     row = load_photo_file_row(db_url, "family-events/birthday-park/birthday_park_006.jpg")
@@ -234,7 +226,7 @@ def test_reconcile_directory_marks_absent_files_missing(tmp_path, monkeypatch):
     assert row["missing_ts"] is not None
     assert row["deleted_ts"] is None
 
-    watched_folder = load_watched_folder_row(db_url, SEED_CORPUS_CONTAINER_PATH)
+    watched_folder = load_watched_folder_row(db_url, staged_corpus_dir.as_posix())
     assert watched_folder["availability_state"] == "active"
     assert watched_folder["last_failure_reason"] is None
     assert watched_folder["last_successful_scan_ts"] is not None
@@ -250,7 +242,6 @@ def test_reconcile_directory_deletes_missing_file_after_grace_period(tmp_path, m
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=now,
     )
 
@@ -260,13 +251,11 @@ def test_reconcile_directory_deletes_missing_file_after_grace_period(tmp_path, m
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=now,
     )
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=now + timedelta(days=1, seconds=1),
     )
 
@@ -278,7 +267,7 @@ def test_reconcile_directory_deletes_missing_file_after_grace_period(tmp_path, m
     assert row["missing_ts"] == now
     assert row["deleted_ts"] == now + timedelta(days=1, seconds=1)
 
-    watched_folder = load_watched_folder_row(db_url, SEED_CORPUS_CONTAINER_PATH)
+    watched_folder = load_watched_folder_row(db_url, staged_corpus_dir.as_posix())
     assert watched_folder["availability_state"] == "active"
     assert watched_folder["last_failure_reason"] is None
     assert watched_folder["last_successful_scan_ts"] == now + timedelta(days=1, seconds=1)
@@ -294,7 +283,6 @@ def test_reconcile_directory_with_zero_day_grace_immediately_deletes_missing_fil
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=now,
         missing_file_grace_period_days=0,
     )
@@ -305,7 +293,6 @@ def test_reconcile_directory_with_zero_day_grace_immediately_deletes_missing_fil
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=now,
         missing_file_grace_period_days=0,
     )
@@ -318,7 +305,7 @@ def test_reconcile_directory_with_zero_day_grace_immediately_deletes_missing_fil
     assert row["missing_ts"] == now
     assert row["deleted_ts"] == now
 
-    watched_folder = load_watched_folder_row(db_url, SEED_CORPUS_CONTAINER_PATH)
+    watched_folder = load_watched_folder_row(db_url, staged_corpus_dir.as_posix())
     assert watched_folder["availability_state"] == "active"
     assert watched_folder["last_failure_reason"] is None
     assert watched_folder["last_successful_scan_ts"] == now
@@ -336,11 +323,10 @@ def test_reconcile_directory_marks_watched_folder_unreachable_when_root_scan_fai
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=healthy_now,
     )
 
-    watched_folder = load_watched_folder_row(db_url, SEED_CORPUS_CONTAINER_PATH)
+    watched_folder = load_watched_folder_row(db_url, staged_corpus_dir.as_posix())
     assert watched_folder["availability_state"] == "active"
     assert watched_folder["last_failure_reason"] is None
     assert watched_folder["last_successful_scan_ts"] == healthy_now
@@ -351,11 +337,10 @@ def test_reconcile_directory_marks_watched_folder_unreachable_when_root_scan_fai
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=failure_now,
     )
 
-    row = load_watched_folder_row(db_url, SEED_CORPUS_CONTAINER_PATH)
+    row = load_watched_folder_row(db_url, staged_corpus_dir.as_posix())
     assert row["availability_state"] == "unreachable"
     assert row["last_successful_scan_ts"] == healthy_now
 
@@ -373,7 +358,6 @@ def test_reconcile_directory_preserves_last_successful_scan_ts_when_root_scan_fa
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=healthy_now,
     )
 
@@ -381,11 +365,10 @@ def test_reconcile_directory_preserves_last_successful_scan_ts_when_root_scan_fa
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=failure_now,
     )
 
-    row = load_watched_folder_row(db_url, SEED_CORPUS_CONTAINER_PATH)
+    row = load_watched_folder_row(db_url, staged_corpus_dir.as_posix())
     assert row["availability_state"] == "unreachable"
     assert row["last_failure_reason"] == "permission_denied"
     assert row["last_successful_scan_ts"] == healthy_now
@@ -424,7 +407,6 @@ def test_reconcile_directory_does_not_advance_file_lifecycle_when_root_scan_fail
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=healthy_now,
     )
 
@@ -439,7 +421,6 @@ def test_reconcile_directory_does_not_advance_file_lifecycle_when_root_scan_fail
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=failure_now,
     )
 
@@ -464,7 +445,6 @@ def test_reconcile_directory_preserves_parent_photo_deleted_timestamp_when_root_
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=now,
     )
 
@@ -474,14 +454,12 @@ def test_reconcile_directory_preserves_parent_photo_deleted_timestamp_when_root_
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=now,
     )
     deleted_now = now + timedelta(days=1, seconds=1)
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=deleted_now,
     )
 
@@ -501,7 +479,6 @@ def test_reconcile_directory_preserves_parent_photo_deleted_timestamp_when_root_
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=failure_now,
     )
 
@@ -524,7 +501,6 @@ def test_reconcile_directory_clears_unreachable_state_after_later_healthy_scan(
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=healthy_now,
     )
 
@@ -535,7 +511,6 @@ def test_reconcile_directory_clears_unreachable_state_after_later_healthy_scan(
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=failure_now,
     )
 
@@ -548,11 +523,10 @@ def test_reconcile_directory_clears_unreachable_state_after_later_healthy_scan(
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=recovered_now,
     )
 
-    row = load_watched_folder_row(db_url, SEED_CORPUS_CONTAINER_PATH)
+    row = load_watched_folder_row(db_url, staged_corpus_dir.as_posix())
     assert row["availability_state"] == "active"
     assert row["last_failure_reason"] is None
     assert row["last_successful_scan_ts"] == recovered_now
@@ -570,20 +544,18 @@ def test_reconcile_directory_persists_thumbnail_and_keeps_it_when_source_goes_of
     source_id = seed_linked_storage_source(
         db_url,
         scan_root=staged_corpus_dir,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=healthy_now,
     )
 
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=healthy_now,
     )
 
     photo = load_photo_row(
         db_url,
-        f"{SEED_CORPUS_CONTAINER_PATH}/family-events/birthday-park/birthday_park_001.jpg",
+        f"{staged_corpus_dir.as_posix()}/family-events/birthday-park/birthday_park_001.jpg",
     )
     assert photo["thumbnail_mime_type"] == "image/jpeg"
     assert photo["thumbnail_width"] > 0
@@ -597,7 +569,6 @@ def test_reconcile_directory_persists_thumbnail_and_keeps_it_when_source_goes_of
     reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=offline_now,
     )
 
@@ -607,7 +578,7 @@ def test_reconcile_directory_persists_thumbnail_and_keeps_it_when_source_goes_of
 
     preserved = load_photo_row(
         db_url,
-        f"{SEED_CORPUS_CONTAINER_PATH}/family-events/birthday-park/birthday_park_001.jpg",
+        f"{staged_corpus_dir.as_posix()}/family-events/birthday-park/birthday_park_001.jpg",
     )
     assert preserved["thumbnail_jpeg"] == photo["thumbnail_jpeg"]
     assert preserved["thumbnail_width"] == photo["thumbnail_width"]
@@ -626,7 +597,6 @@ def test_reconcile_directory_reports_thumbnail_failures_without_marking_source_u
     source_id = seed_linked_storage_source(
         db_url,
         scan_root=staged_corpus_dir,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=now,
     )
 
@@ -638,7 +608,6 @@ def test_reconcile_directory_reports_thumbnail_failures_without_marking_source_u
     result = reconcile_directory(
         staged_corpus_dir,
         database_url=db_url,
-        container_mount_path=SEED_CORPUS_CONTAINER_PATH,
         now=now,
     )
 
@@ -654,7 +623,7 @@ def test_reconcile_directory_reports_thumbnail_failures_without_marking_source_u
 
     photo = load_photo_row(
         db_url,
-        f"{SEED_CORPUS_CONTAINER_PATH}/family-events/birthday-park/birthday_park_001.jpg",
+        f"{staged_corpus_dir.as_posix()}/family-events/birthday-park/birthday_park_001.jpg",
     )
     assert photo["thumbnail_jpeg"] is None
 
@@ -695,9 +664,53 @@ def test_poll_registered_storage_sources_scans_enabled_registered_watched_folder
 
     photo = load_photo_row(
         db_url,
-        f"{staged_corpus_dir.as_posix()}/family-events/birthday-park/birthday_park_001.jpg",
+        _source_aware_photo_path(
+            source_id,
+            "family-events/birthday-park/birthday_park_001.jpg",
+        ),
     )
     assert photo["thumbnail_mime_type"] == "image/jpeg"
+
+
+def test_poll_registered_storage_sources_ignores_legacy_scan_path_for_identity(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'poll-storage-sources-source-aware-paths.db'}"
+    upgrade_database(db_url)
+
+    now = datetime(2026, 3, 28, 21, 15, tzinfo=UTC)
+    source_id, watched_folder_id = seed_registered_storage_source_with_watched_folder(
+        db_url,
+        root_path=staged_corpus_dir,
+        watched_path=staged_corpus_dir,
+        display_name="Seed Corpus",
+        now=now,
+    )
+    engine = create_engine(db_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            update(watched_folders)
+            .where(watched_folders.c.watched_folder_id == watched_folder_id)
+            .values(scan_path="/legacy/photos/seed-corpus")
+        )
+
+    result = poll_registered_storage_sources(database_url=db_url, now=now)
+
+    assert result.errors == []
+    photo = load_photo_row(
+        db_url,
+        _source_aware_photo_path(
+            source_id,
+            "family-events/birthday-park/birthday_park_001.jpg",
+        ),
+    )
+    assert photo["path"] == _source_aware_photo_path(
+        source_id,
+        "family-events/birthday-park/birthday_park_001.jpg",
+    )
+    assert not photo["path"].startswith("/legacy/photos/")
 
 
 def test_poll_registered_storage_sources_aborts_reconciliation_on_marker_mismatch(
@@ -923,7 +936,7 @@ def test_upsert_photo_skips_thumbnail_lookup_when_record_has_fresh_thumbnail(tmp
     database_url = f"sqlite:///{tmp_path / 'upsert-photo-thumbnail-fast-path.db'}"
     upgrade_database(database_url)
     now = datetime(2026, 3, 28, 20, 0, tzinfo=UTC)
-    path = f"{SEED_CORPUS_CONTAINER_PATH}/family-events/birthday-park/birthday_park_001.jpg"
+    path = "/test-root/family-events/birthday-park/birthday_park_001.jpg"
 
     engine = create_engine(database_url, future=True)
     with engine.begin() as connection:
@@ -1082,12 +1095,12 @@ def load_photo_row(database_url: str, path: str) -> dict:
     return payload
 
 
-def load_watched_folder_row(database_url: str, container_mount_path: str) -> dict:
+def load_watched_folder_row(database_url: str, scan_path: str) -> dict:
     engine = create_engine(database_url, future=True)
     with engine.connect() as connection:
         row = connection.execute(
             select(watched_folders).where(
-                watched_folders.c.container_mount_path == container_mount_path
+                watched_folders.c.scan_path == scan_path
             )
         ).mappings().one()
     payload = dict(row)
@@ -1186,11 +1199,16 @@ def load_ingest_runs(database_url: str) -> list[dict]:
     return payloads
 
 
+def _source_aware_photo_path(storage_source_id: str, relative_path: str) -> str:
+    return posixpath.normpath(
+        posixpath.join("/storage-sources", storage_source_id, relative_path)
+    )
+
+
 def seed_linked_storage_source(
     database_url: str,
     *,
     scan_root: Path,
-    container_mount_path: str,
     now: datetime,
 ) -> str:
     engine = create_engine(database_url, future=True)
@@ -1208,7 +1226,6 @@ def seed_linked_storage_source(
                     uuid5(NAMESPACE_URL, f"watched-folder:{scan_root.resolve().as_posix()}")
                 ),
                 scan_path=scan_root.resolve().as_posix(),
-                container_mount_path=container_mount_path,
                 storage_source_id=source["storage_source_id"],
                 relative_path=".",
                 display_name="Family NAS / seed-corpus",
@@ -1271,7 +1288,7 @@ def seed_photo_with_file_instances(database_url: str) -> None:
         connection.execute(
             insert(photos).values(
                 photo_id="photo-1",
-                path=f"{SEED_CORPUS_CONTAINER_PATH}/family-events/birthday-park/birthday_park_001.jpg",
+                path="/test-root/family-events/birthday-park/birthday_park_001.jpg",
                 sha256="a" * 64,
                 phash=None,
                 filesize=100,
@@ -1340,7 +1357,7 @@ def seed_deleted_photo_with_file_instance(database_url: str, *, deleted_ts: date
         connection.execute(
             insert(photos).values(
                 photo_id="photo-1",
-                path=f"{SEED_CORPUS_CONTAINER_PATH}/family-events/birthday-park/birthday_park_001.jpg",
+                path="/test-root/family-events/birthday-park/birthday_park_001.jpg",
                 sha256="b" * 64,
                 phash=None,
                 filesize=100,

--- a/apps/api/tests/test_migrations.py
+++ b/apps/api/tests/test_migrations.py
@@ -207,7 +207,6 @@ def test_ingest_succeeds_after_running_migrations(tmp_path):
     result = ingest_directory(
         staged_root,
         database_url=database_url,
-        container_mount_path="/photos/seed-corpus",
     )
 
     assert result.errors == []

--- a/apps/api/tests/test_schema_definition.py
+++ b/apps/api/tests/test_schema_definition.py
@@ -46,7 +46,6 @@ def test_phase_zero_schema_applies_core_constraints():
 
     assert photos.c.sha256.unique is True
     assert watched_folders.c.scan_path.unique is True
-    assert watched_folders.c.container_mount_path.unique is True
     assert watched_folders.c.storage_source_id.nullable is True
     assert watched_folders.c.relative_path.nullable is True
     assert [fk.column.table.name for fk in watched_folders.c.storage_source_id.foreign_keys] == [

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -538,7 +538,6 @@ class TestPhotosRepositoryOfflineBrowseIntegration:
                 insert(watched_folders).values(
                     watched_folder_id="watched-folder-1",
                     scan_path="/photos/seed-corpus",
-                    container_mount_path="/photos/seed-corpus",
                     storage_source_id="source-1",
                     relative_path=".",
                     display_name="Family NAS / seed-corpus",
@@ -646,7 +645,6 @@ class TestPhotosRepositoryOfflineBrowseIntegration:
                 insert(watched_folders).values(
                     watched_folder_id="watched-folder-1",
                     scan_path="/photos/seed-corpus",
-                    container_mount_path="/photos/seed-corpus",
                     storage_source_id="source-1",
                     relative_path=".",
                     display_name="Family NAS / seed-corpus",
@@ -748,7 +746,6 @@ class TestPhotosRepositoryOfflineBrowseIntegration:
                         {
                             "watched_folder_id": "watched-folder-healthy",
                             "scan_path": "/photos/healthy",
-                            "container_mount_path": "/photos/healthy",
                             "storage_source_id": "source-1",
                             "relative_path": "healthy",
                             "display_name": "Healthy Folder",
@@ -762,7 +759,6 @@ class TestPhotosRepositoryOfflineBrowseIntegration:
                         {
                             "watched_folder_id": "watched-folder-unreachable",
                             "scan_path": "/photos/offline",
-                            "container_mount_path": "/photos/offline",
                             "storage_source_id": "source-1",
                             "relative_path": "offline",
                             "display_name": "Offline Folder",

--- a/apps/api/tests/test_seed_corpus_cli.py
+++ b/apps/api/tests/test_seed_corpus_cli.py
@@ -111,6 +111,5 @@ def test_load_seed_corpus_into_database_uses_local_queue_loading(monkeypatch):
     assert calls[0][0] == "ingest"
     assert calls[0][1] == {
         "database_url": "sqlite:///seed.db",
-        "container_mount_path": seed_corpus.resolve_seed_corpus_root(),
     }
     assert calls[1:] == []

--- a/apps/api/tests/test_storage_sources.py
+++ b/apps/api/tests/test_storage_sources.py
@@ -150,7 +150,6 @@ def test_create_watched_folder_persists_source_relative_path(tmp_path):
     )
     assert created["relative_path"] == "2024/trips"
     assert created["scan_path"] == "//nas/family/2024/trips"
-    assert created["container_mount_path"] == "//nas/family/2024/trips"
     assert [entry["relative_path"] for entry in rows] == ["2024/trips"]
     assert row["display_name"] == "Trips"
     assert row["is_enabled"] == 1

--- a/docs/superpowers/plans/2026-03-28-issue-23-source-aware-file-reconciliation.md
+++ b/docs/superpowers/plans/2026-03-28-issue-23-source-aware-file-reconciliation.md
@@ -1,0 +1,83 @@
+# Issue 23 Source-Aware File Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make source-backed ingest and reconciliation derive stable file identity from registered source ownership and source-relative paths, while removing touched legacy container-path assumptions.
+
+**Architecture:** Lock the new behavior with focused ingest tests first, then refactor the source-backed polling path so canonical photo identity no longer depends on alias or container path spellings. Keep missing-file behavior conservative by preserving the existing source-validation gate and limit cleanup to the files touched by this slice.
+
+**Tech Stack:** Python, SQLAlchemy Core, pytest, uv
+
+---
+
+## File Map
+
+- Modify: `apps/api/app/processing/ingest.py`
+- Modify: `apps/api/app/services/file_reconciliation.py`
+- Modify: `apps/api/app/db/ingest_runs.py`
+- Modify: `apps/api/tests/test_ingest.py`
+- Modify: `README.md`
+
+### Task 1: Lock source-aware identity in tests
+
+**Files:**
+- Modify: `apps/api/tests/test_ingest.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add focused tests covering:
+
+- source-backed polling through two aliases keeps the same canonical `photos.path` and `photo_id`
+- a changed file in a registered watched folder updates the existing logical photo instead of creating alias-specific duplicates
+- source-backed polling no longer needs container-path-derived expectations in the touched assertions/helpers
+
+- [ ] **Step 2: Run the focused tests to verify failure**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest.py -k "storage_sources or alias or changed" -q`
+Expected: FAIL because source-backed identity still depends on alias/container-style paths.
+
+### Task 2: Refactor source-backed ingest and reconciliation
+
+**Files:**
+- Modify: `apps/api/app/processing/ingest.py`
+- Modify: `apps/api/app/services/file_reconciliation.py`
+- Modify: `apps/api/app/db/ingest_runs.py`
+
+- [ ] **Step 1: Implement minimal source-aware canonical path helpers**
+
+Refactor the source-backed polling path to build canonical logical paths from:
+
+- `storage_source_id`
+- persisted watched-folder `relative_path`
+- file path relative to the watched folder root
+
+Keep the legacy one-shot ingest/reconcile entry points working unless the touched code can be simplified safely.
+
+- [ ] **Step 2: Remove touched legacy container-path references**
+
+Delete or stop using container-path plumbing in the source-backed polling path where the validated source context already provides the needed identity inputs.
+
+- [ ] **Step 3: Run the focused tests to verify pass**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest.py -k "storage_sources or alias or changed" -q`
+Expected: PASS
+
+### Task 3: Update docs and run verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `apps/api/tests/test_ingest.py`
+
+- [ ] **Step 1: Update touched docs**
+
+Adjust the README only where it still implies that source-backed reconciliation identity comes from container-mount paths.
+
+- [ ] **Step 2: Run targeted verification**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest.py -q`
+Expected: PASS
+
+- [ ] **Step 3: Run full verification**
+
+Run: `uv run python -m pytest -q`
+Expected: PASS

--- a/docs/superpowers/specs/2026-03-28-issue-23-source-aware-file-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-03-28-issue-23-source-aware-file-reconciliation-design.md
@@ -1,0 +1,78 @@
+# Issue 23 Source-Aware File Reconciliation Design
+
+Date: 2026-03-28
+Issue: #23
+
+## Context
+
+The source-registration and watched-folder work is already in place, and the polling loop now validates a registered storage source before scanning. The remaining gap is that file reconciliation still carries legacy path assumptions in the ingest path:
+
+- watched-folder scan setup still has legacy helpers based on raw scan paths
+- canonical photo identity is still built from alias-resolved or container-style paths
+- tests and helpers still encode container-path terminology even when the worker is operating on a registered source
+
+That leaves new and changed file handling too close to runtime path spellings, which is the wrong trust boundary for source-backed ingestion.
+
+## Goal
+
+Make new and changed file reconciliation source-aware so the ingest path derives stable identity from registered source ownership and source-relative paths rather than alias-specific or container-specific path contracts.
+
+## Non-Goals
+
+- schema-wide migration of all historical path fields
+- move detection
+- thumbnail redesign
+- unrelated cleanup outside ingest, reconciliation, and directly touched tests/docs
+
+## Decision
+
+Treat `storage_source_id` plus source-relative paths as the identity boundary for source-backed reconciliation.
+
+For the issue-23 slice:
+
+- registered-source polling should derive canonical photo identity from the validated source, the watched folder's persisted relative path, and the file path relative to that watched folder
+- source-backed reconcile flows should not depend on raw scan-path-derived watched-folder identifiers
+- legacy `container_mount_path` references should be removed from the touched source-backed ingest/reconciliation code where they are no longer needed
+- missing/deleted lifecycle behavior must remain conservative and only run after source validation succeeds
+
+## Design
+
+### Canonical file identity
+
+When polling a registered source, the worker already knows:
+
+- which `storage_source_id` was validated
+- which persisted `watched_folder_id` is being scanned
+- the watched folder's persisted source-relative path
+- the file path relative to the watched folder root
+
+That is enough to build a source-aware logical path. The canonical path used for `photo_id`, `photos.path`, queue payloads, and comparisons should be derived from those persisted values rather than from the alias root or a container mount path.
+
+This keeps the same file stable even if the worker reaches the same source through a different alias later.
+
+### Reconciliation boundary
+
+Reconciliation should continue to operate on the persisted `watched_folder_id`, with observed file membership expressed as file paths relative to that watched folder. The worker should only advance missing/deleted transitions after:
+
+1. a source alias is resolved
+2. the source root is validated
+3. the source marker matches the expected `storage_source_id`
+
+If any of those checks fail, the source and watched folder remain marked unreachable and file lifecycle state must not advance.
+
+### Legacy path cleanup
+
+Issue `#23` is also the point to remove stale container-path assumptions from the touched source-aware code. That does not require deleting every historical field immediately. It does require:
+
+- stopping new source-backed identity derivation from using `container_mount_path`
+- updating tests and helpers to assert source-aware behavior directly
+- renaming or simplifying local helpers where their old names still imply a container-path contract
+
+## Testing
+
+Add or update focused tests that prove:
+
+- the same registered source scanned through different aliases resolves to the same canonical photo identity
+- new and changed files under a registered watched folder reconcile correctly
+- marker mismatch and unreachable-source failures do not advance missing/deleted lifecycle
+- touched helpers and docs no longer rely on legacy container-path language for source-backed polling behavior

--- a/packages/db-schema/photoorg_db_schema/schema.py
+++ b/packages/db-schema/photoorg_db_schema/schema.py
@@ -108,7 +108,6 @@ watched_folders = Table(
     metadata,
     Column("watched_folder_id", String(36), primary_key=True),
     Column("scan_path", Text, nullable=False, unique=True),
-    Column("container_mount_path", Text, nullable=False, unique=True),
     Column(
         "storage_source_id",
         String(36),


### PR DESCRIPTION
## Summary
- make registered-source ingest and reconciliation derive canonical file identity from storage source ownership and source-relative paths
- remove the legacy `container_mount_path` contract from schema, watched-folder APIs, ingest helpers, and related tests/OpenAPI
- add issue-specific spec and plan docs for the implementation slice

## Why
- source-backed reconciliation still depended on deployment-specific path spellings
- the old container mount path field was no longer needed and was carrying dead pre-launch contract surface

## Validation
- `uv run python -m pytest apps/api/tests/test_ingest.py apps/api/tests/test_storage_sources.py apps/api/tests/test_storage_source_api.py apps/api/tests/test_search_service.py apps/api/tests/test_schema_definition.py apps/api/tests/test_migrations.py apps/api/tests/test_seed_corpus_cli.py apps/api/tests/test_main.py -q`
- `uv run python -m pytest -q`

Closes #23

@codex please review the source-aware reconciliation and legacy path cleanup.