### PR TITLE
[codex] Add facet-style search filters

### DIFF
--- a/apps/api/app/domain/facets.py
+++ b/apps/api/app/domain/facets.py
@@ -257,6 +257,51 @@ class DuplicatesFacet(Facet):
         return False
 
 
+class HasFacesFacet(Facet):
+    """Facet for face-bearing versus no-face photos."""
+
+    def __init__(self):
+        super().__init__("has_faces", FacetType.SIMPLE_COUNT)
+
+    def compute(self, filtered_photo_ids: List[str], context: 'FacetContext') -> FacetResult:
+        if not filtered_photo_ids:
+            return FacetResult(
+                facet_name=self.name,
+                facet_type=self.facet_type,
+                values=[],
+                total_count=0,
+            )
+
+        from sqlalchemy import case, select, func
+
+        has_faces_case = case(
+            (context.photos.c.faces_count > 0, "true"),
+            else_="false",
+        )
+        query = (
+            select(
+                has_faces_case.label("has_faces"),
+                func.count().label("count"),
+            )
+            .where(context.photos.c.photo_id.in_(filtered_photo_ids))
+            .group_by(has_faces_case)
+        )
+        rows = context.db.execute(query).all()
+
+        values = [FacetValue(value=value, count=int(count)) for value, count in rows]
+        values.sort(key=lambda v: v.value)
+
+        return FacetResult(
+            facet_name=self.name,
+            facet_type=self.facet_type,
+            values=values,
+            total_count=sum(v.count for v in values),
+        )
+
+    def supports_drill_sideways(self) -> bool:
+        return True
+
+
 @dataclass
 class FacetContext:
     """Context object providing dependencies for facet computation."""

--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -9,6 +9,7 @@ from app.schemas.search_request import SearchFilters, SortSpec, PageSpec
 from app.domain.facets import (
     TagsFacet,
     PeopleFacet,
+    HasFacesFacet,
     DateHierarchyFacet,
     DuplicatesFacet,
     FacetContext,
@@ -157,6 +158,10 @@ class PhotosRepository:
             where_conditions.append(self.photos.c.camera_make.in_(filters.camera_make))
         if filters.extension:
             where_conditions.append(self.photos.c.ext.in_(filters.extension))
+        if filters.path_hints:
+            where_conditions.append(
+                or_(*[self.photos.c.path.ilike(f"%{hint}%") for hint in filters.path_hints])
+            )
         if filters.orientation:
             where_conditions.append(self.photos.c.orientation.in_(filters.orientation))
         
@@ -429,17 +434,20 @@ class PhotosRepository:
         
         tags_facet = TagsFacet()
         people_facet = PeopleFacet()
+        has_faces_facet = HasFacesFacet()
         date_facet = DateHierarchyFacet()
         duplicates_facet = DuplicatesFacet()
         
         date_result = date_facet.compute(filtered_photo_ids, context)
         tags_result = tags_facet.compute(filtered_photo_ids, context)
         people_result = people_facet.compute(filtered_photo_ids, context)
+        has_faces_result = has_faces_facet.compute(filtered_photo_ids, context)
         duplicates_result = duplicates_facet.compute(filtered_photo_ids, context)
         
         return {
             "date": self._format_date_facet(date_result),
             "people": self._format_simple_facet(people_result),
+            "has_faces": self._format_boolean_facet(has_faces_result),
             "tags": self._format_simple_facet(tags_result),
             "duplicates": self._format_duplicates_facet(duplicates_result),
         }
@@ -482,4 +490,11 @@ class PhotosRepository:
         return {
             "exact": int(metadata.get("exact", 0) or 0),
             "near": int(metadata.get("near", 0) or 0),
+        }
+
+    @staticmethod
+    def _format_boolean_facet(result: FacetResult) -> Dict[str, int]:
+        return {
+            str(value.value): int(value.count)
+            for value in (result.values or [])
         }

--- a/apps/api/app/schemas/search_request.py
+++ b/apps/api/app/schemas/search_request.py
@@ -19,6 +19,7 @@ class SearchFilters(BaseModel):
     date: Optional[DateFilter] = None
     camera_make: Optional[List[str]] = None
     extension: Optional[List[str]] = None
+    path_hints: Optional[List[str]] = None
     orientation: Optional[List[str]] = None
     filesize_range: Optional[FilesizeRange] = None
     has_faces: Optional[bool] = None

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -308,6 +308,33 @@ class TestSearchServiceExecution:
         )
         mock_repo.get_filtered_photo_ids.assert_called_once_with(request.filters, "hawaii beach")
 
+    def test_given_path_hints_when_executing_search_then_passes_path_hints_to_repository(self):
+        """Given path hints, when executing search, then passes them through in typed filters."""
+        mock_repo = Mock()
+        service = SearchService(repo=mock_repo)
+
+        mock_repo.search_photos.return_value = ([], 0, None)
+        mock_repo.get_filtered_photo_ids.return_value = []
+        mock_repo.compute_facets.return_value = {}
+
+        filters = SearchFilters(path_hints=["lake-weekend", "travel"])
+        assert filters.model_dump().get("path_hints") == ["lake-weekend", "travel"]
+        request = SearchRequest(
+            filters=filters,
+            sort=SortSpec(by="shot_ts", dir="desc"),
+            page=PageSpec(limit=50),
+        )
+
+        service.execute(request)
+
+        mock_repo.search_photos.assert_called_once_with(
+            filters=filters,
+            sort=request.sort,
+            page=request.page,
+            text_query=None,
+        )
+        mock_repo.get_filtered_photo_ids.assert_called_once_with(filters, None)
+
     def test_given_empty_results_when_executing_search_then_returns_empty_response_with_facets(self):
         """Given empty results, when executing search, then returns empty response with facets."""
         # Given
@@ -671,6 +698,163 @@ class TestPhotosRepositorySoftDeleteFiltering:
 
         assert photo_ids == ["active-photo"]
 
+    def test_search_repository_filters_by_path_hints(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-path-hints.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 3, 30, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "lake-photo",
+                        "path": "seed-corpus/family-events/lake-weekend/lake_weekend_001.jpg",
+                        "sha256": "e" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "travel-photo",
+                        "path": "seed-corpus/travel/city-break/city_break_001.jpg",
+                        "sha256": "f" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(path_hints=["lake-weekend"]),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["lake-photo"]
+        assert total == 1
+
+    def test_search_repository_combines_path_hints_with_has_faces_false(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-path-hints-no-faces.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 3, 30, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "birthday-no-faces",
+                        "path": "seed-corpus/family-events/birthday-park/birthday_park_004.png",
+                        "sha256": "1" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "png",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "birthday-with-face",
+                        "path": "seed-corpus/family-events/birthday-park/birthday_park_001.jpg",
+                        "sha256": "2" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(faces).values(
+                    face_id="face-birthday-with-face",
+                    photo_id="birthday-with-face",
+                    person_id=None,
+                    bbox_x=0,
+                    bbox_y=0,
+                    bbox_w=10,
+                    bbox_h=10,
+                    bitmap=None,
+                    embedding=None,
+                    detector_name="seed",
+                    detector_version="1",
+                    provenance=None,
+                    created_ts=now,
+                )
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(path_hints=["birthday-park"], has_faces=False),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["birthday-no-faces"]
+        assert total == 1
+
 
 class TestPhotosRepositoryOfflineBrowseIntegration:
     def test_search_repository_exposes_thumbnail_and_original_availability(self, tmp_path):
@@ -780,6 +964,90 @@ class TestPhotosRepositoryOfflineBrowseIntegration:
         assert hit.original.is_available is False
         assert hit.original.availability_state == "unreachable"
         assert hit.original.last_failure_reason == "permission_denied"
+
+
+class TestPhotosRepositoryHasFacesFacet:
+    def test_compute_facets_includes_has_faces_facet_breakdown(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-has-faces-facet.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 3, 30, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "face-photo",
+                        "path": "seed-corpus/family-events/lake-weekend/lake_weekend_003.png",
+                        "sha256": "3" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "png",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                    {
+                        "photo_id": "no-face-photo",
+                        "path": "seed-corpus/family-events/lake-weekend/lake_weekend_001.jpg",
+                        "sha256": "4" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(faces).values(
+                    face_id="face-photo-face",
+                    photo_id="face-photo",
+                    person_id=None,
+                    bbox_x=0,
+                    bbox_y=0,
+                    bbox_w=10,
+                    bbox_h=10,
+                    bitmap=None,
+                    embedding=None,
+                    detector_name="seed",
+                    detector_version="1",
+                    provenance=None,
+                    created_ts=now,
+                )
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            facets = repo.compute_facets(["face-photo", "no-face-photo"])
+
+        assert facets["has_faces"] == {"true": 1, "false": 1}
 
 
 class TestSeedCorpusSearchFixtureCatalog:

--- a/docs/superpowers/plans/2026-03-30-issue-38-facet-filters.md
+++ b/docs/superpowers/plans/2026-03-30-issue-38-facet-filters.md
@@ -1,0 +1,54 @@
+# Issue 38 Facet Filters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add path-hint filtering and `has_faces` facet breakdown support to the current Phase 3 search stack.
+
+**Architecture:** Extend the typed search request schema with `path_hints`, lock the behavior with failing repository and service tests, then implement minimal query and facet changes inside the existing search repository. Keep the change local to the current search slice so later text-search and date-range work can build on it.
+
+**Tech Stack:** Python, SQLAlchemy, Pydantic, pytest, uv
+
+---
+
+### Task 1: Lock the request and filter semantics in tests
+
+**Files:**
+- Modify: `apps/api/tests/test_search_service.py`
+- Modify: `apps/api/app/schemas/search_request.py`
+
+- [ ] **Step 1: Write a failing test that validates `SearchFilters` accepts `path_hints` and passes it through to repository calls**
+- [ ] **Step 2: Run `uv run python -m pytest apps/api/tests/test_search_service.py -k path_hints -q` and verify it fails**
+- [ ] **Step 3: Add the minimal `path_hints` field to `SearchFilters`**
+- [ ] **Step 4: Re-run `uv run python -m pytest apps/api/tests/test_search_service.py -k path_hints -q` and verify it passes**
+
+### Task 2: Implement repository filtering for path hints and boolean face filters
+
+**Files:**
+- Modify: `apps/api/tests/test_search_service.py`
+- Modify: `apps/api/app/repositories/photos_repo.py`
+
+- [ ] **Step 1: Write failing repository tests for `path_hints` filtering and for combining `path_hints` with `has_faces=false`**
+- [ ] **Step 2: Run `uv run python -m pytest apps/api/tests/test_search_service.py -k \"path_hints or has_faces\" -q` and verify the new cases fail for the expected reason**
+- [ ] **Step 3: Implement minimal query changes in `PhotosRepository._apply_filters` so `path_hints` uses `ANY` semantics within the field and composes with existing filters using `AND`**
+- [ ] **Step 4: Re-run `uv run python -m pytest apps/api/tests/test_search_service.py -k \"path_hints or has_faces\" -q` and verify the focused slice passes**
+
+### Task 3: Add `has_faces` facet output
+
+**Files:**
+- Modify: `apps/api/tests/test_search_service.py`
+- Modify: `apps/api/app/domain/facets.py`
+- Modify: `apps/api/app/repositories/photos_repo.py`
+
+- [ ] **Step 1: Write a failing test that expects `compute_facets` to return a `has_faces` breakdown over the filtered photo set**
+- [ ] **Step 2: Run `uv run python -m pytest apps/api/tests/test_search_service.py -k has_faces_facet -q` and verify it fails**
+- [ ] **Step 3: Add the minimal facet implementation and response formatting needed to produce the `has_faces` counts**
+- [ ] **Step 4: Re-run `uv run python -m pytest apps/api/tests/test_search_service.py -k has_faces_facet -q` and verify it passes**
+
+### Task 4: Verify the search slice and seed-corpus contract
+
+**Files:**
+- Modify: `seed-corpus/search-fixtures.json` only if a new supported fixture is needed
+
+- [ ] **Step 1: Add or update a seed-corpus-backed fixture for a path-hint search if the current catalog does not already cover the new typed filter contract**
+- [ ] **Step 2: Run `uv run python -m pytest apps/api/tests/test_search_service.py -q` and verify the full search test module passes**
+- [ ] **Step 3: Run `uv run python -m pytest -q` if the focused slice remains clean enough to justify the broader verification**

--- a/docs/superpowers/specs/2026-03-30-issue-38-facet-filters-design.md
+++ b/docs/superpowers/specs/2026-03-30-issue-38-facet-filters-design.md
@@ -1,0 +1,87 @@
+# Issue 38 Facet Filters Design
+
+## Summary
+
+Issue `#38` should add the first explicit facet-style search filter slice to the current Phase 3 search implementation. The scope should stay narrow: support path-hint filtering and boolean face-presence filtering in the request contract, and expose a `has_faces` facet breakdown over the filtered result set.
+
+## Goals
+
+- Add a request-level filter for path-derived hints without reopening the full text-search design.
+- Preserve and tighten `has_faces` filtering semantics for both `true` and `false`.
+- Expose a `has_faces` facet result so callers can inspect the filtered set's face-bearing versus no-face breakdown.
+- Keep the change aligned with the current search service and repository architecture.
+
+## Non-Goals
+
+- Redesign the full search DSL or transport contract.
+- Add people or geo facet families beyond what already exists.
+- Introduce separate indexing infrastructure for path hints.
+- Expand the seed corpus.
+
+## Design Decisions
+
+### Path hints are explicit filters, not free-text fallback
+
+The Phase 3 scenario catalog distinguishes text search from typed filters. For `#38`, path hints should be modeled as an explicit `SearchFilters.path_hints` field rather than folded into `q`. This keeps path-derived filtering composable with text search and other typed filters.
+
+### Path hints derive from the existing canonical photo path
+
+The implementation should derive path-hint matching from `photos.path`, using substring matching over normalized hint tokens. This is sufficient for the current seed-corpus-backed Phase 3 slice and avoids introducing a separate stored hint table.
+
+### `has_faces` remains a boolean filter and becomes a boolean facet
+
+`has_faces` already exists as a filter field and now supports `true` and `false`. `#38` should extend the facet output so clients can ask "within this filtered set, how many photos have faces and how many do not?" The facet should be returned alongside the existing `date`, `people`, `tags`, and `duplicates` facets.
+
+## Expected Request Contract
+
+Within the current schema, add:
+
+- `filters.path_hints: list[str] | null`
+
+Meaning:
+
+- values combine with `ANY` semantics within the field
+- path-hint filtering combines with all other filter families using `AND`
+
+Example:
+
+```json
+{
+  "filters": {
+    "path_hints": ["lake-weekend"],
+    "has_faces": false
+  }
+}
+```
+
+## Expected Response Contract
+
+Extend the facet payload with:
+
+- `facets.has_faces`
+
+Recommended shape:
+
+```json
+{
+  "true": 4,
+  "false": 2
+}
+```
+
+This is intentionally narrow and should be computed over the filtered result set, not the whole corpus.
+
+## Test Strategy
+
+Add coverage at the search repository and search service layer for:
+
+- filtering by a single path hint
+- combining path hints with `has_faces`
+- returning the `has_faces` facet breakdown for filtered photo IDs
+- ensuring the seed-corpus-backed search fixtures remain valid after the schema change
+
+## Risks And Constraints
+
+- The current search implementation centralizes filtering in `PhotosRepository._apply_filters`, so `#38` will share files with later search issues.
+- Path matching should avoid pretending to be a full tokenizer; keep the behavior simple and documented.
+- Facet output changes should remain backward-compatible with the current search response shape conventions.

--- a/seed-corpus/search-fixtures.json
+++ b/seed-corpus/search-fixtures.json
@@ -147,6 +147,30 @@
         "birthday_park_004",
         "birthday_park_006"
       ]
+    },
+    {
+      "scenario_id": "SF07",
+      "description": "typed path-hint filtering combines with has_faces=false for birthday photos",
+      "phase_scope": "phase_3",
+      "request": {
+        "filters": {
+          "path_hints": [
+            "birthday-park"
+          ],
+          "has_faces": false
+        },
+        "sort": {
+          "by": "shot_ts",
+          "dir": "desc"
+        },
+        "page": {
+          "limit": 50
+        }
+      },
+      "expected_asset_ids": [
+        "birthday_park_004",
+        "birthday_park_006"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add typed `path_hints` support to the search filter schema and repository query layer
- add a `has_faces` facet breakdown over the filtered result set
- extend search tests and seed-corpus fixtures to cover typed path-hint filtering with face-presence filters

## Why
Phase 3 needs typed facet-style filters that are distinct from free-text search. This PR adds the first narrow slice of that contract without reopening the full search DSL.

Closes #38

## Validation
- `uv run --group test python -m pytest apps/api/tests/test_search_service.py -q`
- `uv run --group test python -m pytest -q`