### PR TITLE
[codex] Add search validation fixtures

### DIFF
--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -171,6 +171,11 @@ class PhotosRepository:
                 self.faces.c.photo_id == self.photos.c.photo_id
             ).limit(1)
             where_conditions.append(faces_subquery.exists())
+        elif filters.has_faces is False:
+            faces_subquery = select(self.faces.c.photo_id).where(
+                self.faces.c.photo_id == self.photos.c.photo_id
+            ).limit(1)
+            where_conditions.append(~faces_subquery.exists())
         
         # People filter (OR logic within people)
         if filters.people:
@@ -263,6 +268,8 @@ class PhotosRepository:
         
         # Convert ISO string back to datetime for cursor encoding
         shot_ts_str = last_item["shot_ts"]
+        if shot_ts_str is None:
+            return None
         shot_ts_dt = datetime.fromisoformat(shot_ts_str.replace("Z", "+00:00"))
         
         return encode_cursor(shot_ts_dt, last_item["photo_id"])

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -6,9 +6,12 @@ the repository and facet computation services.
 """
 
 import base64
-import pytest
-from unittest.mock import Mock
+import json
 from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
 
 from sqlalchemy import create_engine, insert
 from sqlalchemy.orm import Session
@@ -19,7 +22,164 @@ from app.services.search_service import SearchService
 from app.schemas.search_request import SearchRequest, SearchFilters, SortSpec, PageSpec, DateFilter
 from app.schemas.search_response import SearchResponse, Hits, PhotoHit
 from app.core.enums import FilesizeRange
-from app.storage import photo_files, photos, storage_sources, watched_folders
+from app.storage import faces, photo_files, photo_tags, photos, storage_sources, watched_folders
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SEED_CORPUS_DIR = REPO_ROOT / "seed-corpus"
+SEED_CORPUS_MANIFEST_PATH = SEED_CORPUS_DIR / "manifest.json"
+SEARCH_FIXTURES_PATH = SEED_CORPUS_DIR / "search-fixtures.json"
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_seed_manifest() -> dict:
+    return _load_json(SEED_CORPUS_MANIFEST_PATH)
+
+
+def _load_search_fixtures() -> list[dict]:
+    data = _load_json(SEARCH_FIXTURES_PATH)
+    assert isinstance(data, dict)
+    fixtures = data["fixtures"]
+    assert isinstance(fixtures, list)
+    return fixtures
+
+
+def _fixture_scenarios_for_parametrize() -> list[dict]:
+    if not SEARCH_FIXTURES_PATH.exists():
+        return []
+    return _load_search_fixtures()
+
+
+def _asset_id_by_manifest_path() -> dict[str, str]:
+    return {
+        asset["path"]: asset["asset_id"]
+        for asset in _load_seed_manifest()["assets"]
+    }
+
+
+def _seed_search_fixture_catalog(connection) -> None:
+    manifest = _load_seed_manifest()
+    now = datetime(2026, 3, 29, tzinfo=UTC)
+
+    connection.execute(
+        insert(storage_sources).values(
+            storage_source_id="seed-source",
+            display_name="Seed Corpus",
+            marker_filename=".photo-org-source.json",
+            marker_version=1,
+            availability_state="active",
+            last_failure_reason=None,
+            last_validated_ts=now,
+            created_ts=now,
+            updated_ts=now,
+        )
+    )
+    connection.execute(
+        insert(watched_folders).values(
+            watched_folder_id="seed-watched-folder",
+            scan_path=str(SEED_CORPUS_DIR),
+            storage_source_id="seed-source",
+            relative_path=".",
+            display_name="Seed Corpus",
+            is_enabled=1,
+            availability_state="active",
+            last_failure_reason=None,
+            last_successful_scan_ts=now,
+            created_ts=now,
+            updated_ts=now,
+        )
+    )
+
+    photo_rows = []
+    photo_file_rows = []
+    face_rows = []
+    tag_rows = []
+
+    for index, asset in enumerate(manifest["assets"], start=1):
+        asset_id = asset["asset_id"]
+        expected = asset["expected"]
+        manifest_path = asset["path"]
+        relative_path = manifest_path.removeprefix("seed-corpus/")
+        shot_ts = expected.get("shot_ts")
+        parsed_shot_ts = datetime.fromisoformat(shot_ts) if shot_ts else None
+        photo_id = f"photo-{asset_id}"
+
+        photo_rows.append(
+            {
+                "photo_id": photo_id,
+                "path": manifest_path,
+                "sha256": f"{index:064x}",
+                "phash": None,
+                "filesize": expected["filesize_bytes"],
+                "ext": expected["format"],
+                "created_ts": now,
+                "modified_ts": now,
+                "shot_ts": parsed_shot_ts,
+                "shot_ts_source": "seed-manifest" if parsed_shot_ts else None,
+                "camera_make": expected.get("camera_make"),
+                "camera_model": expected.get("camera_model"),
+                "software": None,
+                "orientation": None,
+                "gps_latitude": None,
+                "gps_longitude": None,
+                "gps_altitude": None,
+                "updated_ts": now,
+                "deleted_ts": None,
+                "faces_count": 1 if expected["has_faces"] else 0,
+                "faces_detected_ts": now if expected["has_faces"] else None,
+            }
+        )
+        photo_file_rows.append(
+            {
+                "photo_file_id": f"photo-file-{asset_id}",
+                "photo_id": photo_id,
+                "watched_folder_id": "seed-watched-folder",
+                "relative_path": relative_path,
+                "filename": Path(relative_path).name,
+                "extension": expected["format"],
+                "filesize": expected["filesize_bytes"],
+                "created_ts": now,
+                "modified_ts": now,
+                "first_seen_ts": now,
+                "last_seen_ts": now,
+                "missing_ts": None,
+                "deleted_ts": None,
+                "lifecycle_state": "active",
+                "absence_reason": None,
+            }
+        )
+
+        if expected["has_faces"]:
+            face_rows.append(
+                {
+                    "face_id": f"face-{asset_id}",
+                    "photo_id": photo_id,
+                    "person_id": None,
+                    "bbox_x": 0,
+                    "bbox_y": 0,
+                    "bbox_w": 10,
+                    "bbox_h": 10,
+                    "bitmap": None,
+                    "embedding": None,
+                    "detector_name": "seed-fixture",
+                    "detector_version": "1",
+                    "provenance": None,
+                    "created_ts": now,
+                }
+            )
+
+        for tag in asset.get("scenario_tags", []):
+            tag_rows.append({"photo_id": photo_id, "tag": tag})
+
+    connection.execute(insert(photos), photo_rows)
+    connection.execute(insert(photo_files), photo_file_rows)
+    if face_rows:
+        connection.execute(insert(faces), face_rows)
+    if tag_rows:
+        connection.execute(insert(photo_tags), tag_rows)
 
 
 class TestSearchServiceExecution:
@@ -620,6 +780,54 @@ class TestPhotosRepositoryOfflineBrowseIntegration:
         assert hit.original.is_available is False
         assert hit.original.availability_state == "unreachable"
         assert hit.original.last_failure_reason == "permission_denied"
+
+
+class TestSeedCorpusSearchFixtureCatalog:
+    def test_fixture_catalog_references_known_manifest_assets(self):
+        manifest_asset_ids = {
+            asset["asset_id"]
+            for asset in _load_seed_manifest()["assets"]
+        }
+
+        fixtures = _load_search_fixtures()
+
+        assert fixtures
+        for fixture in fixtures:
+            assert fixture["scenario_id"]
+            assert fixture["description"]
+            assert fixture["phase_scope"] == "phase_3"
+            SearchRequest.model_validate(fixture["request"])
+            assert fixture["expected_asset_ids"]
+            assert set(fixture["expected_asset_ids"]).issubset(manifest_asset_ids)
+
+
+class TestSeedCorpusSearchFixtureExecution:
+    @pytest.mark.parametrize(
+        "fixture",
+        _fixture_scenarios_for_parametrize(),
+        ids=lambda fixture: fixture["scenario_id"],
+    )
+    def test_search_fixture_execution_matches_expected_asset_ids(self, tmp_path, fixture):
+        database_url = f"sqlite:///{tmp_path / 'search-fixtures.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+
+        with engine.begin() as connection:
+            _seed_search_fixture_catalog(connection)
+
+        request = SearchRequest.model_validate(fixture["request"])
+        expected_asset_ids = fixture["expected_asset_ids"]
+        asset_by_path = _asset_id_by_manifest_path()
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            service = SearchService(repo=repo)
+            response = service.execute(request)
+
+        returned_asset_ids = [asset_by_path[item.path] for item in response.hits.items]
+
+        assert set(returned_asset_ids) == set(expected_asset_ids)
+        assert response.hits.total == len(expected_asset_ids)
 
     def test_search_repository_excludes_missing_file_rows_from_original_availability(self, tmp_path):
         database_url = f"sqlite:///{tmp_path / 'search-missing-original-availability.db'}"

--- a/docs/superpowers/plans/2026-03-29-issue-40-search-validation-fixtures.md
+++ b/docs/superpowers/plans/2026-03-29-issue-40-search-validation-fixtures.md
@@ -1,0 +1,49 @@
+# Issue 40 Search Validation Fixtures Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a seed-corpus-backed search fixture catalog and automated validation tests that assert representative supported search scenarios by manifest asset ID.
+
+**Architecture:** Keep fixture data under `seed-corpus/` beside the manifest, then add a test harness that reads the manifest and fixture catalog, prepares searchable records for the checked-in corpus, maps search results back to manifest asset IDs, and asserts supported scenarios end to end at the search layer.
+
+**Tech Stack:** Python, JSON, pytest, SQLAlchemy, uv
+
+---
+
+### Task 1: Inspect the current search and seed-corpus contracts
+
+**Files:**
+- Modify: `apps/api/tests/test_search_service.py`
+- Create: `seed-corpus/search-fixtures.json`
+
+- [ ] **Step 1: Identify which approved Phase 3 scenarios are executable with the current search request schema and checked-in seed corpus**
+- [ ] **Step 2: Write the initial failing structural test that expects a checked-in fixture catalog and validates that every expected asset ID exists in `seed-corpus/manifest.json`**
+- [ ] **Step 3: Run `uv run python -m pytest apps/api/tests/test_search_service.py -k fixture_catalog -q` and verify it fails**
+
+### Task 2: Add the seed-corpus fixture catalog
+
+**Files:**
+- Create: `seed-corpus/search-fixtures.json`
+- Modify: `seed-corpus/README.md` if fixture usage needs documentation
+
+- [ ] **Step 1: Add the minimal fixture catalog for currently supported scenarios using manifest asset IDs and current search request payloads**
+- [ ] **Step 2: Re-run `uv run python -m pytest apps/api/tests/test_search_service.py -k fixture_catalog -q` and verify it passes**
+
+### Task 3: Execute fixtures against the search stack
+
+**Files:**
+- Modify: `apps/api/tests/test_search_service.py`
+- Modify: `apps/api/app/services/search_service.py` only if fixture execution exposes a search-service contract gap
+
+- [ ] **Step 1: Write the failing execution test that loads the manifest and fixture catalog, prepares searchable records for the checked-in corpus, and asserts fixture expectations by manifest asset ID**
+- [ ] **Step 2: Run `uv run python -m pytest apps/api/tests/test_search_service.py -k search_fixture_execution -q` and verify it fails**
+- [ ] **Step 3: Add the minimal test harness or production-code changes needed to execute fixture-backed assertions cleanly**
+- [ ] **Step 4: Re-run `uv run python -m pytest apps/api/tests/test_search_service.py -k search_fixture_execution -q` and verify it passes**
+
+### Task 4: Verify the touched slice
+
+**Files:**
+- Modify: `seed-corpus/README.md` if local validation workflow needs explanation
+
+- [ ] **Step 1: Run `uv run python -m pytest apps/api/tests/test_search_service.py -q` and verify the search test module passes**
+- [ ] **Step 2: Run `uv run python -m pytest -q` if the focused slice stays clean enough to justify the broader check**

--- a/docs/superpowers/specs/2026-03-29-issue-40-search-validation-fixtures-design.md
+++ b/docs/superpowers/specs/2026-03-29-issue-40-search-validation-fixtures-design.md
@@ -1,0 +1,62 @@
+# Issue 40 Search Validation Fixtures Design
+
+## Summary
+
+Issue `#40` should define executable search validation fixtures for the checked-in seed corpus rather than expanding the seed corpus itself. The seed corpus remains the base dataset, while this issue adds the assertion layer that records which supported Phase 3 search requests should return which manifest-backed assets.
+
+## Goals
+
+- Define a checked-in search fixture catalog rooted in the existing `seed-corpus/` data.
+- Use manifest asset IDs as the expected-result contract for search validation.
+- Keep registered storage source concerns in deterministic test setup rather than in fixture data.
+- Add automated tests that validate fixture integrity and execute supported scenarios against seed-corpus-backed search data.
+
+## Non-Goals
+
+- Add new seed-corpus photos to satisfy currently unsupported scenarios.
+- Finalize the full canonical Phase 3 search DSL beyond the currently implemented request schema.
+- Model persistent storage-source identities in the fixture file itself.
+
+## Design Decisions
+
+### Keep the fixture catalog close to the corpus
+
+The fixture catalog should live under `seed-corpus/` beside `manifest.json`, not inside test-only Python modules. This keeps the executable assertions physically close to the curated dataset they depend on and makes corpus changes and fixture changes reviewable together.
+
+### Use manifest asset IDs as the result contract
+
+Expected matches should be recorded using manifest asset IDs instead of filesystem paths. That makes the fixtures resilient to path-shape refactors inside the application while staying aligned with the curated seed-corpus metadata contract.
+
+### Treat registered storage sources as harness setup
+
+The seed corpus does not intrinsically model a registered storage source. Tests should work around that by registering a temporary storage source rooted at the local `seed-corpus/` directory during setup. The harness can then ingest or seed search data, map searchable photo records back to manifest entries through source-relative paths, and compare the resulting manifest asset IDs to fixture expectations.
+
+## Fixture File Shape
+
+Add a new file such as `seed-corpus/search-fixtures.json` containing scenario entries with fields like:
+
+- `scenario_id`: stable fixture identifier
+- `description`: human-readable scenario summary
+- `phase_scope`: expected scope classification, limited to executable scenarios in this issue
+- `request`: search request payload using the current search API schema
+- `expected_asset_ids`: manifest asset IDs expected in the result set
+- `notes`: optional fixture-specific assumptions
+
+The fixture catalog should only include scenarios the current seed corpus can already validate. Data-blocked scenarios remain in the scenario catalog and should be covered by a separate follow-up issue for corpus expansion.
+
+## Test Strategy
+
+Add two layers of automated verification:
+
+1. A structural test that loads `manifest.json` and `search-fixtures.json` and fails if a fixture references unknown asset IDs or malformed request data.
+2. An execution test that registers a temporary source rooted at `seed-corpus/`, prepares searchable records, runs each fixture request through the search stack, maps returned photos back to manifest asset IDs, and asserts the expected result set.
+
+## Error Handling
+
+- Fail fast if fixture entries reference asset IDs absent from `manifest.json`.
+- Fail fast if an ingested or seeded search result cannot be mapped back to a manifest asset ID.
+- Do not silently skip unsupported scenarios; they should simply not appear in `search-fixtures.json`.
+
+## Follow-Up Boundary
+
+Create a separate issue for seed-corpus additions required to cover scenarios that the current corpus cannot validate, including person-linked, geotagged, multi-person, and unlabeled-face cases identified by the Phase 3 scenario catalog.

--- a/seed-corpus/search-fixtures.json
+++ b/seed-corpus/search-fixtures.json
@@ -1,0 +1,152 @@
+{
+  "version": 1,
+  "fixtures": [
+    {
+      "scenario_id": "SF01",
+      "description": "text search for lake photos matches the full lake-weekend subset",
+      "phase_scope": "phase_3",
+      "request": {
+        "q": "lake",
+        "filters": {},
+        "sort": {
+          "by": "shot_ts",
+          "dir": "desc"
+        },
+        "page": {
+          "limit": 50
+        }
+      },
+      "expected_asset_ids": [
+        "lake_weekend_001",
+        "lake_weekend_002",
+        "lake_weekend_003",
+        "lake_weekend_004",
+        "lake_weekend_005",
+        "lake_weekend_006"
+      ]
+    },
+    {
+      "scenario_id": "SF02",
+      "description": "camera make filter for Canon photos returns all Canon-tagged seed assets",
+      "phase_scope": "phase_3",
+      "request": {
+        "filters": {
+          "camera_make": [
+            "Canon"
+          ]
+        },
+        "sort": {
+          "by": "shot_ts",
+          "dir": "desc"
+        },
+        "page": {
+          "limit": 50
+        }
+      },
+      "expected_asset_ids": [
+        "birthday_park_001",
+        "birthday_park_002",
+        "lake_weekend_005",
+        "city_break_005",
+        "reference_face_001",
+        "reference_face_002",
+        "reference_face_003",
+        "reference_face_004"
+      ]
+    },
+    {
+      "scenario_id": "SF03",
+      "description": "date range filter for July 2022 returns only dated July assets",
+      "phase_scope": "phase_3",
+      "request": {
+        "filters": {
+          "date": {
+            "from": "2022-07-01",
+            "to": "2022-07-31"
+          }
+        },
+        "sort": {
+          "by": "shot_ts",
+          "dir": "desc"
+        },
+        "page": {
+          "limit": 50
+        }
+      },
+      "expected_asset_ids": [
+        "lake_weekend_001",
+        "lake_weekend_004",
+        "lake_weekend_005"
+      ]
+    },
+    {
+      "scenario_id": "SF04",
+      "description": "extension and path query combine with AND semantics for city-break jpeg photos",
+      "phase_scope": "phase_3",
+      "request": {
+        "q": "city-break",
+        "filters": {
+          "extension": [
+            "jpeg"
+          ]
+        },
+        "sort": {
+          "by": "shot_ts",
+          "dir": "desc"
+        },
+        "page": {
+          "limit": 50
+        }
+      },
+      "expected_asset_ids": [
+        "city_break_005"
+      ]
+    },
+    {
+      "scenario_id": "SF05",
+      "description": "birthday text search plus has_faces=true keeps only face-bearing birthday assets",
+      "phase_scope": "phase_3",
+      "request": {
+        "q": "birthday",
+        "filters": {
+          "has_faces": true
+        },
+        "sort": {
+          "by": "shot_ts",
+          "dir": "desc"
+        },
+        "page": {
+          "limit": 50
+        }
+      },
+      "expected_asset_ids": [
+        "birthday_park_001",
+        "birthday_park_002",
+        "birthday_park_003",
+        "birthday_park_005"
+      ]
+    },
+    {
+      "scenario_id": "SF06",
+      "description": "birthday text search plus has_faces=false keeps only no-face birthday assets",
+      "phase_scope": "phase_3",
+      "request": {
+        "q": "birthday",
+        "filters": {
+          "has_faces": false
+        },
+        "sort": {
+          "by": "shot_ts",
+          "dir": "desc"
+        },
+        "page": {
+          "limit": 50
+        }
+      },
+      "expected_asset_ids": [
+        "birthday_park_004",
+        "birthday_park_006"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a seed-corpus-backed `search-fixtures.json` contract keyed by manifest asset IDs
- add structural and execution tests that validate representative Phase 3 search scenarios against the checked-in corpus
- fix `has_faces=false` filtering and guard cursor generation when paginated results end on photos without `shot_ts`

## Why
Issue #40 was narrowed to fixture derivation and validation against the current seed corpus, while corpus expansion for unsupported scenarios will live in a separate follow-up issue.

Closes #40

## Validation
- `uv run python -m pytest apps/api/tests/test_search_service.py -q`
- `uv run python -m pytest -q`