### PR TITLE
[codex] Implement deterministic pagination and stable sort semantics

### DIFF
--- a/apps/api/app/core/pagination.py
+++ b/apps/api/app/core/pagination.py
@@ -1,6 +1,6 @@
 import base64
 from datetime import datetime, timezone
-from typing import Tuple
+from typing import Optional, Tuple
 
 def iso_utc(dt: datetime) -> str:
     """ Convert datetime to ISO 8601 UTC string with 'Z' suffix. """
@@ -8,13 +8,19 @@ def iso_utc(dt: datetime) -> str:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
-def encode_cursor(ts: datetime, photo_id: str) -> str:
+NULL_CURSOR_TIMESTAMP = "null"
+
+
+def encode_cursor(ts: Optional[datetime], photo_id: str) -> str:
     """ Encode a cursor from timestamp and photo ID. """
-    payload = f"{iso_utc(ts)}|{photo_id}"
+    ts_part = NULL_CURSOR_TIMESTAMP if ts is None else iso_utc(ts)
+    payload = f"{ts_part}|{photo_id}"
     return base64.urlsafe_b64encode(payload.encode()).decode()
 
-def decode_cursor(cur: str) -> Tuple[datetime, str]:
+def decode_cursor(cur: str) -> Tuple[Optional[datetime], str]:
     """ Decode a cursor into timestamp and photo ID. """
     raw = base64.urlsafe_b64decode(cur.encode()).decode()
     ts_s, pid = raw.split("|", 1)
+    if ts_s == NULL_CURSOR_TIMESTAMP:
+        return None, pid
     return datetime.fromisoformat(ts_s.replace("Z", "+00:00")), pid

--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -133,11 +133,7 @@ class PhotosRepository:
 
     def list_photos(self) -> List[Dict[str, Any]]:
         """Return catalog photos in a deterministic browse order."""
-        query = select(self.photos).order_by(
-            self.photos.c.shot_ts.is_(None),
-            self.photos.c.shot_ts.desc(),
-            self.photos.c.photo_id.desc(),
-        )
+        query = select(self.photos).order_by(*self._sorting_clauses(SortSpec()))
         rows = [row for row in self.db.execute(query).all() if row.deleted_ts is None]
         return self._hydrate_items(rows)
 
@@ -321,37 +317,15 @@ class PhotosRepository:
 
     def _apply_sorting(self, query: Select, sort: SortSpec) -> Select:
         """Apply sorting to the query."""
-        if sort.by == "shot_ts":
-            if sort.dir == "desc":
-                return query.order_by(self.photos.c.shot_ts.desc(), self.photos.c.photo_id.desc())
-            else:
-                return query.order_by(self.photos.c.shot_ts.asc(), self.photos.c.photo_id.asc())
-        elif sort.by == "relevance":
-            # For now, fallback to shot_ts sorting
-            # TODO: Implement actual relevance scoring
-            return query.order_by(self.photos.c.shot_ts.desc(), self.photos.c.photo_id.desc())
-        else:
-            return query.order_by(self.photos.c.shot_ts.desc(), self.photos.c.photo_id.desc())
+        return query.order_by(*self._sorting_clauses(sort))
 
     def _apply_pagination(self, query: Select, page: PageSpec, sort: SortSpec) -> Select:
         """Apply pagination to the query."""
         if page.cursor:
             from app.core.pagination import decode_cursor
             last_ts, last_pid = decode_cursor(page.cursor)
-            
-            # Cursor conditions depend on sort direction
-            if sort.dir == "desc":
-                # For descending: next page has timestamps < last_ts
-                query = query.where(or_(
-                    self.photos.c.shot_ts < last_ts,
-                    and_(self.photos.c.shot_ts == last_ts, self.photos.c.photo_id < last_pid)
-                ))
-            else:  # asc
-                # For ascending: next page has timestamps > last_ts
-                query = query.where(or_(
-                    self.photos.c.shot_ts > last_ts,
-                    and_(self.photos.c.shot_ts == last_ts, self.photos.c.photo_id > last_pid)
-                ))
+
+            query = query.where(self._cursor_boundary_clause(last_ts, last_pid, sort))
         
         limit = page.limit or 50
         return query.limit(limit)
@@ -372,11 +346,41 @@ class PhotosRepository:
         
         # Convert ISO string back to datetime for cursor encoding
         shot_ts_str = last_item["shot_ts"]
-        if shot_ts_str is None:
-            return None
-        shot_ts_dt = datetime.fromisoformat(shot_ts_str.replace("Z", "+00:00"))
+        shot_ts_dt = None if shot_ts_str is None else datetime.fromisoformat(shot_ts_str.replace("Z", "+00:00"))
         
         return encode_cursor(shot_ts_dt, last_item["photo_id"])
+
+    def _sorting_clauses(self, sort: SortSpec):
+        """Return a deterministic sort order with null timestamps last."""
+        direction = sort.dir if sort.by in {"shot_ts", "relevance"} else "desc"
+        shot_ts_order = self.photos.c.shot_ts.desc() if direction == "desc" else self.photos.c.shot_ts.asc()
+        photo_id_order = self.photos.c.photo_id.desc() if direction == "desc" else self.photos.c.photo_id.asc()
+        return (
+            self.photos.c.shot_ts.is_(None),
+            shot_ts_order,
+            photo_id_order,
+        )
+
+    def _cursor_boundary_clause(self, last_ts: Optional[datetime], last_pid: str, sort: SortSpec):
+        """Return the strict boundary for the next page in the current sort order."""
+        direction = sort.dir if sort.by in {"shot_ts", "relevance"} else "desc"
+
+        if last_ts is None:
+            pid_clause = self.photos.c.photo_id < last_pid if direction == "desc" else self.photos.c.photo_id > last_pid
+            return and_(self.photos.c.shot_ts.is_(None), pid_clause)
+
+        ts_clause = self.photos.c.shot_ts < last_ts if direction == "desc" else self.photos.c.shot_ts > last_ts
+        pid_clause = self.photos.c.photo_id < last_pid if direction == "desc" else self.photos.c.photo_id > last_pid
+        return or_(
+            and_(
+                self.photos.c.shot_ts.is_not(None),
+                or_(
+                    ts_clause,
+                    and_(self.photos.c.shot_ts == last_ts, pid_clause),
+                ),
+            ),
+            self.photos.c.shot_ts.is_(None),
+        )
 
     def _hydrate_items(self, rows: List[Row], *, include_face_regions: bool = False) -> List[Dict[str, Any]]:
         """Hydrate photo rows with related data (tags, people, faces)."""
@@ -501,26 +505,6 @@ class PhotosRepository:
                 "last_failure_reason": reason,
             }
         return availability
-
-    # Legacy methods for backward compatibility (can be removed after refactoring)
-    def select_hits(self, sel, order_desc, limit: int, cursor: str | None) -> List[Row]:
-        """Legacy method - deprecated, use search_photos instead."""
-        from app.core.pagination import decode_cursor
-        sel = sel.order_by(*order_desc)
-        if cursor:
-            last_ts, last_pid = decode_cursor(cursor)
-            sel = sel.where(or_(self.photos.c.shot_ts < last_ts,
-                                and_(self.photos.c.shot_ts == last_ts,
-                                     self.photos.c.photo_id < last_pid)))
-        return list(self.db.execute(sel.limit(limit)).all())
-
-    def count_total(self, sel) -> int:
-        """Legacy method - deprecated, use search_photos instead."""
-        return int(self.db.execute(select(func.count()).select_from(sel.subquery())).scalar_one())
-
-    def hydrate_items(self, rows: List[Row]) -> List[Dict[str, Any]]:
-        """Legacy method - deprecated, use search_photos instead."""
-        return self._hydrate_items(rows)
 
     def compute_facets(self, filtered_photo_ids: List[str]) -> Dict[str, Any]:
         """Compute facets for the filtered photo set."""

--- a/apps/api/tests/test_pagination.py
+++ b/apps/api/tests/test_pagination.py
@@ -159,6 +159,23 @@ class TestEncodeCursor:
         assert decoded_dt == expected_dt
         assert decoded_id == photo_id
 
+    def test_given_null_timestamp_when_encoding_then_preserves_null_boundary(self):
+        """
+        Given: A null timestamp
+        When: Encoding as cursor
+        Then: Decoded timestamp remains null and the photo ID is preserved
+        """
+        # Given
+        photo_id = "photo123"
+
+        # When
+        result = encode_cursor(None, photo_id)
+
+        # Then
+        decoded_dt, decoded_id = decode_cursor(result)
+        assert decoded_dt is None
+        assert decoded_id == photo_id
+
 
 class TestDecodeCursor:
     def test_given_valid_encoded_cursor_when_decoding_then_returns_original_datetime_and_photo_id(self):

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -741,6 +741,228 @@ class TestPhotosRepositorySoftDeleteFiltering:
         assert total == 1
         assert cursor is not None
 
+    def test_search_repository_pages_deterministically_across_duplicate_and_null_timestamps(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-stable-pagination.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        shared_ts = datetime(2026, 3, 24, 12, 0, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "photo-b",
+                        "path": "photos/photo-b.jpg",
+                        "sha256": "e" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": shared_ts,
+                        "modified_ts": shared_ts,
+                        "shot_ts": shared_ts,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": shared_ts,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "photo-a",
+                        "path": "photos/photo-a.jpg",
+                        "sha256": "f" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": shared_ts,
+                        "modified_ts": shared_ts,
+                        "shot_ts": shared_ts,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": shared_ts,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "photo-d",
+                        "path": "photos/photo-d.jpg",
+                        "sha256": "1" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": shared_ts,
+                        "modified_ts": shared_ts,
+                        "shot_ts": None,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": shared_ts,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "photo-c",
+                        "path": "photos/photo-c.jpg",
+                        "sha256": "2" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": shared_ts,
+                        "modified_ts": shared_ts,
+                        "shot_ts": None,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": shared_ts,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            first_page, total, first_cursor = repo.search_photos(
+                filters=SearchFilters(),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=1),
+            )
+            second_page, _, second_cursor = repo.search_photos(
+                filters=SearchFilters(),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=1, cursor=first_cursor),
+            )
+            third_page, _, third_cursor = repo.search_photos(
+                filters=SearchFilters(),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=1, cursor=second_cursor),
+            )
+            fourth_page, _, fourth_cursor = repo.search_photos(
+                filters=SearchFilters(),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=1, cursor=third_cursor),
+            )
+            fifth_page, _, fifth_cursor = repo.search_photos(
+                filters=SearchFilters(),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=1, cursor=fourth_cursor),
+            )
+
+        assert total == 4
+        assert [item["photo_id"] for item in first_page] == ["photo-b"]
+        assert [item["photo_id"] for item in second_page] == ["photo-a"]
+        assert [item["photo_id"] for item in third_page] == ["photo-d"]
+        assert [item["photo_id"] for item in fourth_page] == ["photo-c"]
+        assert first_cursor is not None
+        assert second_cursor is not None
+        assert third_cursor is not None
+        assert fourth_cursor is not None
+        assert fifth_page == []
+        assert fifth_cursor is None
+
+    def test_search_repository_uses_requested_direction_for_relevance_sorting(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-relevance-sort.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        shared_ts = datetime(2026, 3, 24, 12, 0, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "photo-b",
+                        "path": "photos/photo-b.jpg",
+                        "sha256": "3" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": shared_ts,
+                        "modified_ts": shared_ts,
+                        "shot_ts": shared_ts,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": shared_ts,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "photo-a",
+                        "path": "photos/photo-a.jpg",
+                        "sha256": "4" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": shared_ts,
+                        "modified_ts": shared_ts,
+                        "shot_ts": shared_ts,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": shared_ts,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            first_page, _, first_cursor = repo.search_photos(
+                filters=SearchFilters(),
+                sort=SortSpec(by="relevance", dir="asc"),
+                page=PageSpec(limit=1),
+            )
+            second_page, _, second_cursor = repo.search_photos(
+                filters=SearchFilters(),
+                sort=SortSpec(by="relevance", dir="asc"),
+                page=PageSpec(limit=1, cursor=first_cursor),
+            )
+
+        assert [item["photo_id"] for item in first_page] == ["photo-a"]
+        assert [item["photo_id"] for item in second_page] == ["photo-b"]
+        assert first_cursor is not None
+        assert second_cursor is not None
+
     def test_get_filtered_photo_ids_excludes_soft_deleted_photos(self, tmp_path):
         database_url = f"sqlite:///{tmp_path / 'search-filtered-ids.db'}"
         upgrade_database(database_url)


### PR DESCRIPTION
## Summary
- implement deterministic pagination and stable sort semantics for photo search results
- make cursor encoding and repository pagination logic handle duplicate and null timestamps deterministically
- remove the unused legacy pagination compatibility path from the repository

## Why
This closes the search pagination gap tracked in #39 and makes paging behavior stable for downstream consumers.

## Validation
- `uv run --group test python -m pytest apps/api/tests/test_pagination.py apps/api/tests/test_search_service.py -q`
- `uv run --group test python -m pytest apps/api/tests/test_pagination.py apps/api/tests/test_search_service.py -k 'pagination or deterministic or relevance'`

Closes #39