### PR TITLE
[codex] Add Phase 1 milestone recap document

### DIFF
--- a/docs/phase-1-milestone-recap.md
+++ b/docs/phase-1-milestone-recap.md
@@ -1,0 +1,109 @@
+# Phase 1 Milestone Recap
+
+## Purpose Of This Document
+
+This document summarizes what Phase 1 made possible from a user and stakeholder perspective, what can now be demonstrated, and what we learned while shaping the design.
+
+Phase 1 was about making the system trustworthy as a cataloging and ingestion backbone. The milestone is not a polished browse experience yet. Instead, it proves that the product can register shared photo sources, discover and reconcile files in the background, preserve useful metadata, and behave safely when storage is temporarily unavailable.
+
+## Phase 1 Outcome
+
+At the close of Phase 1, Photo Organizer can now act as a centrally managed photo-ingestion system for a shared library.
+
+In practical terms, that means:
+
+- an admin can register a shared storage source and define watched folders under it
+- the system can poll those watched folders in the background and ingest newly discovered photos
+- photo metadata is persisted into the catalog so later browse and search work has a stable foundation
+- file changes, moves, disappearances, and temporary outages are handled as distinct situations rather than collapsed into one generic failure mode
+- ingest activity and source health are visible enough to support demos, troubleshooting, and the next phase of product work
+
+This is the point where the project stops being only a planned architecture and becomes a working ingestion platform.
+
+## What Is Now Possible
+
+From a stakeholder perspective, the milestone unlocks these capabilities:
+
+- Shared photo libraries can be modeled as durable sources rather than one-off machine-specific paths.
+- Multiple watched folders can be managed under a single source boundary.
+- New photos copied into a registered watched folder can be discovered and added to the catalog by background processing.
+- Metadata extraction now gives the catalog meaningful photo facts to build on, including the information needed for later browse and search experiences.
+- The system can preserve photo identity more reliably when files move within a source instead of treating those changes as unrelated deletes and re-adds.
+- Temporary source outages no longer force the product into pretending photos were deleted.
+- The system can surface whether a source is healthy and whether ingest is progressing or failing, which is necessary for operator trust.
+
+## What We Can Demo Now
+
+Phase 1 supports a clear milestone demo even before the browse-first UI work of the next phase.
+
+Recommended demo story:
+
+1. Register a storage source that represents a shared photo library.
+2. Add one or more watched folders beneath that source.
+3. Trigger or wait for background polling.
+4. Show that newly discovered files are ingested into the catalog with metadata.
+5. Move or reorganize a file within the same source and show that the system preserves identity instead of behaving like the photo disappeared and a brand-new one appeared.
+6. Simulate a temporary storage outage and show that the system reports the source as unavailable without incorrectly deleting catalog data.
+7. Restore source availability and show that normal reconciliation resumes.
+8. Show ingest status and recent source health so an operator can understand what happened.
+
+The milestone demo is therefore about trust and operational correctness:
+
+- the system notices the right things
+- it keeps catalog state coherent
+- it fails safely when storage is unreliable
+- it preserves the data needed for later browse and search features
+
+## Why The Design Changed During Phase 1
+
+Phase 1 started with a simpler mental model: configure watched folders and let the system scan them directly.
+
+That initial framing was good enough to begin implementation, but it proved too tied to development-time path mechanics. In particular, it leaned on machine-specific path spellings and container-mount assumptions that do not match the real product story for a family or small-group deployment on a local network.
+
+The design was revised for two important reasons.
+
+First, shared storage needed a stable identity of its own. A user or admin should think in terms of "the family photo share" or "the NAS library," not in terms of whichever workstation path or container mount happened to be used during setup. That led to the move toward first-class storage sources with watched folders defined relative to a source boundary.
+
+Second, temporary storage problems needed to be treated as normal operational events rather than as evidence of deletion. In a local-network deployment, shares go offline, mounts break, and permissions can change temporarily. If the product reacts to those conditions by implying user-driven deletion, it becomes untrustworthy very quickly. That led to the explicit distinction between unreachable storage, missing files, and confirmed deletion.
+
+These revisions improved the product design, not just the implementation:
+
+- they align configuration with how users actually think about shared libraries
+- they reduce false data loss signals
+- they make later UI messaging more honest
+- they preserve catalog usefulness even when the original storage is not currently reachable
+
+## Lessons Learned
+
+The main lesson from Phase 1 is that ingestion is not just a file-scanning problem. It is a trust problem.
+
+Users and stakeholders need the system to answer questions like:
+
+- Is this a real deletion or just a temporary outage?
+- Is this still the same photo after a reorganization?
+- Can the catalog remain useful even if the original source is offline?
+- Can an operator tell what the system did and why?
+
+The Phase 1 design evolved in response to those questions. The result is a stronger foundation for the next phases because browse, search, and labeling only become credible if the underlying catalog state is durable and understandable.
+
+## What Phase 1 Deliberately Did Not Solve
+
+To keep the milestone focused, Phase 1 did not try to finish the full end-user product experience.
+
+It does not yet represent:
+
+- the primary browse and inspect UI flow
+- the richer search and filtering experience
+- face labeling workflows
+- recognition suggestions
+- polished end-user messaging around all source-health states
+
+Those remain important follow-on phases. What Phase 1 provides is the reliable ingestion and cataloging behavior those later experiences depend on.
+
+## Summary
+
+Phase 1 established Photo Organizer as a credible ingestion backbone for a shared photo library.
+
+The product can now register shared sources, monitor watched folders, ingest metadata in the background, preserve identity through common file changes, and handle outages conservatively instead of destructively. Just as importantly, the team used Phase 1 to correct the design where the original model was too tied to implementation-era path assumptions.
+
+That gives the project a stronger and more realistic foundation for demoing the system today and for building the browse, search, and labeling experiences that follow.


### PR DESCRIPTION
## Summary
Add a stakeholder-facing Phase 1 milestone recap under `docs/`.

## What Changed
- added `docs/phase-1-milestone-recap.md`
- summarized what Phase 1 now makes possible from a user and demo perspective
- documented the key design revisions made during Phase 1, especially the shift to source-backed ingest and the decision to distinguish temporary storage outages from deletion

## Why
Phase 1 is complete and now needs a concise milestone document that explains the delivered foundation and the demo story without turning into an implementation changelog.

## Impact
This gives contributors and stakeholders a durable recap of the milestone, what can be demonstrated now, and why the design evolved during the phase.

## Validation
- reviewed the new document content locally for scope and tone

Related to #8