### PR TITLE
Implement tokenized catalog text search

### DIFF
--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -1,7 +1,7 @@
 import base64
 from datetime import UTC, datetime, time
 from typing import List, Dict, Any, Optional, Tuple
-from sqlalchemy import MetaData, Table, select, func, or_, and_, text
+from sqlalchemy import MetaData, Table, select, func, or_, and_
 from sqlalchemy.engine import Row
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import Select
@@ -217,14 +217,26 @@ class PhotosRepository:
         if text_query:
             tokens = [t for t in text_query.lower().split() if t]
             if tokens:
-                tag_exists = select(self.photo_tags.c.photo_id).where(
-                    (self.photo_tags.c.photo_id == self.photos.c.photo_id) &
-                    or_(*[self.photo_tags.c.tag.ilike(f"%{t}%") for t in tokens])
-                ).limit(1).exists()
-                where_conditions.append(or_(
-                    self.photos.c.path.ilike(f"%{tokens[0]}%"), 
-                    tag_exists
-                ))
+                token_conditions = []
+                for token in tokens:
+                    tag_exists = (
+                        select(self.photo_tags.c.photo_id)
+                        .where(
+                            and_(
+                                self.photo_tags.c.photo_id == self.photos.c.photo_id,
+                                self.photo_tags.c.tag.ilike(f"%{token}%"),
+                            )
+                        )
+                        .limit(1)
+                        .exists()
+                    )
+                    token_conditions.append(
+                        or_(
+                            self.photos.c.path.ilike(f"%{token}%"),
+                            tag_exists,
+                        )
+                    )
+                where_conditions.append(and_(*token_conditions))
         
         if where_conditions:
             query = query.where(and_(*where_conditions))

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -1116,6 +1116,226 @@ class TestPhotosRepositorySoftDeleteFiltering:
         assert [item["photo_id"] for item in items] == ["birthday-no-faces"]
         assert total == 1
 
+    def test_search_repository_requires_all_text_query_tokens(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-text-query-all-tokens.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 3, 30, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "lake-weekend",
+                        "path": "seed-corpus/family-events/lake-weekend/lake_weekend_001.jpg",
+                        "sha256": "7" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "lake-only",
+                        "path": "seed-corpus/family-events/lake-house/lake_house_001.jpg",
+                        "sha256": "8" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+                text_query="lake weekend",
+            )
+
+        assert [item["photo_id"] for item in items] == ["lake-weekend"]
+        assert total == 1
+
+    def test_search_repository_matches_text_query_tokens_across_path_and_tags(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-text-query-path-and-tags.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 3, 30, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "lake-tagged-sunset",
+                        "path": "seed-corpus/family-events/lake-weekend/lake_weekend_001.jpg",
+                        "sha256": "9" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "lake-tagged-hike",
+                        "path": "seed-corpus/family-events/lake-weekend/lake_weekend_002.jpg",
+                        "sha256": "a" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(photo_tags),
+                [
+                    {"photo_id": "lake-tagged-sunset", "tag": "sunset"},
+                    {"photo_id": "lake-tagged-hike", "tag": "hike"},
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+                text_query="LAKE sunset",
+            )
+
+        assert [item["photo_id"] for item in items] == ["lake-tagged-sunset"]
+        assert total == 1
+
+    def test_search_repository_ignores_whitespace_only_text_query(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-text-query-whitespace-only.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 3, 30, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "first-photo",
+                        "path": "seed-corpus/family-events/lake-weekend/lake_weekend_001.jpg",
+                        "sha256": "b" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "second-photo",
+                        "path": "seed-corpus/travel/city-break/city_break_001.jpg",
+                        "sha256": "c" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+                text_query="   \t  ",
+            )
+
+        assert {item["photo_id"] for item in items} == {"first-photo", "second-photo"}
+        assert total == 2
+
 
 class TestPhotosRepositoryOfflineBrowseIntegration:
     def test_search_repository_exposes_thumbnail_and_original_availability(self, tmp_path):

--- a/docs/superpowers/plans/2026-03-30-issue-34-text-search.md
+++ b/docs/superpowers/plans/2026-03-30-issue-34-text-search.md
@@ -1,0 +1,39 @@
+# Issue 34 Text Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `q` a predictable tokenized text-search clause over photo paths and tags, with AND semantics across query tokens.
+
+**Architecture:** Lock the text-search semantics with failing repository and service tests first, then replace the current single-token fallback with tokenized path/tag matching that requires all non-empty query terms. Keep sort behavior unchanged and verify the existing seed-corpus fixtures still pass.
+
+**Tech Stack:** Python, SQLAlchemy, pytest, uv
+
+---
+
+### Task 1: Lock text-search semantics in tests
+
+**Files:**
+- Modify: `apps/api/tests/test_search_service.py`
+
+- [ ] **Step 1: Write failing tests for multi-token AND semantics across path and tag matches**
+- [ ] **Step 2: Write failing tests for case-insensitive matching and whitespace-only query handling**
+- [ ] **Step 3: Run `uv run --group test python -m pytest apps/api/tests/test_search_service.py -k text_search -q` and verify the new cases fail for the expected reason**
+
+### Task 2: Implement tokenized path/tag matching
+
+**Files:**
+- Modify: `apps/api/app/repositories/photos_repo.py`
+
+- [ ] **Step 1: Replace the current single-token text-query fallback with tokenized matching across `photos.path` and `photo_tags.tag`**
+- [ ] **Step 2: Require every non-empty token to match via AND semantics while keeping the query case-insensitive**
+- [ ] **Step 3: Treat empty or whitespace-only `q` as no text filter**
+- [ ] **Step 4: Re-run `uv run --group test python -m pytest apps/api/tests/test_search_service.py -k text_search -q` and verify the focused slice passes**
+
+### Task 3: Verify the seed-corpus contract and search slice
+
+**Files:**
+- Modify: `seed-corpus/search-fixtures.json` only if an additional text-search scenario is required
+
+- [ ] **Step 1: Confirm existing text-search fixtures remain valid under the tightened token semantics**
+- [ ] **Step 2: Run `uv run --group test python -m pytest apps/api/tests/test_search_service.py -q` and verify the full search test module passes**
+- [ ] **Step 3: Run `uv run --group test python -m pytest -q` if the focused slice remains clean enough to justify broader verification**

--- a/docs/superpowers/specs/2026-03-30-issue-34-text-search-design.md
+++ b/docs/superpowers/specs/2026-03-30-issue-34-text-search-design.md
@@ -1,0 +1,80 @@
+# Issue 34 Text Search Design
+
+## Summary
+
+Issue `#34` should define a narrow, explicit Phase 3 text-search contract over cataloged photo paths and tags. The goal is not to build full ranking or natural-language interpretation, but to make `q` a predictable tokenized text clause instead of the current single-token fallback.
+
+## Goals
+
+- Treat `q` as a first-class text-search input over `photos.path` and `photo_tags.tag`.
+- Tokenize the query into meaningful non-empty terms.
+- Require every token to match somewhere across the indexed text surfaces for a photo.
+- Preserve the existing sort behavior rather than introducing relevance ranking.
+
+## Non-Goals
+
+- Relevance scoring or ranked result ordering.
+- Phrase search, quoted search, fuzzy matching, stemming, or typo tolerance.
+- Searching people, geo data, or arbitrary metadata outside path and tags.
+- Natural-language normalization beyond simple tokenization.
+
+## Design Decisions
+
+### Text search remains distinct from typed filters
+
+The Phase 3 scenario catalog separates free-text discovery from typed filter clauses. `q` should stay a dedicated text-search field and should not absorb responsibilities that belong to `camera_make`, `date`, `has_faces`, or other typed filters.
+
+### Search surfaces are path and tags only
+
+For this issue, a photo matches text search if query tokens can be found in either:
+
+- `photos.path`
+- related `photo_tags.tag`
+
+This is enough to satisfy the current seed-corpus scenarios without introducing new indexing infrastructure.
+
+### Query terms use AND semantics across the whole query
+
+Each non-empty token in `q` should be required. A photo matches only if every token appears somewhere across the supported text surfaces. This avoids overly broad results for multi-word queries and fits the current catalog expectation for coherent query narrowing.
+
+### Matching stays simple and case-insensitive
+
+Token matching should be case-insensitive substring matching for now. This keeps the implementation small and deterministic across the current SQLAlchemy-backed stack.
+
+## Expected Request Contract
+
+Example:
+
+```json
+{
+  "q": "city break",
+  "filters": {
+    "extension": ["jpeg"]
+  }
+}
+```
+
+Semantics:
+
+- split `q` into normalized non-empty tokens
+- each token must match either the canonical photo path or a related tag
+- typed filters still combine with text search using `AND`
+
+## Test Strategy
+
+Add or tighten coverage for:
+
+- multiple text tokens with AND semantics
+- case-insensitive token matching
+- empty or whitespace-only queries behaving like no text query
+- composition of text search with existing typed filters such as `extension`
+- the existing seed-corpus text fixtures remaining valid
+
+## Seed-Corpus Contract
+
+The current fixture catalog already covers representative text-search scenarios:
+
+- `SF01` for lake-based discovery
+- `SF04` for multi-clause text plus extension filtering
+
+`#34` should keep those green and can add another typed text fixture only if the existing catalog no longer covers the intended semantics well enough.


### PR DESCRIPTION
## Summary
- make catalog text search require every query token to match across photo paths or tags
- add repository integration coverage for all-token matching, cross path/tag matching, and whitespace-only queries
- record the approved issue #34 design and implementation plan

Closes #34

## Verification
- `uv run --group test python -m pytest apps/api/tests/test_search_service.py -k text_query -q`
- `uv run --group test python -m pytest apps/api/tests/test_search_service.py -q`
- `uv run --group test python -m pytest -q`

## Results
- `4 passed`
- `33 passed`
- `261 passed`