### PR TITLE
[codex] implement location proximity search

### DIFF
--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -1,7 +1,8 @@
 import base64
+import math
 from datetime import UTC, datetime, time
 from typing import List, Dict, Any, Optional, Tuple
-from sqlalchemy import MetaData, Table, select, func, or_, and_
+from sqlalchemy import MetaData, Table, select, func, or_, and_, case
 from sqlalchemy.engine import Row
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import Select
@@ -189,6 +190,39 @@ class PhotosRepository:
             )
         if filters.orientation:
             where_conditions.append(self.photos.c.orientation.in_(filters.orientation))
+
+        if filters.location_radius:
+            latitude = filters.location_radius.latitude
+            longitude = filters.location_radius.longitude
+            radius_km = filters.location_radius.radius_km
+
+            earth_radius_km = 6371.0088
+            degrees_to_radians = math.pi / 180.0
+            latitude_radians = latitude * degrees_to_radians
+            longitude_radians = longitude * degrees_to_radians
+            photo_latitude_radians = self.photos.c.gps_latitude * degrees_to_radians
+            photo_longitude_radians = self.photos.c.gps_longitude * degrees_to_radians
+
+            cosine_distance = (
+                func.sin(latitude_radians) * func.sin(photo_latitude_radians)
+                + func.cos(latitude_radians)
+                * func.cos(photo_latitude_radians)
+                * func.cos(photo_longitude_radians - longitude_radians)
+            )
+            clamped_cosine_distance = case(
+                (cosine_distance > 1.0, 1.0),
+                (cosine_distance < -1.0, -1.0),
+                else_=cosine_distance,
+            )
+            spherical_distance_km = earth_radius_km * func.acos(clamped_cosine_distance)
+
+            where_conditions.append(
+                and_(
+                    self.photos.c.gps_latitude.is_not(None),
+                    self.photos.c.gps_longitude.is_not(None),
+                    spherical_distance_km <= radius_km,
+                )
+            )
         
         # Filesize range filter
         if filters.filesize_range:

--- a/apps/api/app/schemas/search_request.py
+++ b/apps/api/app/schemas/search_request.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, ConfigDict, Field
+import math
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from typing import List, Optional, Literal
 
 from app.core.enums import FilesizeRange
@@ -17,6 +19,40 @@ class PageSpec(BaseModel):
     limit: Optional[int] = 50
     cursor: Optional[str] = None
 
+
+class LocationRadiusFilter(BaseModel):
+    latitude: float
+    longitude: float
+    radius_km: float = 50
+
+    @field_validator("latitude")
+    @classmethod
+    def validate_latitude(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("latitude must be finite")
+        if value < -90 or value > 90:
+            raise ValueError("latitude must be between -90 and 90")
+        return value
+
+    @field_validator("longitude")
+    @classmethod
+    def validate_longitude(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("longitude must be finite")
+        if value < -180 or value > 180:
+            raise ValueError("longitude must be between -180 and 180")
+        return value
+
+    @field_validator("radius_km")
+    @classmethod
+    def validate_radius_km(cls, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("radius_km must be finite")
+        if value <= 0:
+            raise ValueError("radius_km must be greater than 0")
+        return value
+
+
 class SearchFilters(BaseModel):
     date: Optional[DateFilter] = None
     camera_make: Optional[List[str]] = None
@@ -28,6 +64,7 @@ class SearchFilters(BaseModel):
     tags: Optional[List[str]] = None
     people: Optional[List[str]] = None
     person_names: Optional[List[str]] = None
+    location_radius: Optional[LocationRadiusFilter] = None
 
 class VectorSpec(BaseModel):
     dim: int

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -31,6 +31,7 @@ from app.storage import (
     storage_sources,
     watched_folders,
 )
+from pydantic import ValidationError
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -66,6 +67,52 @@ def _asset_id_by_manifest_path() -> dict[str, str]:
         asset["path"]: asset["asset_id"]
         for asset in _load_seed_manifest()["assets"]
     }
+
+
+def test_location_radius_validation_accepts_coordinates_and_defaults_radius():
+    filters = SearchFilters(location_radius={"latitude": 37.7749, "longitude": -122.4194})
+
+    assert filters.location_radius.latitude == 37.7749
+    assert filters.location_radius.longitude == -122.4194
+    assert filters.location_radius.radius_km == 50
+
+    request = SearchRequest(filters={"location_radius": {"latitude": 37.7749, "longitude": -122.4194}})
+
+    assert request.filters.location_radius.radius_km == 50
+
+
+def test_location_radius_validation_rejects_latitude_outside_bounds():
+    with pytest.raises(ValidationError) as exc_info:
+        SearchFilters(location_radius={"latitude": 91, "longitude": 0})
+
+    assert "latitude must be between -90 and 90" in str(exc_info.value)
+
+
+def test_location_radius_validation_rejects_longitude_outside_bounds():
+    with pytest.raises(ValidationError) as exc_info:
+        SearchFilters(location_radius={"latitude": 0, "longitude": 181})
+
+    assert "longitude must be between -180 and 180" in str(exc_info.value)
+
+
+def test_location_radius_validation_rejects_non_positive_radius_km():
+    with pytest.raises(ValidationError) as exc_info:
+        SearchFilters(location_radius={"latitude": 0, "longitude": 0, "radius_km": 0})
+
+    assert "radius_km must be greater than 0" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "location_radius",
+    [
+        {"latitude": float("nan"), "longitude": 0},
+        {"latitude": 0, "longitude": float("nan")},
+        {"latitude": 0, "longitude": 0, "radius_km": float("nan")},
+    ],
+)
+def test_location_radius_validation_rejects_non_finite_values(location_radius):
+    with pytest.raises(ValidationError):
+        SearchFilters(location_radius=location_radius)
 
 
 def _seed_search_fixture_catalog(connection) -> None:

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -806,6 +806,267 @@ class TestPhotosRepositorySoftDeleteFiltering:
 
         assert photo_ids == ["active-photo"]
 
+    @staticmethod
+    def _insert_location_filter_photos(connection, now: datetime) -> None:
+        connection.execute(
+            insert(photos),
+            [
+                {
+                    "photo_id": "nearby-geotagged",
+                    "path": "photos/nearby-geotagged.jpg",
+                    "sha256": "e" * 64,
+                    "phash": None,
+                    "filesize": 100,
+                    "ext": "jpg",
+                    "created_ts": now,
+                    "modified_ts": now,
+                    "shot_ts": now,
+                    "shot_ts_source": None,
+                    "camera_make": "Apple",
+                    "camera_model": None,
+                    "software": None,
+                    "orientation": None,
+                    "gps_latitude": 37.7790,
+                    "gps_longitude": -122.4192,
+                    "gps_altitude": None,
+                    "updated_ts": now,
+                    "deleted_ts": None,
+                    "faces_count": 0,
+                    "faces_detected_ts": None,
+                },
+                {
+                    "photo_id": "nearby-other-camera",
+                    "path": "photos/nearby-other-camera.jpg",
+                    "sha256": "f" * 64,
+                    "phash": None,
+                    "filesize": 100,
+                    "ext": "jpg",
+                    "created_ts": now,
+                    "modified_ts": now,
+                    "shot_ts": now,
+                    "shot_ts_source": None,
+                    "camera_make": "Canon",
+                    "camera_model": None,
+                    "software": None,
+                    "orientation": None,
+                    "gps_latitude": 37.7840,
+                    "gps_longitude": -122.4090,
+                    "gps_altitude": None,
+                    "updated_ts": now,
+                    "deleted_ts": None,
+                    "faces_count": 0,
+                    "faces_detected_ts": None,
+                },
+                {
+                    "photo_id": "far-geotagged",
+                    "path": "photos/far-geotagged.jpg",
+                    "sha256": "g" * 64,
+                    "phash": None,
+                    "filesize": 100,
+                    "ext": "jpg",
+                    "created_ts": now,
+                    "modified_ts": now,
+                    "shot_ts": now,
+                    "shot_ts_source": None,
+                    "camera_make": "Apple",
+                    "camera_model": None,
+                    "software": None,
+                    "orientation": None,
+                    "gps_latitude": 34.0522,
+                    "gps_longitude": -118.2437,
+                    "gps_altitude": None,
+                    "updated_ts": now,
+                    "deleted_ts": None,
+                    "faces_count": 0,
+                    "faces_detected_ts": None,
+                },
+                {
+                    "photo_id": "missing-gps",
+                    "path": "photos/missing-gps.jpg",
+                    "sha256": "h" * 64,
+                    "phash": None,
+                    "filesize": 100,
+                    "ext": "jpg",
+                    "created_ts": now,
+                    "modified_ts": now,
+                    "shot_ts": now,
+                    "shot_ts_source": None,
+                    "camera_make": "Apple",
+                    "camera_model": None,
+                    "software": None,
+                    "orientation": None,
+                    "gps_latitude": None,
+                    "gps_longitude": None,
+                    "gps_altitude": None,
+                    "updated_ts": now,
+                    "deleted_ts": None,
+                    "faces_count": 0,
+                    "faces_detected_ts": None,
+                },
+            ],
+        )
+
+    def test_location_radius_filter_returns_only_nearby_geotagged_photos(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-location-radius-nearby.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 4, 1, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            self._insert_location_filter_photos(connection, now)
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(
+                    location_radius={
+                        "latitude": 37.7749,
+                        "longitude": -122.4194,
+                        "radius_km": 15,
+                    }
+                ),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert {item["photo_id"] for item in items} == {
+            "nearby-geotagged",
+            "nearby-other-camera",
+        }
+        assert total == 2
+
+    def test_location_radius_filter_excludes_photos_with_null_gps_coordinates(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-location-radius-null-gps.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 4, 1, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            self._insert_location_filter_photos(connection, now)
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(
+                    location_radius={
+                        "latitude": 37.7749,
+                        "longitude": -122.4194,
+                        "radius_km": 500,
+                    }
+                ),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert {item["photo_id"] for item in items} == {
+            "nearby-geotagged",
+            "nearby-other-camera",
+        }
+        assert total == 2
+
+    def test_location_radius_filter_composes_with_camera_make_using_and_semantics(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-location-radius-and-semantics.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 4, 1, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            self._insert_location_filter_photos(connection, now)
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(
+                    camera_make=["Apple"],
+                    location_radius={
+                        "latitude": 37.7749,
+                        "longitude": -122.4194,
+                        "radius_km": 15,
+                    },
+                ),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["nearby-geotagged"]
+        assert total == 1
+
+    def test_location_radius_filter_uses_spherical_distance_across_antimeridian(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-location-radius-antimeridian.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 4, 1, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "cross-dateline-nearby",
+                        "path": "photos/cross-dateline-nearby.jpg",
+                        "sha256": "i" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": "Apple",
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": 0.0,
+                        "gps_longitude": -179.9,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "cross-dateline-far",
+                        "path": "photos/cross-dateline-far.jpg",
+                        "sha256": "j" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": "Apple",
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": 0.0,
+                        "gps_longitude": -179.4,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(
+                    location_radius={
+                        "latitude": 0.0,
+                        "longitude": 179.9,
+                        "radius_km": 30,
+                    }
+                ),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["cross-dateline-nearby"]
+        assert total == 1
+
     def test_date_filter_from_only_includes_start_of_day_matches(self, tmp_path):
         database_url = f"sqlite:///{tmp_path / 'search-date-filter-from-only.db'}"
         upgrade_database(database_url)

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -416,6 +416,33 @@ class TestSearchServiceExecution:
         )
         mock_repo.get_filtered_photo_ids.assert_called_once_with(filters, None)
 
+    def test_given_location_radius_when_executing_search_then_passes_location_radius_to_repository(self):
+        mock_repo = Mock()
+        service = SearchService(repo=mock_repo)
+
+        mock_repo.search_photos.return_value = ([], 0, None)
+        mock_repo.get_filtered_photo_ids.return_value = []
+        mock_repo.compute_facets.return_value = {}
+
+        filters = SearchFilters(
+            location_radius={"latitude": 37.7749, "longitude": -122.4194, "radius_km": 25}
+        )
+        request = SearchRequest(
+            filters=filters,
+            sort=SortSpec(by="shot_ts", dir="desc"),
+            page=PageSpec(limit=50),
+        )
+
+        service.execute(request)
+
+        mock_repo.search_photos.assert_called_once_with(
+            filters=filters,
+            sort=request.sort,
+            page=request.page,
+            text_query=None,
+        )
+        mock_repo.get_filtered_photo_ids.assert_called_once_with(filters, None)
+
     def test_given_empty_results_when_executing_search_then_returns_empty_response_with_facets(self):
         """Given empty results, when executing search, then returns empty response with facets."""
         # Given

--- a/docs/superpowers/plans/2026-04-04-issue-37-location-proximity.md
+++ b/docs/superpowers/plans/2026-04-04-issue-37-location-proximity.md
@@ -1,0 +1,407 @@
+# Issue 37 Location Proximity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add coordinate-based proximity filtering to the search API with schema-level validation, a default `radius_km` of `50`, and repository filtering that excludes non-geotagged photos.
+
+**Architecture:** Extend the existing typed search request contract with a `location_radius` object and let Pydantic reject invalid inputs at the API boundary. Then update the repository query builder to compose a distance predicate with the current `AND` filter semantics, and lock the behavior with focused search tests before changing implementation.
+
+**Tech Stack:** FastAPI, Pydantic, SQLAlchemy, pytest, SQLite-backed repository tests
+
+---
+
+## File Map
+
+- Modify: `apps/api/app/schemas/search_request.py`
+  Responsibility: define the public search request contract and validation rules.
+- Modify: `apps/api/app/repositories/photos_repo.py`
+  Responsibility: build the search query and apply typed filters, including GPS radius filtering.
+- Modify: `apps/api/tests/test_search_service.py`
+  Responsibility: cover schema validation, service pass-through, and repository search behavior for the geo filter.
+
+### Task 1: Add the failing schema tests for `location_radius`
+
+**Files:**
+- Modify: `apps/api/tests/test_search_service.py`
+- Test: `apps/api/tests/test_search_service.py`
+
+- [ ] **Step 1: Write the failing tests for default radius and invalid input**
+
+```python
+class TestSearchRequestLocationRadiusValidation:
+    def test_location_radius_defaults_radius_km_to_50(self):
+        request = SearchRequest(
+            filters=SearchFilters(
+                location_radius={"latitude": 48.8566, "longitude": 2.3522}
+            )
+        )
+
+        assert request.filters.location_radius is not None
+        assert request.filters.location_radius.radius_km == 50
+
+    @pytest.mark.parametrize(
+        ("payload", "message"),
+        [
+            (
+                {"latitude": 120.0, "longitude": 2.3522, "radius_km": 10},
+                "latitude must be between -90 and 90",
+            ),
+            (
+                {"latitude": 48.8566, "longitude": 200.0, "radius_km": 10},
+                "longitude must be between -180 and 180",
+            ),
+            (
+                {"latitude": 48.8566, "longitude": 2.3522, "radius_km": 0},
+                "radius_km must be greater than 0",
+            ),
+        ],
+    )
+    def test_location_radius_rejects_invalid_values(self, payload, message):
+        with pytest.raises(ValueError, match=message):
+            SearchFilters(location_radius=payload)
+```
+
+- [ ] **Step 2: Run the new schema tests to verify they fail**
+
+Run: `uv run python -m pytest apps/api/tests/test_search_service.py -k location_radius_validation -q`
+Expected: FAIL because `SearchFilters` does not yet define `location_radius` or its validation rules.
+
+- [ ] **Step 3: Add the minimal schema types and validation**
+
+```python
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class LocationRadiusFilter(BaseModel):
+    latitude: float
+    longitude: float
+    radius_km: float = 50
+
+    @field_validator("latitude")
+    @classmethod
+    def validate_latitude(cls, value: float) -> float:
+        if not -90 <= value <= 90:
+            raise ValueError("latitude must be between -90 and 90")
+        return value
+
+    @field_validator("longitude")
+    @classmethod
+    def validate_longitude(cls, value: float) -> float:
+        if not -180 <= value <= 180:
+            raise ValueError("longitude must be between -180 and 180")
+        return value
+
+    @field_validator("radius_km")
+    @classmethod
+    def validate_radius(cls, value: float) -> float:
+        if value <= 0:
+            raise ValueError("radius_km must be greater than 0")
+        return value
+
+
+class SearchFilters(BaseModel):
+    date: Optional[DateFilter] = None
+    camera_make: Optional[List[str]] = None
+    extension: Optional[List[str]] = None
+    path_hints: Optional[List[str]] = None
+    orientation: Optional[List[str]] = None
+    filesize_range: Optional[FilesizeRange] = None
+    has_faces: Optional[bool] = None
+    tags: Optional[List[str]] = None
+    people: Optional[List[str]] = None
+    person_names: Optional[List[str]] = None
+    location_radius: Optional[LocationRadiusFilter] = None
+```
+
+- [ ] **Step 4: Run the schema tests to verify they pass**
+
+Run: `uv run python -m pytest apps/api/tests/test_search_service.py -k location_radius_validation -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit the schema validation checkpoint**
+
+```bash
+git add apps/api/app/schemas/search_request.py apps/api/tests/test_search_service.py
+git commit -m "feat(api): validate location radius search filters"
+```
+
+### Task 2: Add the failing service pass-through test
+
+**Files:**
+- Modify: `apps/api/tests/test_search_service.py`
+- Test: `apps/api/tests/test_search_service.py`
+
+- [ ] **Step 1: Write the failing service test that passes the typed geo filter through**
+
+```python
+def test_given_location_radius_when_executing_search_then_passes_filter_to_repository(self):
+    mock_repo = Mock()
+    service = SearchService(repo=mock_repo)
+
+    mock_repo.search_photos.return_value = ([], 0, None)
+    mock_repo.get_filtered_photo_ids.return_value = []
+    mock_repo.compute_facets.return_value = {}
+
+    filters = SearchFilters(
+        location_radius={"latitude": 48.8566, "longitude": 2.3522}
+    )
+    request = SearchRequest(filters=filters, sort=SortSpec(), page=PageSpec(limit=50))
+
+    service.execute(request)
+
+    mock_repo.search_photos.assert_called_once_with(
+        filters=filters,
+        sort=request.sort,
+        page=request.page,
+        text_query=None,
+    )
+    mock_repo.get_filtered_photo_ids.assert_called_once_with(filters, None)
+```
+
+- [ ] **Step 2: Run the pass-through test to verify it fails for the right reason**
+
+Run: `uv run python -m pytest apps/api/tests/test_search_service.py -k passes_filter_to_repository -q`
+Expected: FAIL before the schema work lands, or PASS immediately after Task 1 because no service changes are required.
+
+- [ ] **Step 3: Keep the implementation minimal**
+
+```python
+class SearchService:
+    def execute(self, req: SearchRequest) -> SearchResponse:
+        items, total, next_cursor = self.repo.search_photos(
+            filters=req.filters,
+            sort=req.sort,
+            page=req.page,
+            text_query=req.q,
+        )
+        filtered_photo_ids = self.repo.get_filtered_photo_ids(req.filters, req.q)
+        facets = self.repo.compute_facets(filtered_photo_ids)
+        return SearchResponse(
+            hits=Hits(total=total, items=[PhotoHit(**item) for item in items], cursor=next_cursor),
+            facets=facets,
+        )
+```
+
+- [ ] **Step 4: Run the pass-through test to confirm the current service still passes**
+
+Run: `uv run python -m pytest apps/api/tests/test_search_service.py -k passes_filter_to_repository -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit the test coverage checkpoint**
+
+```bash
+git add apps/api/tests/test_search_service.py
+git commit -m "test(api): cover location radius search service pass-through"
+```
+
+### Task 3: Add the failing repository behavior tests
+
+**Files:**
+- Modify: `apps/api/tests/test_search_service.py`
+- Test: `apps/api/tests/test_search_service.py`
+
+- [ ] **Step 1: Write failing repository tests for default radius, explicit radius, null GPS exclusion, and filter composition**
+
+```python
+def test_search_repository_filters_by_location_radius(self, tmp_path):
+    database_url = f"sqlite:///{tmp_path / 'search-location-radius.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 4, 4, tzinfo=UTC)
+
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos),
+            [
+                {
+                    "photo_id": "near-photo",
+                    "path": "travel/paris/near-photo.jpg",
+                    "sha256": "1" * 64,
+                    "phash": None,
+                    "filesize": 100,
+                    "ext": "jpg",
+                    "created_ts": now,
+                    "modified_ts": now,
+                    "shot_ts": now,
+                    "shot_ts_source": "exif",
+                    "camera_make": "Canon",
+                    "camera_model": None,
+                    "software": None,
+                    "orientation": None,
+                    "gps_latitude": 48.8570,
+                    "gps_longitude": 2.3500,
+                    "gps_altitude": None,
+                    "updated_ts": now,
+                    "deleted_ts": None,
+                    "faces_count": 0,
+                    "faces_detected_ts": None,
+                    "thumbnail_jpeg": None,
+                    "thumbnail_mime_type": None,
+                    "thumbnail_width": None,
+                    "thumbnail_height": None,
+                },
+                {
+                    "photo_id": "far-photo",
+                    "path": "travel/lyon/far-photo.jpg",
+                    "sha256": "2" * 64,
+                    "phash": None,
+                    "filesize": 100,
+                    "ext": "jpg",
+                    "created_ts": now,
+                    "modified_ts": now,
+                    "shot_ts": now,
+                    "shot_ts_source": "exif",
+                    "camera_make": "Canon",
+                    "camera_model": None,
+                    "software": None,
+                    "orientation": None,
+                    "gps_latitude": 45.7640,
+                    "gps_longitude": 4.8357,
+                    "gps_altitude": None,
+                    "updated_ts": now,
+                    "deleted_ts": None,
+                    "faces_count": 0,
+                    "faces_detected_ts": None,
+                    "thumbnail_jpeg": None,
+                    "thumbnail_mime_type": None,
+                    "thumbnail_width": None,
+                    "thumbnail_height": None,
+                },
+                {
+                    "photo_id": "no-gps-photo",
+                    "path": "travel/paris/no-gps-photo.jpg",
+                    "sha256": "3" * 64,
+                    "phash": None,
+                    "filesize": 100,
+                    "ext": "jpg",
+                    "created_ts": now,
+                    "modified_ts": now,
+                    "shot_ts": now,
+                    "shot_ts_source": "exif",
+                    "camera_make": "Canon",
+                    "camera_model": None,
+                    "software": None,
+                    "orientation": None,
+                    "gps_latitude": None,
+                    "gps_longitude": None,
+                    "gps_altitude": None,
+                    "updated_ts": now,
+                    "deleted_ts": None,
+                    "faces_count": 0,
+                    "faces_detected_ts": None,
+                    "thumbnail_jpeg": None,
+                    "thumbnail_mime_type": None,
+                    "thumbnail_width": None,
+                    "thumbnail_height": None,
+                },
+            ],
+        )
+
+    with Session(engine) as session:
+        repo = PhotosRepository(session)
+        items, total, _ = repo.search_photos(
+            filters=SearchFilters(
+                location_radius={"latitude": 48.8566, "longitude": 2.3522, "radius_km": 5}
+            ),
+            sort=SortSpec(by="shot_ts", dir="desc"),
+            page=PageSpec(limit=50),
+        )
+
+    assert total == 1
+    assert [item["photo_id"] for item in items] == ["near-photo"]
+```
+
+- [ ] **Step 2: Run the repository tests to verify they fail before implementation**
+
+Run: `uv run python -m pytest apps/api/tests/test_search_service.py -k location_radius -q`
+Expected: FAIL because the repository does not yet apply a geo-distance predicate.
+
+- [ ] **Step 3: Implement the minimal repository geo filter**
+
+```python
+from sqlalchemy import and_, func, or_, select
+
+
+EARTH_RADIUS_KM = 6371.0
+
+
+if filters.location_radius:
+    latitude = filters.location_radius.latitude
+    longitude = filters.location_radius.longitude
+    radius_km = filters.location_radius.radius_km
+    lat_radians = func.radians(self.photos.c.gps_latitude)
+    lon_radians = func.radians(self.photos.c.gps_longitude)
+    target_lat_radians = func.radians(latitude)
+    target_lon_radians = func.radians(longitude)
+
+    distance_km = EARTH_RADIUS_KM * func.acos(
+        func.min(
+            1.0,
+            func.max(
+                -1.0,
+                func.sin(lat_radians) * func.sin(target_lat_radians)
+                + func.cos(lat_radians)
+                * func.cos(target_lat_radians)
+                * func.cos(lon_radians - target_lon_radians),
+            ),
+        )
+    )
+
+    where_conditions.extend(
+        [
+            self.photos.c.gps_latitude.is_not(None),
+            self.photos.c.gps_longitude.is_not(None),
+            distance_km <= radius_km,
+        ]
+    )
+```
+
+- [ ] **Step 4: Run the repository tests to verify they pass**
+
+Run: `uv run python -m pytest apps/api/tests/test_search_service.py -k location_radius -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit the repository behavior checkpoint**
+
+```bash
+git add apps/api/app/repositories/photos_repo.py apps/api/tests/test_search_service.py
+git commit -m "feat(api): add location radius search filtering"
+```
+
+### Task 4: Run the relevant regression slice and finish
+
+**Files:**
+- Modify: `apps/api/app/schemas/search_request.py`
+- Modify: `apps/api/app/repositories/photos_repo.py`
+- Modify: `apps/api/tests/test_search_service.py`
+
+- [ ] **Step 1: Run the focused search suite**
+
+Run: `uv run python -m pytest apps/api/tests/test_search_service.py -q`
+Expected: PASS
+
+- [ ] **Step 2: Run the repo baseline check**
+
+Run: `make test`
+Expected: PASS with the existing schema, migration, ingest, and search-adjacent verification still green.
+
+- [ ] **Step 3: Inspect the final diff**
+
+Run: `git diff --stat HEAD~3..HEAD`
+Expected: shows the schema, repository, and search test updates only.
+
+- [ ] **Step 4: Create the final implementation commit if the work was squashed during execution**
+
+```bash
+git add apps/api/app/schemas/search_request.py apps/api/app/repositories/photos_repo.py apps/api/tests/test_search_service.py
+git commit -m "feat(api): implement location proximity search"
+```
+
+- [ ] **Step 5: Prepare branch handoff**
+
+```bash
+git status --short
+git log --oneline -5
+```
+
+Expected: clean working tree and a short, reviewable commit stack for issue `#37`.

--- a/docs/superpowers/specs/2026-04-04-issue-37-location-proximity-design.md
+++ b/docs/superpowers/specs/2026-04-04-issue-37-location-proximity-design.md
@@ -1,0 +1,112 @@
+# Issue 37 Design: Location Filtering And Proximity Search
+
+## Summary
+
+Issue #37 adds coordinate-based proximity filtering to the existing search API.
+The search contract will accept a typed `location_radius` filter with `latitude`, `longitude`, and an optional `radius_km`.
+If `radius_km` is omitted, the API defaults it to `50`.
+The API rejects invalid coordinates and non-positive radius values with clear validation errors.
+When a location filter is present, photos without GPS coordinates are excluded.
+
+## Goals
+
+- Support coordinate-based proximity search through the existing search request contract.
+- Keep the issue scoped to typed latitude/longitude input with an optional radius.
+- Exclude non-geotagged photos whenever a location filter is active.
+- Add automated coverage for request validation and repository filtering behavior.
+
+## Non-Goals
+
+- Place-name search such as "near Paris".
+- Geocoding or reverse geocoding.
+- Geographic region inference such as countries, cities, or landmarks.
+- Ranking or relevance changes beyond existing search sort behavior.
+- UI workflows for choosing coordinates.
+
+## Existing Context
+
+The current search stack already supports typed filters such as date, people, path hints, and camera make.
+The Phase 3 search scenario catalog already reserves `location_radius` and identifies coordinate-based proximity as the minimum viable geo predicate for Phase 3.
+The repository already stores canonical photo GPS fields on `photos.gps_latitude` and `photos.gps_longitude`, so the first delivery slice can stay within the current schema and repository surfaces.
+
+## Proposed Contract
+
+The existing `SearchFilters` model gains an optional `location_radius` field:
+
+```text
+filters:
+  location_radius:
+    latitude: <float>
+    longitude: <float>
+    radius_km: <float, optional, default 50>
+```
+
+Validation rules:
+
+- `latitude` is required when `location_radius` is present and must be between `-90` and `90`.
+- `longitude` is required when `location_radius` is present and must be between `-180` and `180`.
+- `radius_km` defaults to `50` when omitted.
+- `radius_km` must be greater than `0`.
+- Invalid payloads fail at the API schema boundary with helpful 422 validation messages.
+
+## Search Semantics
+
+When `location_radius` is present:
+
+- only photos with both `gps_latitude` and `gps_longitude` are eligible
+- distance is measured from the request coordinate to the photo coordinate
+- a photo matches when its computed distance is less than or equal to the requested radius
+- the location predicate composes with all other filters using the same `AND` semantics as the rest of the search contract
+
+The implementation should not silently approximate unsupported user intent.
+If the caller wants place-based search, that belongs to a future geocoding-oriented slice, not this issue.
+
+## Repository Design
+
+The repository implementation stays in the existing search query builder.
+`PhotosRepository._apply_filters()` should append a geo predicate only when `filters.location_radius` is present.
+
+The predicate should:
+
+- require non-null GPS coordinates on the photo row
+- compute spherical distance from the request point
+- compare the computed distance to the radius in kilometers
+
+For this slice, an inline SQL expression is sufficient.
+The design does not require a migration, PostGIS, or a new helper table.
+The query should remain portable across the project’s current database-backed test workflows.
+
+## Error Handling
+
+Invalid geo filters are request-contract failures, not repository-level soft failures.
+The API should surface those failures through the normal FastAPI and Pydantic validation response path so callers get actionable error details without ambiguous empty-result behavior.
+
+## Testing Strategy
+
+Add test coverage in the existing search test suite for:
+
+- accepting `location_radius` without `radius_km` and using the default radius
+- matching only photos within a requested explicit radius
+- excluding photos that have null GPS coordinates when the location filter is present
+- combining location filtering with another existing filter to confirm `AND` semantics
+- rejecting invalid latitude values
+- rejecting invalid longitude values
+- rejecting zero or negative `radius_km`
+
+The repository tests should continue to use the current temporary database fixture pattern already used by the search suite.
+
+## Documentation Impact
+
+Developer-facing documentation should be updated only where the search contract or verification examples need to mention coordinate-based filtering.
+No user-facing geocoding language should be introduced, because that would imply broader scope than this issue delivers.
+
+## Verification
+
+The implementation should be verified with focused automated tests for the search schema and repository behavior, plus the normal repo test slice used for search-related work.
+
+## Open Questions Resolved
+
+- Scope remains coordinate-based only.
+- Photos without GPS coordinates are excluded when the filter is present.
+- `radius_km` is optional and defaults to `50`.
+- Invalid input is rejected by the API with helpful validation errors.


### PR DESCRIPTION
## Summary
- add typed `location_radius` search filters with schema validation and a default `radius_km` of `50`
- implement spherical distance filtering in the photo search repository, excluding photos without GPS coordinates and preserving existing `AND` semantics
- add search service and repository coverage for location-radius filtering, including an antimeridian case

## Why
- delivers issue #37 as the coordinate-based proximity slice without adding geocoding or place-name scope
- gives the search API a validated location filter other search workflows can build on

## Test Plan
- [x] `uv run python -m pytest apps/api/tests/test_search_service.py -q`
- [x] `make test`

Closes #37