### PR TITLE
[codex] Expose face regions on photo detail payloads

### DIFF
--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -94,7 +94,7 @@ class PhotosRepository:
         if not rows:
             return None
 
-        item = self._hydrate_items(rows)[0]
+        item = self._hydrate_items(rows, include_face_regions=True)[0]
         row = rows[0]
         item["metadata"] = {
             "sha256": row.sha256,
@@ -267,7 +267,7 @@ class PhotosRepository:
         
         return encode_cursor(shot_ts_dt, last_item["photo_id"])
 
-    def _hydrate_items(self, rows: List[Row]) -> List[Dict[str, Any]]:
+    def _hydrate_items(self, rows: List[Row], *, include_face_regions: bool = False) -> List[Dict[str, Any]]:
         """Hydrate photo rows with related data (tags, people, faces)."""
         if not rows:
             return []
@@ -287,13 +287,34 @@ class PhotosRepository:
             tag_map[r.photo_id].append(r.tag)
 
         # Load faces and people
+        face_columns = [self.faces.c.photo_id, self.faces.c.person_id]
+        if include_face_regions:
+            face_columns.extend(
+                [
+                    self.faces.c.bbox_x,
+                    self.faces.c.bbox_y,
+                    self.faces.c.bbox_w,
+                    self.faces.c.bbox_h,
+                ]
+            )
+
         for r in self.db.execute(
-            select(self.faces.c.photo_id, self.faces.c.person_id)
+            select(*face_columns)
             .where(self.faces.c.photo_id.in_(pids))
         ).all():
             if r.person_id:
                 ppl_map[r.photo_id].append(r.person_id)
-            faces_map[r.photo_id].append({"person_id": r.person_id})
+            face_item = {"person_id": r.person_id}
+            if include_face_regions:
+                face_item.update(
+                    {
+                        "bbox_x": r.bbox_x,
+                        "bbox_y": r.bbox_y,
+                        "bbox_w": r.bbox_w,
+                        "bbox_h": r.bbox_h,
+                    }
+                )
+            faces_map[r.photo_id].append(face_item)
 
         original_map = self._load_original_availability(pids)
 

--- a/apps/api/app/schemas/photo_response.py
+++ b/apps/api/app/schemas/photo_response.py
@@ -4,7 +4,15 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
-from app.schemas.search_response import FaceHit, OriginalAvailabilityHit, ThumbnailHit
+from app.schemas.search_response import OriginalAvailabilityHit, ThumbnailHit
+
+
+class PhotoDetailFace(BaseModel):
+    person_id: str | None = None
+    bbox_x: int | None = None
+    bbox_y: int | None = None
+    bbox_w: int | None = None
+    bbox_h: int | None = None
 
 
 class PhotoMetadataProjection(BaseModel):
@@ -34,7 +42,7 @@ class PhotoDetailResponse(BaseModel):
     filesize: int
     tags: list[str] = []
     people: list[str] = []
-    faces: list[FaceHit] = []
+    faces: list[PhotoDetailFace] = []
     thumbnail: ThumbnailHit | None = None
     original: OriginalAvailabilityHit | None = None
     metadata: PhotoMetadataProjection

--- a/apps/api/openapi/spec.yaml
+++ b/apps/api/openapi/spec.yaml
@@ -399,6 +399,35 @@ components:
       - is_available
       - availability_state
       title: OriginalAvailabilityHit
+    PhotoDetailFace:
+      properties:
+        person_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Person Id
+        bbox_x:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Bbox X
+        bbox_y:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Bbox Y
+        bbox_w:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Bbox W
+        bbox_h:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Bbox H
+      type: object
+      title: PhotoDetailFace
     PhotoDetailResponse:
       properties:
         photo_id:
@@ -440,7 +469,7 @@ components:
           default: []
         faces:
           items:
-            $ref: '#/components/schemas/FaceHit'
+            $ref: '#/components/schemas/PhotoDetailFace'
           type: array
           title: Faces
           default: []

--- a/apps/api/tests/test_photo_detail_api.py
+++ b/apps/api/tests/test_photo_detail_api.py
@@ -67,7 +67,15 @@ def test_photo_detail_api_returns_projected_metadata_and_related_fields(tmp_path
     assert payload["shot_ts"] == "2026-03-28T19:30:00Z"
     assert payload["tags"] == ["vacation"]
     assert payload["people"] == ["person-1"]
-    assert payload["faces"] == [{"person_id": "person-1"}]
+    assert payload["faces"] == [
+        {
+            "person_id": "person-1",
+            "bbox_x": 10,
+            "bbox_y": 20,
+            "bbox_w": 30,
+            "bbox_h": 40,
+        }
+    ]
     assert payload["thumbnail"] is None
     assert payload["original"] is None
     assert payload["metadata"]["camera_model"] == "iPhone 15 Pro"


### PR DESCRIPTION
## Summary
- expose stored face bounding boxes on the photo detail payload only
- keep browse/list payloads on the existing face shape
- regenerate the checked-in OpenAPI contract for the updated detail response

## Why
The UI needs face-region coordinates when rendering an individual photo, and issue #32 scopes that requirement to the photo detail payload rather than the broader browse/search surface.

## Validation
- `uv run python -m pytest apps/api/tests/test_photo_detail_api.py apps/api/tests/test_photos_api.py -q`
- `uv run python -m pytest apps/api/tests/test_main.py -q`

Closes #32