### PR TITLE
[codex] Tighten date range filtering

### DIFF
--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -1,4 +1,5 @@
 import base64
+from datetime import UTC, datetime, time
 from typing import List, Dict, Any, Optional, Tuple
 from sqlalchemy import MetaData, Table, select, func, or_, and_, text
 from sqlalchemy.engine import Row
@@ -149,9 +150,19 @@ class PhotosRepository:
         # Date filters
         if filters.date:
             if filters.date.from_:
-                where_conditions.append(self.photos.c.shot_ts >= text(f"'{filters.date.from_}T00:00:00Z'"))
+                from_bound = datetime.combine(
+                    datetime.fromisoformat(filters.date.from_).date(),
+                    time.min,
+                    tzinfo=UTC,
+                )
+                where_conditions.append(self.photos.c.shot_ts >= from_bound)
             if filters.date.to:
-                where_conditions.append(self.photos.c.shot_ts <= text(f"'{filters.date.to}T23:59:59Z'"))
+                to_bound = datetime.combine(
+                    datetime.fromisoformat(filters.date.to).date(),
+                    time.max,
+                    tzinfo=UTC,
+                )
+                where_conditions.append(self.photos.c.shot_ts <= to_bound)
         
         # Simple list filters
         if filters.camera_make:

--- a/apps/api/app/schemas/search_request.py
+++ b/apps/api/app/schemas/search_request.py
@@ -1,9 +1,11 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from typing import List, Optional, Literal
 
 from app.core.enums import FilesizeRange
 
 class DateFilter(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     from_: Optional[str] = Field(default=None, alias="from")
     to: Optional[str] = None
 

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -698,6 +698,267 @@ class TestPhotosRepositorySoftDeleteFiltering:
 
         assert photo_ids == ["active-photo"]
 
+    def test_date_filter_from_only_includes_start_of_day_matches(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-date-filter-from-only.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        start_of_day = datetime(2022, 7, 1, 0, 0, 0, tzinfo=UTC)
+        previous_day = datetime(2022, 6, 30, 23, 59, 59, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "from-match",
+                        "path": "photos/from-match.jpg",
+                        "sha256": "1" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": start_of_day,
+                        "modified_ts": start_of_day,
+                        "shot_ts": start_of_day,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": start_of_day,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "from-excluded",
+                        "path": "photos/from-excluded.jpg",
+                        "sha256": "2" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": previous_day,
+                        "modified_ts": previous_day,
+                        "shot_ts": previous_day,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": previous_day,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(date=DateFilter(from_="2022-07-01")),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["from-match"]
+        assert total == 1
+
+    def test_date_filter_to_only_includes_end_of_day_fractional_second_matches(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-date-filter-to-only.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        end_of_day_fraction = datetime(2022, 7, 31, 23, 59, 59, 500000, tzinfo=UTC)
+        next_day = datetime(2022, 8, 1, 0, 0, 0, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "to-match",
+                        "path": "photos/to-match.jpg",
+                        "sha256": "3" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": end_of_day_fraction,
+                        "modified_ts": end_of_day_fraction,
+                        "shot_ts": end_of_day_fraction,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": end_of_day_fraction,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "to-excluded",
+                        "path": "photos/to-excluded.jpg",
+                        "sha256": "4" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": next_day,
+                        "modified_ts": next_day,
+                        "shot_ts": next_day,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": next_day,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(date=DateFilter(to="2022-07-31")),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["to-match"]
+        assert total == 1
+
+    def test_date_filter_bounded_includes_full_end_day_and_excludes_null_timestamps(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-date-filter-bounded.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        match_ts = datetime(2022, 7, 31, 23, 59, 59, 999999, tzinfo=UTC)
+        outside_ts = datetime(2022, 8, 1, 0, 0, 0, tzinfo=UTC)
+        earlier_ts = datetime(2022, 6, 30, 23, 59, 59, tzinfo=UTC)
+        now = datetime(2026, 3, 30, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "bounded-match",
+                        "path": "photos/bounded-match.jpg",
+                        "sha256": "5" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": match_ts,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "bounded-outside",
+                        "path": "photos/bounded-outside.jpg",
+                        "sha256": "6" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": outside_ts,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "bounded-earlier",
+                        "path": "photos/bounded-earlier.jpg",
+                        "sha256": "7" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": earlier_ts,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "bounded-null",
+                        "path": "photos/bounded-null.jpg",
+                        "sha256": "8" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": None,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(date=DateFilter(from_="2022-07-01", to="2022-07-31")),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["bounded-match"]
+        assert total == 1
+
     def test_search_repository_filters_by_path_hints(self, tmp_path):
         database_url = f"sqlite:///{tmp_path / 'search-path-hints.db'}"
         upgrade_database(database_url)

--- a/docs/superpowers/plans/2026-03-30-issue-35-date-range.md
+++ b/docs/superpowers/plans/2026-03-30-issue-35-date-range.md
@@ -1,0 +1,38 @@
+# Issue 35 Date Range Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make search date range filtering a well-specified typed filter over canonical `shot_ts` with inclusive day boundaries and seed-corpus-backed verification.
+
+**Architecture:** Lock the desired date semantics with failing repository and service tests first, then replace the current raw SQL date-bound construction with typed `datetime` comparisons inside the existing search repository. Finish by verifying the seed-corpus-backed July 2022 search fixture and the broader test suite.
+
+**Tech Stack:** Python, SQLAlchemy, Pydantic, pytest, uv
+
+---
+
+### Task 1: Lock date filter semantics in tests
+
+**Files:**
+- Modify: `apps/api/tests/test_search_service.py`
+
+- [ ] **Step 1: Write failing tests for `from`-only, `to`-only, and bounded date filtering semantics**
+- [ ] **Step 2: Write a failing test proving null `shot_ts` rows are excluded when any date filter is applied**
+- [ ] **Step 3: Run `uv run --group test python -m pytest apps/api/tests/test_search_service.py -k date_filter -q` and verify the new cases fail for the expected reason**
+
+### Task 2: Implement typed inclusive date bounds
+
+**Files:**
+- Modify: `apps/api/app/repositories/photos_repo.py`
+
+- [ ] **Step 1: Replace the raw SQL date-bound interpolation in `PhotosRepository._apply_filters` with typed `datetime` boundary values**
+- [ ] **Step 2: Keep `from` inclusive at the start of day and `to` inclusive through the end of day**
+- [ ] **Step 3: Re-run `uv run --group test python -m pytest apps/api/tests/test_search_service.py -k date_filter -q` and verify the focused slice passes**
+
+### Task 3: Verify the seed-corpus contract and search slice
+
+**Files:**
+- Modify: `seed-corpus/search-fixtures.json` only if the existing July 2022 fixture needs adjustment
+
+- [ ] **Step 1: Confirm the existing July 2022 fixture remains valid under the tightened date semantics**
+- [ ] **Step 2: Run `uv run --group test python -m pytest apps/api/tests/test_search_service.py -q` and verify the full search test module passes**
+- [ ] **Step 3: Run `uv run --group test python -m pytest -q` if the focused slice remains clean enough to justify broader verification**

--- a/docs/superpowers/specs/2026-03-30-issue-35-date-range-design.md
+++ b/docs/superpowers/specs/2026-03-30-issue-35-date-range-design.md
@@ -1,0 +1,69 @@
+# Issue 35 Date Range Filtering Design
+
+## Summary
+
+Issue `#35` should turn the existing date filter into an explicit, tested Phase 3 contract over canonical `shot_ts`. The goal is not to redesign the broader search DSL, but to make date filtering predictable: inclusive day-based boundaries, null timestamp exclusion when a date filter is active, and seed-corpus-backed verification of the July 2022 scenario.
+
+## Goals
+
+- Define clear semantics for `filters.date.from` and `filters.date.to`.
+- Ensure date filtering operates on canonical `photos.shot_ts`.
+- Exclude rows with null `shot_ts` whenever a date filter is present.
+- Add seed-corpus-backed verification for the representative July 2022 scenario.
+
+## Non-Goals
+
+- Rename the public request shape away from `date`.
+- Add relative-language handling such as "before the birthday weekend".
+- Add timezone-localized interpretation beyond the current UTC-based stored timestamps.
+- Redesign sorting or pagination behavior.
+
+## Design Decisions
+
+### Preserve the current outward request shape
+
+The current request schema already models:
+
+```json
+{
+  "filters": {
+    "date": {
+      "from": "2022-07-01",
+      "to": "2022-07-31"
+    }
+  }
+}
+```
+
+`#35` should keep that shape for compatibility and tighten its semantics instead of introducing a larger contract change.
+
+### Date bounds are inclusive day boundaries
+
+The expected behavior should be:
+
+- `from` means inclusive start of day at `00:00:00`
+- `to` means inclusive end of day at `23:59:59.999...`
+
+This matches the scenario catalog intent for "photos from July 2022" and keeps request values human-readable.
+
+### Null `shot_ts` rows are excluded when date filtering is active
+
+Photos without canonical timestamps cannot satisfy a bounded date query. When either `from` or `to` is present, rows with null `shot_ts` should not appear in results.
+
+### The implementation should avoid ad hoc SQL text fragments
+
+The current repository implementation uses raw SQL text interpolation for date boundaries. `#35` should replace that with typed Python `datetime` values passed through SQLAlchemy expressions so the behavior is safer and easier to reason about across SQLite and PostgreSQL.
+
+## Test Strategy
+
+Add or tighten coverage for:
+
+- `from`-only filtering
+- `to`-only filtering
+- bounded `from` + `to` filtering
+- exclusion of null `shot_ts` rows from date-filtered results
+- the existing seed-corpus fixture for July 2022 remaining green
+
+## Seed-Corpus Contract
+
+The current seed corpus already supports the representative July 2022 scenario. `seed-corpus/search-fixtures.json` should continue to carry that scenario as an executable contract rather than requiring new corpus assets.


### PR DESCRIPTION
## Summary
- tighten date range filtering to use typed UTC day boundaries instead of raw SQL text fragments
- allow `DateFilter` to be populated consistently through both the internal `from_` field name and the external `from` alias
- add repository-level tests for from-only, to-only, bounded ranges, and null `shot_ts` exclusion semantics

## Why
Phase 3 date filtering needs a stable contract over canonical `shot_ts`, especially for inclusive day bounds and predictable behavior across SQLite and PostgreSQL.

Closes #35

## Validation
- `uv run --group test python -m pytest apps/api/tests/test_search_service.py -q`
- `uv run --group test python -m pytest -q`