### PR TITLE
[codex] Expose browse ingestion status detail

### DIFF
--- a/apps/api/app/routers/storage_sources.py
+++ b/apps/api/app/routers/storage_sources.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
 from app.services.storage_source_status import (
+    get_storage_source_status,
     list_storage_source_statuses,
     list_watched_folder_statuses,
 )
@@ -129,6 +130,25 @@ def list_storage_sources(
 ) -> list[StorageSourceStatusResponse]:
     rows = list_storage_source_statuses(db.connection())
     return [StorageSourceStatusResponse.model_validate(row) for row in rows]
+
+
+@router.get(
+    "/{storage_source_id}",
+    response_model=StorageSourceStatusResponse,
+    responses={
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Storage source not found",
+        }
+    },
+)
+def get_storage_source(
+    storage_source_id: str,
+    db: Session = Depends(get_db),
+) -> StorageSourceStatusResponse:
+    row = get_storage_source_status(db.connection(), storage_source_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Storage source not found")
+    return StorageSourceStatusResponse.model_validate(row)
 
 
 @router.get("/{storage_source_id}/watched-folders", response_model=list[WatchedFolderResponse])

--- a/apps/api/app/services/storage_source_status.py
+++ b/apps/api/app/services/storage_source_status.py
@@ -28,31 +28,16 @@ def list_storage_source_statuses(connection: Connection) -> list[dict[str, Any]]
             select(storage_sources).order_by(storage_sources.c.created_ts, storage_sources.c.storage_source_id)
         ).mappings()
     )
-    statuses: list[dict[str, Any]] = []
-    for source in sources:
-        storage_source_id = str(source["storage_source_id"])
-        watched_folder_rows = list_watched_folder_statuses(connection, storage_source_id)
-        active_photo_count = _count_queryable_photos(connection, storage_source_id)
-        thumbnail_count = _count_photos_with_thumbnails(connection, storage_source_id)
-        latest_run = _load_latest_ingest_run_for_source(connection, storage_source_id)
-        statuses.append(
-            {
-                **dict(source),
-                "alias_paths": _list_alias_paths(connection, storage_source_id),
-                "watched_folder_count": len(watched_folder_rows),
-                "unreachable_watched_folder_count": sum(
-                    1 for row in watched_folder_rows if row["availability_state"] != "active"
-                ),
-                "catalog": {
-                    "metadata_queryable": active_photo_count > 0,
-                    "thumbnails_available": thumbnail_count > 0,
-                    "originals_available": source["availability_state"] == "active",
-                },
-                "latest_ingest_run": _serialize_ingest_run_summary(latest_run),
-                "recent_failures": _list_recent_failures(connection, storage_source_id),
-            }
-        )
-    return statuses
+    return [_build_storage_source_status(connection, source) for source in sources]
+
+
+def get_storage_source_status(connection: Connection, storage_source_id: str) -> dict[str, Any] | None:
+    source = connection.execute(
+        select(storage_sources).where(storage_sources.c.storage_source_id == storage_source_id)
+    ).mappings().first()
+    if source is None:
+        return None
+    return _build_storage_source_status(connection, source)
 
 
 def list_watched_folder_statuses(
@@ -75,6 +60,29 @@ def list_watched_folder_statuses(
         }
         for row in rows
     ]
+
+
+def _build_storage_source_status(connection: Connection, source: dict[str, Any]) -> dict[str, Any]:
+    storage_source_id = str(source["storage_source_id"])
+    watched_folder_rows = list_watched_folder_statuses(connection, storage_source_id)
+    active_photo_count = _count_queryable_photos(connection, storage_source_id)
+    thumbnail_count = _count_photos_with_thumbnails(connection, storage_source_id)
+    latest_run = _load_latest_ingest_run_for_source(connection, storage_source_id)
+    return {
+        **dict(source),
+        "alias_paths": _list_alias_paths(connection, storage_source_id),
+        "watched_folder_count": len(watched_folder_rows),
+        "unreachable_watched_folder_count": sum(
+            1 for row in watched_folder_rows if row["availability_state"] != "active"
+        ),
+        "catalog": {
+            "metadata_queryable": active_photo_count > 0,
+            "thumbnails_available": thumbnail_count > 0,
+            "originals_available": source["availability_state"] == "active",
+        },
+        "latest_ingest_run": _serialize_ingest_run_summary(latest_run),
+        "recent_failures": _list_recent_failures(connection, storage_source_id),
+    }
 
 
 def _list_alias_paths(connection: Connection, storage_source_id: str) -> list[str]:

--- a/apps/api/openapi/spec.yaml
+++ b/apps/api/openapi/spec.yaml
@@ -78,6 +78,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/storage-sources/{storage_source_id}:
+    get:
+      tags:
+      - storage-sources
+      summary: Get Storage Source
+      operationId: get_storage_source_api_v1_storage_sources__storage_source_id__get
+      parameters:
+      - name: storage_source_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Storage Source Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StorageSourceStatusResponse'
+        '404':
+          description: Storage source not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/storage-sources/{storage_source_id}/watched-folders:
     get:
       tags:

--- a/apps/api/tests/test_storage_source_api.py
+++ b/apps/api/tests/test_storage_source_api.py
@@ -4,7 +4,7 @@ import json
 from datetime import UTC, datetime
 
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, insert, select
+from sqlalchemy import create_engine, insert
 
 from app.dependencies import _get_session_factory
 from app.main import app
@@ -529,6 +529,107 @@ def test_storage_sources_api_lists_source_health_latest_runs_and_catalog_availab
             "completed_ts": "2026-03-29T14:00:00Z",
         }
     ]
+
+
+def test_storage_source_detail_api_includes_ingest_status_summary(tmp_path, monkeypatch):
+    from app.services.storage_sources import (
+        attach_storage_source_alias,
+        create_storage_source,
+        update_storage_source_availability,
+    )
+    from app.services.watched_folders import create_watched_folder
+
+    database_url = f"sqlite:///{tmp_path / 'storage-source-api-detail.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    root = tmp_path / "family-share"
+    watched_root = root / "2024" / "trips"
+    watched_root.mkdir(parents=True)
+    now = datetime(2026, 3, 29, 14, 0, tzinfo=UTC)
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Family Share",
+            marker_filename=".photo-org-source.json",
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=str(root),
+            now=now,
+        )
+        watched_folder = create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=str(root),
+            watched_path=str(watched_root),
+            display_name="Trips",
+            now=now,
+        )
+        update_storage_source_availability(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            availability_state="unreachable",
+            last_failure_reason="folder_unmounted",
+            now=now,
+        )
+        connection.execute(
+            insert(ingest_runs).values(
+                ingest_run_id="run-failed",
+                watched_folder_id=watched_folder["watched_folder_id"],
+                status="failed",
+                started_ts=now,
+                completed_ts=now,
+                files_seen=0,
+                files_created=0,
+                files_updated=0,
+                files_missing=0,
+                error_count=1,
+                error_summary="marker mismatch on alias //nas/family-share",
+            )
+        )
+
+    client = TestClient(app)
+
+    response = client.get(f"/api/v1/storage-sources/{source['storage_source_id']}")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["storage_source_id"] == source["storage_source_id"]
+    assert payload["availability_state"] == "unreachable"
+    assert payload["watched_folder_count"] == 1
+    assert payload["unreachable_watched_folder_count"] == 0
+    assert payload["catalog"]["metadata_queryable"] is False
+    assert payload["catalog"]["thumbnails_available"] is False
+    assert payload["catalog"]["originals_available"] is False
+    assert payload["latest_ingest_run"]["status"] == "failed"
+    assert payload["recent_failures"] == [
+        {
+            "watched_folder_id": watched_folder["watched_folder_id"],
+            "status": "failed",
+            "error_summary": "marker mismatch on alias //nas/family-share",
+            "completed_ts": "2026-03-29T14:00:00Z",
+        }
+    ]
+
+
+def test_storage_source_detail_api_returns_404_for_missing_source(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'storage-source-api-detail-missing.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    client = TestClient(app)
+
+    response = client.get("/api/v1/storage-sources/missing-source-id")
+
+    assert response.status_code == 404
 
 
 def test_storage_source_watched_folder_list_includes_latest_ingest_run_summary(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `GET /api/v1/storage-sources/{storage_source_id}` for browse/inspect-oriented ingestion status detail
- reuse the existing storage source status model and refactor the service to share source-status assembly
- update the checked-in OpenAPI spec and extend storage source API coverage

## Validation
- `.venv/bin/python -m pytest apps/api/tests/test_storage_source_api.py apps/api/tests/test_main.py -q`
- `.venv/bin/python -m ruff check apps/api/app/routers/storage_sources.py apps/api/app/services/storage_source_status.py apps/api/tests/test_storage_source_api.py`
- `git diff --check`

Closes #33