### PR TITLE
[codex] implement person-based filtering

### DIFF
--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -28,6 +28,7 @@ class PhotosRepository:
         # Single source of truth for table objects
         self.photos: Table = Table("photos", md, autoload_with=bind)
         self.faces: Table = Table("faces", md, autoload_with=bind)
+        self.people: Table = Table("people", md, autoload_with=bind)
         self.photo_tags: Table = Table("photo_tags", md, autoload_with=bind)
         self.photo_files: Table = Table("photo_files", md, autoload_with=bind)
         self.watched_folders: Table = Table("watched_folders", md, autoload_with=bind)
@@ -202,6 +203,30 @@ class PhotosRepository:
                 )
             ).limit(1)
             where_conditions.append(people_subquery.exists())
+
+        if filters.person_names:
+            person_name_subquery = (
+                select(self.faces.c.photo_id)
+                .select_from(
+                    self.faces.join(
+                        self.people,
+                        self.faces.c.person_id == self.people.c.person_id,
+                    )
+                )
+                .where(
+                    and_(
+                        self.faces.c.photo_id == self.photos.c.photo_id,
+                        or_(
+                            *[
+                                self.people.c.display_name.ilike(f"%{name}%")
+                                for name in filters.person_names
+                            ]
+                        ),
+                    )
+                )
+                .limit(1)
+            )
+            where_conditions.append(person_name_subquery.exists())
         
         # Tags filter (OR logic within tags)
         if filters.tags:

--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -34,6 +34,19 @@ class PhotosRepository:
         self.watched_folders: Table = Table("watched_folders", md, autoload_with=bind)
         self.storage_sources: Table = Table("storage_sources", md, autoload_with=bind)
 
+    @staticmethod
+    def _normalize_person_name_terms(person_names: List[str]) -> List[str]:
+        terms = []
+        for name in person_names:
+            term = name.strip()
+            if term:
+                terms.append(term)
+        return terms
+
+    @staticmethod
+    def _escape_like_literal(term: str) -> str:
+        return term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
     def search_photos(self, filters: SearchFilters, sort: SortSpec, page: PageSpec,
                      text_query: Optional[str] = None) -> Tuple[List[Dict[str, Any]], int, Optional[str]]:
         """
@@ -204,7 +217,8 @@ class PhotosRepository:
             ).limit(1)
             where_conditions.append(people_subquery.exists())
 
-        if filters.person_names:
+        person_name_terms = self._normalize_person_name_terms(filters.person_names or [])
+        if person_name_terms:
             person_name_subquery = (
                 select(self.faces.c.photo_id)
                 .select_from(
@@ -218,8 +232,11 @@ class PhotosRepository:
                         self.faces.c.photo_id == self.photos.c.photo_id,
                         or_(
                             *[
-                                self.people.c.display_name.ilike(f"%{name}%")
-                                for name in filters.person_names
+                                self.people.c.display_name.ilike(
+                                    f"%{self._escape_like_literal(name)}%",
+                                    escape="\\",
+                                )
+                                for name in person_name_terms
                             ]
                         ),
                     )

--- a/apps/api/app/schemas/search_request.py
+++ b/apps/api/app/schemas/search_request.py
@@ -27,6 +27,7 @@ class SearchFilters(BaseModel):
     has_faces: Optional[bool] = None
     tags: Optional[List[str]] = None
     people: Optional[List[str]] = None
+    person_names: Optional[List[str]] = None
 
 class VectorSpec(BaseModel):
     dim: int

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -1503,6 +1503,199 @@ class TestPhotosRepositorySoftDeleteFiltering:
         assert items == []
         assert total == 0
 
+    def test_search_repository_person_names_treat_like_wildcards_as_literals(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-person-names-literal-wildcards.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 4, 3, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "photo-inez",
+                        "path": "seed-corpus/family/image_001.jpg",
+                        "sha256": "f" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    }
+                ],
+            )
+            connection.execute(
+                insert(people).values(
+                    person_id="person-inez",
+                    display_name="Inez Rivera",
+                    created_ts=now,
+                    updated_ts=now,
+                )
+            )
+            connection.execute(
+                insert(faces).values(
+                    face_id="face-inez",
+                    photo_id="photo-inez",
+                    person_id="person-inez",
+                    bbox_x=0,
+                    bbox_y=0,
+                    bbox_w=10,
+                    bbox_h=10,
+                    bitmap=None,
+                    embedding=None,
+                    detector_name="seed",
+                    detector_version="1",
+                    provenance=None,
+                    created_ts=now,
+                )
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(person_names=["%"]),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert items == []
+        assert total == 0
+
+    def test_search_repository_person_names_drop_blank_terms_before_building_clause(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-person-names-blank.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 4, 3, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "photo-inez",
+                        "path": "seed-corpus/family/image_001.jpg",
+                        "sha256": "1" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                    {
+                        "photo_id": "photo-mateo",
+                        "path": "seed-corpus/family/image_002.jpg",
+                        "sha256": "2" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(people).values(
+                    person_id="person-inez",
+                    display_name="Inez Rivera",
+                    created_ts=now,
+                    updated_ts=now,
+                )
+            )
+            connection.execute(
+                insert(people).values(
+                    person_id="person-mateo",
+                    display_name="Mateo Rivera",
+                    created_ts=now,
+                    updated_ts=now,
+                )
+            )
+            connection.execute(
+                insert(faces),
+                [
+                    {
+                        "face_id": "face-inez",
+                        "photo_id": "photo-inez",
+                        "person_id": "person-inez",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                    {
+                        "face_id": "face-mateo",
+                        "photo_id": "photo-mateo",
+                        "person_id": "person-mateo",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(person_names=["   ", "inez"]),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["photo-inez"]
+        assert total == 1
+
     def test_search_repository_requires_all_text_query_tokens(self, tmp_path):
         database_url = f"sqlite:///{tmp_path / 'search-text-query-all-tokens.db'}"
         upgrade_database(database_url)

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -1272,6 +1272,271 @@ class TestPhotosRepositorySoftDeleteFiltering:
         assert [item["photo_id"] for item in items] == ["photo-inez"]
         assert total == 1
 
+    def test_search_repository_composes_person_names_with_path_hints(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-person-names-path-hints.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 4, 3, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "photo-match-both",
+                        "path": "seed-corpus/family-events/lake-weekend/photo-match-both.jpg",
+                        "sha256": "a" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                    {
+                        "photo_id": "photo-path-only",
+                        "path": "seed-corpus/family-events/lake-weekend/photo-path-only.jpg",
+                        "sha256": "b" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                    {
+                        "photo_id": "photo-person-only",
+                        "path": "seed-corpus/family-events/city-break/photo-person-only.jpg",
+                        "sha256": "c" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(people),
+                [
+                    {
+                        "person_id": "person-inez",
+                        "display_name": "Inez Rivera",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "person_id": "person-mateo",
+                        "display_name": "Mateo Rivera",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(faces),
+                [
+                    {
+                        "face_id": "face-match-both",
+                        "photo_id": "photo-match-both",
+                        "person_id": "person-inez",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                    {
+                        "face_id": "face-path-only",
+                        "photo_id": "photo-path-only",
+                        "person_id": "person-mateo",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                    {
+                        "face_id": "face-person-only",
+                        "photo_id": "photo-person-only",
+                        "person_id": "person-inez",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(path_hints=["lake-weekend"], person_names=["inez"]),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["photo-match-both"]
+        assert total == 1
+
+    def test_search_repository_people_filter_still_works(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-people-regression.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 4, 3, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "photo-inez",
+                        "path": "seed-corpus/family/image_001.jpg",
+                        "sha256": "d" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                    {
+                        "photo_id": "photo-mateo",
+                        "path": "seed-corpus/family/image_002.jpg",
+                        "sha256": "e" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(faces),
+                [
+                    {
+                        "face_id": "face-inez",
+                        "photo_id": "photo-inez",
+                        "person_id": "person-inez",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                    {
+                        "face_id": "face-mateo",
+                        "photo_id": "photo-mateo",
+                        "person_id": "person-mateo",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(people=["person-inez"]),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["photo-inez"]
+        assert total == 1
+
     def test_search_repository_person_names_use_or_semantics(self, tmp_path):
         database_url = f"sqlite:///{tmp_path / 'search-person-names-or.db'}"
         upgrade_database(database_url)

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -22,7 +22,15 @@ from app.services.search_service import SearchService
 from app.schemas.search_request import SearchRequest, SearchFilters, SortSpec, PageSpec, DateFilter
 from app.schemas.search_response import SearchResponse, Hits, PhotoHit
 from app.core.enums import FilesizeRange
-from app.storage import faces, photo_files, photo_tags, photos, storage_sources, watched_folders
+from app.storage import (
+    faces,
+    people,
+    photo_files,
+    photo_tags,
+    photos,
+    storage_sources,
+    watched_folders,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -1141,6 +1149,314 @@ class TestPhotosRepositorySoftDeleteFiltering:
 
         assert [item["photo_id"] for item in items] == ["birthday-no-faces"]
         assert total == 1
+
+    def test_search_repository_filters_by_person_names(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-person-names.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 4, 3, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "photo-inez",
+                        "path": "seed-corpus/family/inez_001.jpg",
+                        "sha256": "a" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                    {
+                        "photo_id": "photo-mateo",
+                        "path": "seed-corpus/family/mateo_001.jpg",
+                        "sha256": "b" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(people),
+                [
+                    {
+                        "person_id": "person-inez",
+                        "display_name": "Inez Rivera",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "person_id": "person-mateo",
+                        "display_name": "Mateo Rivera",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(faces),
+                [
+                    {
+                        "face_id": "face-inez",
+                        "photo_id": "photo-inez",
+                        "person_id": "person-inez",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                    {
+                        "face_id": "face-mateo",
+                        "photo_id": "photo-mateo",
+                        "person_id": "person-mateo",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(person_names=["inez"]),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["photo-inez"]
+        assert total == 1
+
+    def test_search_repository_person_names_use_or_semantics(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-person-names-or.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 4, 3, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "photo-inez",
+                        "path": "seed-corpus/family/inez_001.jpg",
+                        "sha256": "c" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                    {
+                        "photo_id": "photo-grandma",
+                        "path": "seed-corpus/family/grandma_001.jpg",
+                        "sha256": "d" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(people),
+                [
+                    {
+                        "person_id": "person-inez",
+                        "display_name": "Inez Rivera",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "person_id": "person-grandma",
+                        "display_name": "Grandma Elena",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(faces),
+                [
+                    {
+                        "face_id": "face-inez",
+                        "photo_id": "photo-inez",
+                        "person_id": "person-inez",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                    {
+                        "face_id": "face-grandma",
+                        "photo_id": "photo-grandma",
+                        "person_id": "person-grandma",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(person_names=["inez", "grandma"]),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert {item["photo_id"] for item in items} == {"photo-inez", "photo-grandma"}
+        assert total == 2
+
+    def test_search_repository_person_names_ignore_unlabeled_faces(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-person-names-unlabeled.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 4, 3, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "photo-unlabeled",
+                        "path": "seed-corpus/family/unlabeled_001.jpg",
+                        "sha256": "e" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    }
+                ],
+            )
+            connection.execute(
+                insert(faces).values(
+                    face_id="face-unlabeled",
+                    photo_id="photo-unlabeled",
+                    person_id=None,
+                    bbox_x=0,
+                    bbox_y=0,
+                    bbox_w=10,
+                    bbox_h=10,
+                    bitmap=None,
+                    embedding=None,
+                    detector_name="seed",
+                    detector_version="1",
+                    provenance=None,
+                    created_ts=now,
+                )
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(person_names=["inez"]),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert items == []
+        assert total == 0
 
     def test_search_repository_requires_all_text_query_tokens(self, tmp_path):
         database_url = f"sqlite:///{tmp_path / 'search-text-query-all-tokens.db'}"

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -1328,6 +1328,29 @@ class TestPhotosRepositorySoftDeleteFiltering:
                         "faces_count": 1,
                         "faces_detected_ts": now,
                     },
+                    {
+                        "photo_id": "photo-jordan",
+                        "path": "seed-corpus/family/jordan_001.jpg",
+                        "sha256": "e" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
                 ],
             )
             connection.execute(
@@ -1342,6 +1365,12 @@ class TestPhotosRepositorySoftDeleteFiltering:
                     {
                         "person_id": "person-grandma",
                         "display_name": "Grandma Elena",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "person_id": "person-jordan",
+                        "display_name": "Jordan Lee",
                         "created_ts": now,
                         "updated_ts": now,
                     },
@@ -1380,6 +1409,21 @@ class TestPhotosRepositorySoftDeleteFiltering:
                         "provenance": None,
                         "created_ts": now,
                     },
+                    {
+                        "face_id": "face-jordan",
+                        "photo_id": "photo-jordan",
+                        "person_id": "person-jordan",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
                 ],
             )
 
@@ -1392,6 +1436,7 @@ class TestPhotosRepositorySoftDeleteFiltering:
             )
 
         assert {item["photo_id"] for item in items} == {"photo-inez", "photo-grandma"}
+        assert "photo-jordan" not in {item["photo_id"] for item in items}
         assert total == 2
 
     def test_search_repository_person_names_ignore_unlabeled_faces(self, tmp_path):

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -1162,7 +1162,7 @@ class TestPhotosRepositorySoftDeleteFiltering:
                 [
                     {
                         "photo_id": "photo-inez",
-                        "path": "seed-corpus/family/inez_001.jpg",
+                        "path": "seed-corpus/family/image_001.jpg",
                         "sha256": "a" * 64,
                         "phash": None,
                         "filesize": 100,
@@ -1185,7 +1185,7 @@ class TestPhotosRepositorySoftDeleteFiltering:
                     },
                     {
                         "photo_id": "photo-mateo",
-                        "path": "seed-corpus/family/mateo_001.jpg",
+                        "path": "seed-corpus/family/image_002.jpg",
                         "sha256": "b" * 64,
                         "phash": None,
                         "filesize": 100,
@@ -1284,7 +1284,7 @@ class TestPhotosRepositorySoftDeleteFiltering:
                 [
                     {
                         "photo_id": "photo-inez",
-                        "path": "seed-corpus/family/inez_001.jpg",
+                        "path": "seed-corpus/family/image_001.jpg",
                         "sha256": "c" * 64,
                         "phash": None,
                         "filesize": 100,
@@ -1307,7 +1307,7 @@ class TestPhotosRepositorySoftDeleteFiltering:
                     },
                     {
                         "photo_id": "photo-grandma",
-                        "path": "seed-corpus/family/grandma_001.jpg",
+                        "path": "seed-corpus/family/image_002.jpg",
                         "sha256": "d" * 64,
                         "phash": None,
                         "filesize": 100,
@@ -1330,7 +1330,7 @@ class TestPhotosRepositorySoftDeleteFiltering:
                     },
                     {
                         "photo_id": "photo-jordan",
-                        "path": "seed-corpus/family/jordan_001.jpg",
+                        "path": "seed-corpus/family/image_003.jpg",
                         "sha256": "e" * 64,
                         "phash": None,
                         "filesize": 100,
@@ -1451,7 +1451,7 @@ class TestPhotosRepositorySoftDeleteFiltering:
                 [
                     {
                         "photo_id": "photo-unlabeled",
-                        "path": "seed-corpus/family/unlabeled_001.jpg",
+                        "path": "seed-corpus/family/image_004.jpg",
                         "sha256": "e" * 64,
                         "phash": None,
                         "filesize": 100,

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -335,6 +335,32 @@ class TestSearchServiceExecution:
         )
         mock_repo.get_filtered_photo_ids.assert_called_once_with(filters, None)
 
+    def test_given_person_names_when_executing_search_then_passes_person_names_to_repository(self):
+        mock_repo = Mock()
+        service = SearchService(repo=mock_repo)
+
+        mock_repo.search_photos.return_value = ([], 0, None)
+        mock_repo.get_filtered_photo_ids.return_value = []
+        mock_repo.compute_facets.return_value = {}
+
+        filters = SearchFilters(person_names=["inez", "grandma"])
+        assert filters.model_dump().get("person_names") == ["inez", "grandma"]
+        request = SearchRequest(
+            filters=filters,
+            sort=SortSpec(by="shot_ts", dir="desc"),
+            page=PageSpec(limit=50),
+        )
+
+        service.execute(request)
+
+        mock_repo.search_photos.assert_called_once_with(
+            filters=filters,
+            sort=request.sort,
+            page=request.page,
+            text_query=None,
+        )
+        mock_repo.get_filtered_photo_ids.assert_called_once_with(filters, None)
+
     def test_given_empty_results_when_executing_search_then_returns_empty_response_with_facets(self):
         """Given empty results, when executing search, then returns empty response with facets."""
         # Given

--- a/docs/superpowers/specs/2026-04-03-issue-36-person-based-filtering-design.md
+++ b/docs/superpowers/specs/2026-04-03-issue-36-person-based-filtering-design.md
@@ -1,0 +1,96 @@
+# Issue 36 Person-Based Filtering Design
+
+## Summary
+
+Issue `#36` should add person-based filtering to the current Phase 3 search surface by allowing callers to filter photos with fuzzy name matching against labeled people. The scope should stay narrow: add an explicit request field for person-name queries, resolve those queries against stored person identities, and apply the filter through the existing search repository path.
+
+## Goals
+
+- Add a typed search filter for fuzzy person-name matching.
+- Keep the change aligned with the current `SearchRequest` and `PhotosRepository` architecture.
+- Make person-name filtering compose cleanly with existing text, date, path-hint, tag, and face-presence filters.
+- Cover the new behavior with automated tests at the repository and search-service layer.
+
+## Non-Goals
+
+- Redesign the full search DSL.
+- Introduce a separate fuzzy-search index or ranking system for people.
+- Change the search response payload to expose person display names.
+- Implement exact `person_id` filtering semantics beyond preserving the existing field.
+
+## Design Decisions
+
+### Person-name filtering is a typed filter, not free text
+
+The search request should gain a dedicated `filters.person_names` field rather than folding person matching into top-level `q`. This keeps person filtering explicit, composable with other filter families, and consistent with the existing typed-filter direction established by date and path-hint filtering.
+
+### `filters.people` remains reserved for exact identifiers
+
+The existing `filters.people` field should not be repurposed to mean fuzzy names. Its name already implies exact person identifiers, and overloading it now would create avoidable ambiguity when exact ID filtering is implemented later. For this issue, the new behavior belongs in `filters.person_names`.
+
+### Matching resolves against `people.display_name`
+
+The filter should resolve against the canonical person record in `people.display_name`, not only against `faces.person_id`. A photo matches when at least one labeled face on that photo refers to a `people` row whose `display_name` matches any requested person-name term.
+
+### Matching semantics stay simple and documented
+
+Each `person_names` entry should use case-insensitive substring matching via SQL `ILIKE '%term%'`. This is a pragmatic fuzzy baseline that matches the current search implementation style without introducing tokenizer, stemming, or edit-distance infrastructure in this slice.
+
+## Expected Request Contract
+
+Within the current schema, add:
+
+- `filters.person_names: list[str] | null`
+
+Meaning:
+
+- values combine with `ANY` semantics within the field
+- `person_names` combines with all other filter families using `AND`
+- unlabeled faces do not satisfy this filter
+
+Example:
+
+```json
+{
+  "filters": {
+    "person_names": ["inez", "grandma"],
+    "has_faces": true
+  }
+}
+```
+
+## Repository Behavior
+
+Implementation should stay centralized in `PhotosRepository._apply_filters(...)`.
+
+Recommended query shape:
+
+- autoload the `people` table in `PhotosRepository.__init__`
+- when `filters.person_names` is present, add a correlated `EXISTS` subquery
+- join `faces` to `people` on `faces.person_id == people.person_id`
+- scope the subquery to the current `photos.photo_id`
+- match any provided term against `people.display_name` with case-insensitive substring conditions
+
+This keeps hit selection and facet computation consistent because both already reuse `_apply_filters(...)`.
+
+## Response Behavior
+
+No response-contract change is required for this issue. Search hits may continue returning person identifiers in the existing `people` and `faces` fields. Exposing person display names is a separate concern and should not be bundled into person-name filtering.
+
+## Test Strategy
+
+Add coverage for:
+
+- filtering by a single fuzzy person-name term
+- filtering by multiple person-name terms with `OR` semantics
+- combining `person_names` with another filter family such as `has_faces` or `path_hints`
+- ensuring unlabeled faces do not satisfy `person_names`
+- ensuring non-matching names correctly exclude photos
+
+Targeted repository-backed tests are sufficient for this issue even if the checked-in seed corpus does not yet contain representative person-labeled data. If seed fixtures are later expanded with labeled people, they can add higher-level scenario coverage without changing the contract defined here.
+
+## Risks And Constraints
+
+- The current repository stores face-level `person_id` values directly on `faces`, so the filter must avoid assuming names are already denormalized there.
+- Substring matching is intentionally limited; it should not be described as full fuzzy search beyond documented partial-name matching.
+- This issue shares the central filter pipeline with adjacent Phase 3 search work, so tests should be explicit about cross-filter composition.


### PR DESCRIPTION
## Summary
- add typed `filters.person_names` support for search requests
- implement repository filtering against `people.display_name` with literal substring matching and blank-term/wildcard hardening
- add repository-backed coverage for person-name matching, composition with `path_hints`, and `filters.people` non-regression

## Why
This implements issue #36 by making person-based filtering usable through fuzzy name matching on labeled people without changing the current response contract.

Closes #36.

## Test Plan
- [x] `uv run pytest apps/api/tests/test_search_service.py -v`
- [x] `make test`
