### PR TITLE
[codex] Implement photo listing endpoint

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
 from app.routers.ingest_queue import router as ingest_queue_router
+from app.routers.photos import router as photos_router
 from app.routers.storage_sources import router as storage_sources_router
 
 app = FastAPI(title="Photo Organizer API")
 
 app.include_router(ingest_queue_router, prefix="/api/v1")
+app.include_router(photos_router, prefix="/api/v1")
 app.include_router(storage_sources_router, prefix="/api/v1")
 
 # Simple health for E2E bring-up

--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql import Select
 
 from app.schemas.search_request import SearchFilters, SortSpec, PageSpec
-from app.core.enums import FilesizeRange
 from app.domain.facets import (
     TagsFacet,
     PeopleFacet,
@@ -31,7 +30,7 @@ class PhotosRepository:
         self.watched_folders: Table = Table("watched_folders", md, autoload_with=bind)
         self.storage_sources: Table = Table("storage_sources", md, autoload_with=bind)
 
-    def search_photos(self, filters: SearchFilters, sort: SortSpec, page: PageSpec, 
+    def search_photos(self, filters: SearchFilters, sort: SortSpec, page: PageSpec,
                      text_query: Optional[str] = None) -> Tuple[List[Dict[str, Any]], int, Optional[str]]:
         """
         Main search method that handles all query building and execution.
@@ -55,8 +54,18 @@ class PhotosRepository:
         
         # Generate next cursor
         next_cursor = self._generate_cursor(items, sort) if items else None
-        
+
         return items, total_count, next_cursor
+
+    def list_photos(self) -> List[Dict[str, Any]]:
+        """Return catalog photos in a deterministic browse order."""
+        query = select(self.photos).order_by(
+            self.photos.c.shot_ts.is_(None),
+            self.photos.c.shot_ts.desc(),
+            self.photos.c.photo_id.desc(),
+        )
+        rows = [row for row in self.db.execute(query).all() if row.deleted_ts is None]
+        return self._hydrate_items(rows)
 
     def get_filtered_photo_ids(self, filters: SearchFilters, text_query: Optional[str] = None) -> List[str]:
         """Get photo IDs for facet computation."""

--- a/apps/api/app/routers/photos.py
+++ b/apps/api/app/routers/photos.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_db
+from app.repositories.photos_repo import PhotosRepository
+from app.schemas.search_response import PhotoHit
+
+
+router = APIRouter(prefix="/photos", tags=["photos"])
+
+
+@router.get("", response_model=list[PhotoHit])
+def list_photos(db: Session = Depends(get_db)) -> list[PhotoHit]:
+    repo = PhotosRepository(db)
+    return [PhotoHit(**item) for item in repo.list_photos()]

--- a/apps/api/openapi/spec.yaml
+++ b/apps/api/openapi/spec.yaml
@@ -36,6 +36,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/photos:
+    get:
+      tags:
+      - photos
+      summary: List Photos
+      operationId: list_photos_api_v1_photos_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/PhotoHit'
+                type: array
+                title: Response List Photos Api V1 Photos Get
   /api/v1/storage-sources:
     get:
       tags:
@@ -251,6 +267,15 @@ components:
       - alias_path
       - watched_path
       title: CreateWatchedFolderRequest
+    FaceHit:
+      properties:
+        person_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Person Id
+      type: object
+      title: FaceHit
     HTTPValidationError:
       properties:
         detail:
@@ -300,6 +325,90 @@ components:
       - files_missing
       - error_count
       title: IngestRunSummaryResponse
+    OriginalAvailabilityHit:
+      properties:
+        is_available:
+          type: boolean
+          title: Is Available
+        availability_state:
+          type: string
+          title: Availability State
+        last_failure_reason:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Last Failure Reason
+      type: object
+      required:
+      - is_available
+      - availability_state
+      title: OriginalAvailabilityHit
+    PhotoHit:
+      properties:
+        photo_id:
+          type: string
+          title: Photo Id
+        path:
+          type: string
+          title: Path
+        ext:
+          type: string
+          title: Ext
+        camera_make:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Camera Make
+        orientation:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Orientation
+        shot_ts:
+          type: string
+          title: Shot Ts
+        filesize:
+          type: integer
+          title: Filesize
+        tags:
+          items:
+            type: string
+          type: array
+          title: Tags
+          default: []
+        people:
+          items:
+            type: string
+          type: array
+          title: People
+          default: []
+        faces:
+          items:
+            $ref: '#/components/schemas/FaceHit'
+          type: array
+          title: Faces
+          default: []
+        thumbnail:
+          anyOf:
+          - $ref: '#/components/schemas/ThumbnailHit'
+          - type: 'null'
+        original:
+          anyOf:
+          - $ref: '#/components/schemas/OriginalAvailabilityHit'
+          - type: 'null'
+        relevance:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Relevance
+      type: object
+      required:
+      - photo_id
+      - path
+      - ext
+      - shot_ts
+      - filesize
+      title: PhotoHit
     ProcessQueueRequest:
       properties:
         limit:
@@ -490,6 +599,27 @@ components:
       - catalog
       - recent_failures
       title: StorageSourceStatusResponse
+    ThumbnailHit:
+      properties:
+        mime_type:
+          type: string
+          title: Mime Type
+        width:
+          type: integer
+          title: Width
+        height:
+          type: integer
+          title: Height
+        data_base64:
+          type: string
+          title: Data Base64
+      type: object
+      required:
+      - mime_type
+      - width
+      - height
+      - data_base64
+      title: ThumbnailHit
     UpdateWatchedFolderRequest:
       properties:
         is_enabled:

--- a/apps/api/tests/test_photos_api.py
+++ b/apps/api/tests/test_photos_api.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import datetime
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, insert, update
+from sqlalchemy.orm import Session
+
+from app.dependencies import _get_session_factory, get_db
+from app.main import app
+from app.migrations import upgrade_database
+from app.storage import photos
+
+
+def test_photo_listing_api_returns_photos_in_deterministic_order(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'photos-api.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    same_ts = datetime(2026, 3, 28, 19, 30)
+    later_ts = datetime(2026, 3, 29, 9, 15)
+    deleted_ts = datetime(2026, 3, 29, 10, 0)
+
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos),
+            [
+                {
+                    "photo_id": "photo-b",
+                    "sha256": "b" * 64,
+                    "path": "/library/b.jpg",
+                    "shot_ts": same_ts,
+                    "created_ts": same_ts,
+                    "updated_ts": same_ts,
+                    "ext": "jpg",
+                    "filesize": 111,
+                },
+                {
+                    "photo_id": "photo-c",
+                    "sha256": "c" * 64,
+                    "path": "/library/c.jpg",
+                    "shot_ts": same_ts,
+                    "created_ts": same_ts,
+                    "updated_ts": same_ts,
+                    "ext": "jpg",
+                    "filesize": 222,
+                },
+                {
+                    "photo_id": "photo-a",
+                    "sha256": "a" * 64,
+                    "path": "/library/a.jpg",
+                    "shot_ts": later_ts,
+                    "created_ts": later_ts,
+                    "updated_ts": later_ts,
+                    "ext": "jpg",
+                    "filesize": 333,
+                },
+                {
+                    "photo_id": "photo-deleted",
+                    "sha256": "d" * 64,
+                    "path": "/library/deleted.jpg",
+                    "shot_ts": deleted_ts,
+                    "created_ts": deleted_ts,
+                    "updated_ts": deleted_ts,
+                    "ext": "jpg",
+                    "filesize": 444,
+                },
+            ],
+        )
+        connection.execute(
+            update(photos)
+            .where(photos.c.photo_id == "photo-deleted")
+            .values(deleted_ts=deleted_ts)
+        )
+
+    session_factory = _get_session_factory(database_url)
+
+    def override_get_db() -> Iterator[Session]:
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        client = TestClient(app)
+        response = client.get("/api/v1/photos")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert [row["photo_id"] for row in payload] == ["photo-a", "photo-c", "photo-b"]
+    assert all(row["photo_id"] != "photo-deleted" for row in payload)
+    assert [row["shot_ts"] for row in payload] == [
+        "2026-03-29T09:15:00Z",
+        "2026-03-28T19:30:00Z",
+        "2026-03-28T19:30:00Z",
+    ]


### PR DESCRIPTION
## Summary
- add `GET /api/v1/photos` for deterministic photo listing
- return browse-ready photo hits ordered by `shot_ts` descending with `photo_id` as a stable tie-breaker
- update the checked-in OpenAPI spec and add API coverage for the listing route

## Validation
- `.venv/bin/python -m pytest apps/api/tests/test_photos_api.py apps/api/tests/test_main.py -q`
- `.venv/bin/python -m ruff check apps/api/app/main.py apps/api/app/repositories/photos_repo.py apps/api/app/routers/photos.py apps/api/tests/test_photos_api.py`
- `git diff --check`

Closes #30