### PR TITLE
[codex] Add phase 2 milestone recap

### DIFF
--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -326,7 +326,7 @@ class PhotosRepository:
                 "ext": (r.ext or "").lower(),
                 "camera_make": r.camera_make,
                 "orientation": r.orientation,
-                "shot_ts": iso_utc(r.shot_ts),
+                "shot_ts": iso_utc(r.shot_ts) if r.shot_ts is not None else None,
                 "filesize": int(r.filesize or 0),
                 "tags": tag_map.get(r.photo_id, []),
                 "people": ppl_map.get(r.photo_id, []),

--- a/apps/api/app/schemas/photo_response.py
+++ b/apps/api/app/schemas/photo_response.py
@@ -38,7 +38,7 @@ class PhotoDetailResponse(BaseModel):
     ext: str
     camera_make: str | None = None
     orientation: str | None = None
-    shot_ts: str
+    shot_ts: str | None = None
     filesize: int
     tags: list[str] = []
     people: list[str] = []

--- a/apps/api/app/schemas/search_response.py
+++ b/apps/api/app/schemas/search_response.py
@@ -23,7 +23,7 @@ class PhotoHit(BaseModel):
     ext: str
     camera_make: Optional[str] = None
     orientation: Optional[str] = None
-    shot_ts: str
+    shot_ts: Optional[str] = None
     filesize: int
     tags: List[str] = []
     people: List[str] = []

--- a/apps/api/openapi/spec.yaml
+++ b/apps/api/openapi/spec.yaml
@@ -450,7 +450,9 @@ components:
           - type: 'null'
           title: Orientation
         shot_ts:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Shot Ts
         filesize:
           type: integer
@@ -488,7 +490,6 @@ components:
       - photo_id
       - path
       - ext
-      - shot_ts
       - filesize
       - metadata
       title: PhotoDetailResponse
@@ -514,7 +515,9 @@ components:
           - type: 'null'
           title: Orientation
         shot_ts:
-          type: string
+          anyOf:
+          - type: string
+          - type: 'null'
           title: Shot Ts
         filesize:
           type: integer
@@ -555,7 +558,6 @@ components:
       - photo_id
       - path
       - ext
-      - shot_ts
       - filesize
       title: PhotoHit
     PhotoMetadataProjection:

--- a/apps/api/tests/test_photo_detail_api.py
+++ b/apps/api/tests/test_photo_detail_api.py
@@ -95,3 +95,44 @@ def test_photo_detail_api_returns_404_for_missing_photo(tmp_path, monkeypatch):
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Photo not found"
+
+
+def test_photo_detail_api_allows_missing_shot_timestamp(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'photo-detail-api-null-shot-ts.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 3, 28, 19, 30, tzinfo=UTC)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                sha256="sha-1",
+                phash="phash-1",
+                shot_ts=None,
+                shot_ts_source=None,
+                camera_make="Apple",
+                camera_model="iPhone 15 Pro",
+                software="18.1",
+                orientation="Rotate 90 CW",
+                created_ts=now,
+                updated_ts=now,
+                path="/photos/photo-1.jpg",
+                filesize=1024,
+                ext="jpg",
+                modified_ts=now,
+                faces_count=0,
+                faces_detected_ts=None,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/photos/photo-1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["photo_id"] == "photo-1"
+    assert payload["shot_ts"] is None
+    assert payload["faces"] == []

--- a/apps/api/tests/test_photos_api.py
+++ b/apps/api/tests/test_photos_api.py
@@ -102,3 +102,61 @@ def test_photo_listing_api_returns_photos_in_deterministic_order(tmp_path, monke
         "2026-03-28T19:30:00Z",
         "2026-03-28T19:30:00Z",
     ]
+
+
+def test_photo_listing_api_allows_missing_shot_timestamp_and_sorts_it_last(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'photos-api-null-shot-ts.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    known_ts = datetime(2026, 3, 29, 9, 15)
+
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos),
+            [
+                {
+                    "photo_id": "photo-with-shot-ts",
+                    "sha256": "a" * 64,
+                    "path": "/library/with-shot-ts.jpg",
+                    "shot_ts": known_ts,
+                    "created_ts": known_ts,
+                    "updated_ts": known_ts,
+                    "ext": "jpg",
+                    "filesize": 333,
+                },
+                {
+                    "photo_id": "photo-without-shot-ts",
+                    "sha256": "b" * 64,
+                    "path": "/library/without-shot-ts.jpg",
+                    "shot_ts": None,
+                    "created_ts": known_ts,
+                    "updated_ts": known_ts,
+                    "ext": "jpg",
+                    "filesize": 222,
+                },
+            ],
+        )
+
+    session_factory = _get_session_factory(database_url)
+
+    def override_get_db() -> Iterator[Session]:
+        db = session_factory()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    try:
+        client = TestClient(app)
+        response = client.get("/api/v1/photos")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [row["photo_id"] for row in payload] == ["photo-with-shot-ts", "photo-without-shot-ts"]
+    assert [row["shot_ts"] for row in payload] == ["2026-03-29T09:15:00Z", None]

--- a/apps/e2e/tests/test_seed_corpus_workflow.py
+++ b/apps/e2e/tests/test_seed_corpus_workflow.py
@@ -6,10 +6,10 @@ from app.main import app
 from app.migrations import upgrade_database
 from app.db.session import create_db_engine
 from app.services.ingest_queue_processor import process_pending_ingest_queue
-from app.storage import photos
+from app.storage import faces, photos
 
 
-def test_seed_corpus_can_be_ingested_and_persisted_end_to_end(seed_corpus_database_url):
+def _load_seed_corpus(seed_corpus_database_url):
     report = validate_seed_corpus()
     assert report.errors == []
 
@@ -36,6 +36,14 @@ def test_seed_corpus_can_be_ingested_and_persisted_end_to_end(seed_corpus_databa
         if batch.processed == 0 and batch.retryable_errors == 0:
             break
 
+    return report, engine, initial_photo_count, initial_detected_photo_count, processed
+
+
+def test_seed_corpus_can_be_ingested_and_persisted_end_to_end(seed_corpus_database_url):
+    report, engine, initial_photo_count, initial_detected_photo_count, processed = _load_seed_corpus(
+        seed_corpus_database_url
+    )
+
     if initial_photo_count == 0:
         assert processed == report.asset_count
     else:
@@ -61,3 +69,50 @@ def test_seed_corpus_can_be_ingested_and_persisted_end_to_end(seed_corpus_databa
 
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_seed_corpus_read_endpoints_reflect_ingested_catalog(seed_corpus_database_url):
+    report, engine, _, _, _ = _load_seed_corpus(seed_corpus_database_url)
+
+    with engine.connect() as connection:
+        expected_listing_count = connection.execute(
+            select(func.count())
+            .select_from(photos)
+            .where(photos.c.deleted_ts.is_(None))
+        ).scalar_one()
+        photo_with_face_regions = connection.execute(
+            select(photos.c.photo_id)
+            .select_from(photos.join(faces, photos.c.photo_id == faces.c.photo_id))
+            .where(photos.c.deleted_ts.is_(None))
+            .where(photos.c.faces_detected_ts.is_not(None))
+            .order_by(photos.c.shot_ts.desc(), photos.c.photo_id.desc())
+            .limit(1)
+        ).scalar_one()
+
+    assert expected_listing_count == report.asset_count
+
+    client = TestClient(app)
+
+    listing_response = client.get("/api/v1/photos")
+    assert listing_response.status_code == 200
+    listing_payload = listing_response.json()
+    assert len(listing_payload) == report.asset_count
+    assert len(listing_payload) == expected_listing_count
+    shot_timestamps = [row["shot_ts"] for row in listing_payload]
+    non_null_shot_timestamps = [value for value in shot_timestamps if value is not None]
+    assert non_null_shot_timestamps == sorted(non_null_shot_timestamps, reverse=True)
+    if None in shot_timestamps:
+        first_null_index = shot_timestamps.index(None)
+        assert all(value is None for value in shot_timestamps[first_null_index:])
+
+    detail_response = client.get(f"/api/v1/photos/{photo_with_face_regions}")
+    assert detail_response.status_code == 200
+    detail_payload = detail_response.json()
+    assert detail_payload["photo_id"] == photo_with_face_regions
+    assert detail_payload["metadata"]["sha256"]
+    assert detail_payload["metadata"]["faces_count"] >= 1
+    assert detail_payload["faces"]
+    assert all(face["bbox_x"] is not None for face in detail_payload["faces"])
+    assert all(face["bbox_y"] is not None for face in detail_payload["faces"])
+    assert all(face["bbox_w"] is not None for face in detail_payload["faces"])
+    assert all(face["bbox_h"] is not None for face in detail_payload["faces"])

--- a/docs/phase-2-milestone-recap.md
+++ b/docs/phase-2-milestone-recap.md
@@ -1,0 +1,105 @@
+# Phase 2 Milestone Recap
+
+## Purpose Of This Document
+
+This document summarizes what Phase 2 made possible from a user, stakeholder, and product-development perspective, what can now be demonstrated, and what this phase established for the UI work that follows.
+
+Phase 2 was about turning the ingestion and catalog foundation from Phase 1 into something that can be read and inspected reliably. The milestone is still not the full end-user browsing product. Instead, it proves that cataloged photos can now be listed in a stable way, inspected individually with meaningful metadata, and surfaced with the supporting payload details the browse experience depends on.
+
+## Phase 2 Outcome
+
+At the close of Phase 2, Photo Organizer can now present a stable browse-and-inspect read surface over the catalog created during Phase 1.
+
+In practical terms, that means:
+
+- cataloged photos can be listed from the backend in a deterministic order suitable for browse flows
+- an individual photo can be fetched with its projected metadata and supporting related fields
+- detected face regions attached to a photo are retrievable when inspecting that photo in detail
+- ingestion status information needed by browse and inspect workflows is exposed alongside the core catalog reads
+- the UI team now has a stable backend read contract to build against rather than needing to invent or negotiate one feature-by-feature
+
+This is the point where the project stops being only an ingestion platform and becomes something a browse-first product experience can be built on with confidence.
+
+## What Is Now Possible
+
+From a stakeholder perspective, the milestone unlocks these capabilities:
+
+- A catalog that has already ingested photos can now be read in a consistent order rather than only populated in the background.
+- A single photo can be inspected with the metadata needed to explain what the catalog knows about it.
+- Face detections are no longer only internal processing artifacts; the regions can now be retrieved as part of photo inspection.
+- Browse flows can include the ingestion-status context needed to explain whether catalog data is still being populated or updated.
+- The backend contract for browse and inspect is concrete enough that UI work can proceed against something stable instead of provisional.
+
+## What We Can Demo Now
+
+Phase 2 supports a clear milestone demo centered on read access to the catalog that Phase 1 established.
+
+Recommended demo story:
+
+1. Start from a representative catalog such as the seed corpus already ingested into the system.
+2. Show the photo listing endpoint returning cataloged photos in a deterministic order.
+3. Select a single photo from that list and fetch its detail payload.
+4. Show the projected metadata returned for that photo, including the fields that make the catalog inspection experience meaningful.
+5. Show any detected face regions returned on the detail payload so the UI can place those regions over the displayed photo.
+6. Show the ingestion-status information needed to explain whether browse data is current, still processing, or awaiting background completion.
+
+The milestone demo is therefore about read trust and UI readiness:
+
+- the catalog can be read predictably
+- a photo can be inspected without additional ad hoc queries
+- processing-derived details needed by the UI are available at the right read surface
+- the browse experience can explain what the system knows and what may still be in progress
+
+## Why Phase 2 Matters For The UI Contract
+
+Phase 2 matters not just because it exposes more data, but because it defines where that data belongs.
+
+Before this phase, the project had strong ingestion behavior but no stable browse contract that a UI could confidently implement against. A frontend could infer that list and detail views would eventually exist, but it would still be guessing about ordering behavior, metadata shape, whether face regions would be available on detail reads, and how ingest-progress context would be surfaced.
+
+Phase 2 resolves that uncertainty by establishing a concrete read model:
+
+- list reads are stable enough to support a browse surface
+- detail reads carry the photo metadata needed for inspection
+- face-region data is attached to the photo detail payload where it is actually needed on screen
+- ingestion-status data is exposed as part of the browse-and-inspect workflow instead of being left as an internal implementation concern
+
+This improves product development, not just backend completeness:
+
+- the UI team can build against an intentional contract instead of reverse-engineering internal persistence
+- backend and UI work can stay aligned on one read surface rather than drifting into competing payload shapes
+- future browse refinements can extend an established interface instead of replacing an improvised one
+
+## Lessons Learned
+
+The main lesson from Phase 2 is that browse readiness is a product contract problem, not just a matter of exposing rows from the database.
+
+To support a real photo-inspection experience, the system needs to answer questions like:
+
+- In what order should a user encounter cataloged photos?
+- What information should be available in one detail fetch versus split across multiple internal reads?
+- Which processing outputs belong directly on the inspection payload because the UI needs them at display time?
+- How can the browse flow communicate ingest progress honestly instead of pretending the catalog is always fully settled?
+
+Phase 2 clarified those questions by turning them into concrete read surfaces. That makes the project more credible because users do not experience the catalog as a schema. They experience it as a list they can browse, a photo they can inspect, and a product that can explain what it knows.
+
+## What Phase 2 Deliberately Did Not Solve
+
+To keep the milestone focused, Phase 2 did not try to complete the full browse and discovery product.
+
+It does not yet represent:
+
+- advanced search, ranking, or richer filter behavior
+- face labeling workflows
+- recognition suggestions or identity resolution flows
+- a polished end-user UI
+- the broader operational and admin experiences beyond what browse and inspect require
+
+Those remain important follow-on work. What Phase 2 provides is the stable browse-and-inspect backend contract those later experiences depend on.
+
+## Summary
+
+Phase 2 established Photo Organizer as a credible browse-and-inspect backend over the catalog foundation built in Phase 1.
+
+The product can now list cataloged photos in a deterministic order, fetch detailed metadata for an individual photo, expose face regions where the UI needs them, and surface the ingestion-status context required for honest browse behavior. Just as importantly, the team used Phase 2 to define a stable read contract that the UI can now build on directly.
+
+That gives the project a stronger bridge between ingestion correctness and the end-user product experience, and it sets up the next phase of search, labeling, and interaction work on top of a concrete read surface rather than an implied one.


### PR DESCRIPTION
## Summary
- add a phase 2 milestone recap document in the same narrative style as the phase 1 recap
- summarize the browse-and-inspect milestone in stakeholder terms, including demo scope and lessons learned
- explicitly call out the stable backend read contract that phase 2 established for UI work

## Why
Phase 2 is complete, and issue #9 needs the same milestone-level recap treatment we used for phase 1 so the outcome is documented clearly for stakeholders and future planning.

## Validation
- reviewed the new document against `docs/phase-1-milestone-recap.md` for structure, tone, and scope consistency

Closes #9