### PR TITLE
[codex] Add deployment-facing compose API e2e coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ Examples:
 - `PHOTO_ORG_ENVIRONMENT=<name> make compose-down` stops and removes that environment's local Compose stack while preserving the named Postgres volume for persistent environments
 - `PHOTO_ORG_ENVIRONMENT=<name> make compose-down-volumes` stops and removes that environment's local Compose stack and deletes the named Postgres volume for persistent environments
 - `PHOTO_ORG_ENVIRONMENT=<name> make compose-smoke` brings the stack up, enqueues the checked-in seed corpus through the host CLI, processes the queue through the db-service endpoint, and tears the stack back down using the environment's registered storage mode
-- `make compose-e2e-smoke` creates a random ephemeral environment, runs `compose-smoke`, runs `make test-e2e` with `PHOTO_ORG_E2E_DATABASE_URL` pointed at that environment's Compose database, and removes the environment plus its registry file on exit
+- `make compose-e2e-smoke` creates a random ephemeral environment, runs `compose-smoke`, runs `make test-e2e` with `PHOTO_ORG_E2E_DATABASE_URL` pointed at that environment's Compose database and `PHOTO_ORG_E2E_API_BASE_URL` pointed at that environment's Compose API, and removes the environment plus its registry file on exit
 
 At environment creation time, the selected environment derives and records its own Compose project name plus host Postgres and API ports from `PHOTO_ORG_ENVIRONMENT`.
 If you need to override those defaults, provide `PHOTO_ORG_POSTGRES_HOST_PORT`, `PHOTO_ORG_API_HOST_PORT`, `PHOTO_ORG_DB_SERVICE_DATABASE_URL`, and `PHOTO_ORG_COMPOSE_DATABASE_URL` when running `make env-create`.

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ export PHOTO_ORG_API_HOST_PORT
 export PHOTO_ORG_DB_SERVICE_DATABASE_URL
 export PHOTO_ORG_COMPOSE_DATABASE_URL
 
-.PHONY: help sync lint test test-all test-e2e check pre-push migrate env-create compose-up compose-migrate compose-down compose-down-volumes compose-smoke compose-e2e-smoke print-compose-db-url seed-corpus-check seed-corpus-load ensure-environment
+.PHONY: help sync lint test test-all test-e2e check pre-push migrate env-create compose-up compose-migrate compose-down compose-down-volumes compose-smoke compose-e2e-smoke print-compose-db-url print-compose-api-base-url seed-corpus-check seed-corpus-load ensure-environment
 
 help:
 	@printf '%s\n' \
@@ -160,12 +160,21 @@ compose-smoke: ensure-environment
 		fi; \
 		sleep 1; \
 	done; \
-	./scripts/photo-org seed-corpus load --database-url "$(PHOTO_ORG_COMPOSE_DATABASE_URL)"; \
-	processed="$$( $(COMPOSE_STACK) exec -T db-service python -c "import json, urllib.request; req = urllib.request.Request('http://localhost:8000/api/v1/internal/ingest-queue/process', data=b'{\"limit\": 1000}', headers={'Content-Type': 'application/json', 'X-Worker-Role': 'ingest-processor'}); print(json.load(urllib.request.urlopen(req))['processed'])" )"; \
-	printf 'processed=%s\n' "$$processed"
+	until python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:$(PHOTO_ORG_API_HOST_PORT)/healthz').read()" >/dev/null 2>&1; do \
+		sleep 1; \
+	done; \
+	./scripts/photo-org seed-corpus validate >/dev/null; \
+	$(COMPOSE_STACK) exec -T db-service python -c "from app.processing.ingest import ingest_directory; result = ingest_directory('/photos'); print(f'scanned={result.scanned}'); print(f'enqueued={result.enqueued}')" ; \
+	process_json="$$( $(COMPOSE_STACK) exec -T db-service python -c "import json, urllib.request; req = urllib.request.Request('http://localhost:8000/api/v1/internal/ingest-queue/process', data=b'{\"limit\": 1000}', headers={'Content-Type': 'application/json', 'X-Worker-Role': 'ingest-processor'}); print(json.dumps(json.load(urllib.request.urlopen(req))))" )"; \
+	python3 -c 'import json, sys; result = json.loads(sys.argv[1]); print("processed=%s" % result["processed"]); print("failed=%s" % result["failed"]); print("retryable_errors=%s" % result["retryable_errors"]); raise SystemExit(1 if result["failed"] or result["retryable_errors"] else 0)' "$$process_json"; \
+	face_counts="$$( $(COMPOSE_STACK) exec -T db-service python -c "from sqlalchemy import func, select; from app.db.session import create_db_engine; from app.storage import faces, photos; engine = create_db_engine(); connection = engine.connect(); detected = connection.execute(select(func.count()).select_from(photos).where(photos.c.faces_detected_ts.is_not(None))).scalar_one(); face_rows = connection.execute(select(func.count()).select_from(faces)).scalar_one(); connection.close(); print(f'faces_detected={detected}'); print(f'face_rows={face_rows}'); raise SystemExit(0 if detected > 0 and face_rows > 0 else 1)" )"; \
+	printf '%s\n' "$$face_counts"
 
 print-compose-db-url:
 	@printf '%s\n' "$(PHOTO_ORG_COMPOSE_DATABASE_URL)"
+
+print-compose-api-base-url:
+	@printf '%s\n' "http://127.0.0.1:$(PHOTO_ORG_API_HOST_PORT)"
 
 compose-e2e-smoke:
 	@set -eu; \
@@ -181,7 +190,8 @@ compose-e2e-smoke:
 	cd "$(CURDIR)" && env -u PHOTO_ORG_ENVIRONMENT -u PHOTO_ORG_ENV_STORAGE_MODE -u PHOTO_ORG_ENV_REGISTRY_FILE -u PHOTO_ORG_COMPOSE_PROJECT_NAME -u PHOTO_ORG_POSTGRES_HOST_PORT -u PHOTO_ORG_API_HOST_PORT -u PHOTO_ORG_DB_SERVICE_DATABASE_URL -u PHOTO_ORG_COMPOSE_DATABASE_URL $(MAKE) --no-print-directory env-create PHOTO_ORG_ENVIRONMENT="$$env_name" PHOTO_ORG_ENV_STORAGE_MODE=ephemeral PHOTO_ORG_ENV_REGISTRY_DIR="$(PHOTO_ORG_ENV_REGISTRY_DIR)"; \
 	cd "$(CURDIR)" && env -u PHOTO_ORG_ENVIRONMENT -u PHOTO_ORG_ENV_STORAGE_MODE -u PHOTO_ORG_ENV_REGISTRY_FILE -u PHOTO_ORG_COMPOSE_PROJECT_NAME -u PHOTO_ORG_POSTGRES_HOST_PORT -u PHOTO_ORG_API_HOST_PORT -u PHOTO_ORG_DB_SERVICE_DATABASE_URL -u PHOTO_ORG_COMPOSE_DATABASE_URL $(MAKE) --no-print-directory compose-smoke PHOTO_ORG_ENVIRONMENT="$$env_name" PHOTO_ORG_ENV_REGISTRY_DIR="$(PHOTO_ORG_ENV_REGISTRY_DIR)" PHOTO_ORG_COMPOSE_SMOKE_KEEP_RUNNING=1; \
 	database_url="$$( cd "$(CURDIR)" && env -u PHOTO_ORG_ENVIRONMENT -u PHOTO_ORG_ENV_STORAGE_MODE -u PHOTO_ORG_ENV_REGISTRY_FILE -u PHOTO_ORG_COMPOSE_PROJECT_NAME -u PHOTO_ORG_POSTGRES_HOST_PORT -u PHOTO_ORG_API_HOST_PORT -u PHOTO_ORG_DB_SERVICE_DATABASE_URL -u PHOTO_ORG_COMPOSE_DATABASE_URL $(MAKE) --no-print-directory -s print-compose-db-url PHOTO_ORG_ENVIRONMENT="$$env_name" PHOTO_ORG_ENV_REGISTRY_DIR="$(PHOTO_ORG_ENV_REGISTRY_DIR)" )"; \
-	cd "$(CURDIR)" && PHOTO_ORG_E2E_DATABASE_URL="$$database_url" env -u PHOTO_ORG_ENVIRONMENT -u PHOTO_ORG_ENV_STORAGE_MODE -u PHOTO_ORG_ENV_REGISTRY_FILE -u PHOTO_ORG_COMPOSE_PROJECT_NAME -u PHOTO_ORG_POSTGRES_HOST_PORT -u PHOTO_ORG_API_HOST_PORT -u PHOTO_ORG_DB_SERVICE_DATABASE_URL -u PHOTO_ORG_COMPOSE_DATABASE_URL $(MAKE) --no-print-directory test-e2e PHOTO_ORG_ENVIRONMENT="$$env_name" PHOTO_ORG_ENV_REGISTRY_DIR="$(PHOTO_ORG_ENV_REGISTRY_DIR)"
+	api_base_url="$$( cd "$(CURDIR)" && env -u PHOTO_ORG_ENVIRONMENT -u PHOTO_ORG_ENV_STORAGE_MODE -u PHOTO_ORG_ENV_REGISTRY_FILE -u PHOTO_ORG_COMPOSE_PROJECT_NAME -u PHOTO_ORG_POSTGRES_HOST_PORT -u PHOTO_ORG_API_HOST_PORT -u PHOTO_ORG_DB_SERVICE_DATABASE_URL -u PHOTO_ORG_COMPOSE_DATABASE_URL $(MAKE) --no-print-directory -s print-compose-api-base-url PHOTO_ORG_ENVIRONMENT="$$env_name" PHOTO_ORG_ENV_REGISTRY_DIR="$(PHOTO_ORG_ENV_REGISTRY_DIR)" )"; \
+	cd "$(CURDIR)" && PHOTO_ORG_E2E_DATABASE_URL="$$database_url" PHOTO_ORG_E2E_API_BASE_URL="$$api_base_url" env -u PHOTO_ORG_ENVIRONMENT -u PHOTO_ORG_ENV_STORAGE_MODE -u PHOTO_ORG_ENV_REGISTRY_FILE -u PHOTO_ORG_COMPOSE_PROJECT_NAME -u PHOTO_ORG_POSTGRES_HOST_PORT -u PHOTO_ORG_API_HOST_PORT -u PHOTO_ORG_DB_SERVICE_DATABASE_URL -u PHOTO_ORG_COMPOSE_DATABASE_URL $(MAKE) --no-print-directory test-e2e PHOTO_ORG_ENVIRONMENT="$$env_name" PHOTO_ORG_ENV_REGISTRY_DIR="$(PHOTO_ORG_ENV_REGISTRY_DIR)"
 
 seed-corpus-check:
 	./scripts/photo-org seed-corpus validate

--- a/apps/e2e/tests/conftest.py
+++ b/apps/e2e/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import sys
 from pathlib import Path
 
+import httpx
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "api"))
@@ -16,3 +17,17 @@ def seed_corpus_database_url(tmp_path, monkeypatch):
     app.dependency_overrides.clear()
     yield database_url
     app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def seed_corpus_api_base_url() -> str | None:
+    return os.getenv("PHOTO_ORG_E2E_API_BASE_URL")
+
+
+@pytest.fixture
+def deployment_api_client(seed_corpus_api_base_url: str | None):
+    if not seed_corpus_api_base_url:
+        pytest.skip("deployment-facing API tests require PHOTO_ORG_E2E_API_BASE_URL")
+
+    with httpx.Client(base_url=seed_corpus_api_base_url, timeout=30.0) as client:
+        yield client

--- a/apps/e2e/tests/test_compose_smoke.py
+++ b/apps/e2e/tests/test_compose_smoke.py
@@ -156,8 +156,13 @@ def test_makefile_documents_compose_smoke_workflow():
     assert "compose-smoke:" in makefile
     assert "compose-e2e-smoke:" in makefile
     assert "compose.ephemeral.yaml" in makefile
-    assert "./scripts/photo-org seed-corpus load" in makefile
+    assert "./scripts/photo-org seed-corpus validate" in makefile
+    assert "ingest_directory('/photos')" in makefile
+    assert "http://127.0.0.1:$(PHOTO_ORG_API_HOST_PORT)/healthz" in makefile
     assert "/api/v1/internal/ingest-queue/process" in makefile
+    assert 'print("retryable_errors=%s" % result["retryable_errors"])' in makefile
+    assert "faces_detected=" in makefile
+    assert "face_rows=" in makefile
     assert "make test-e2e" in makefile
     assert "compose-down-volumes" in makefile
     assert "compose-smoke" in contributing
@@ -173,6 +178,7 @@ def test_makefile_compose_e2e_smoke_generates_its_own_environment():
     assert "test-e2e PHOTO_ORG_ENVIRONMENT=" in makefile
     assert "compose-down-volumes PHOTO_ORG_ENVIRONMENT=" in makefile
     assert "PHOTO_ORG_E2E_DATABASE_URL=" in makefile
+    assert "PHOTO_ORG_E2E_API_BASE_URL=" in makefile
 
 
 def test_makefile_compose_e2e_smoke_reanchors_nested_make_calls_to_repo_root():

--- a/apps/e2e/tests/test_deployment_api_surface.py
+++ b/apps/e2e/tests/test_deployment_api_surface.py
@@ -1,0 +1,96 @@
+import yaml
+from sqlalchemy import func, select
+
+from app.db.session import create_db_engine
+from app.storage import faces, photos
+
+
+def test_deployment_photo_listing_matches_seed_corpus(
+    seed_corpus_database_url,
+    deployment_api_client,
+):
+    engine = create_db_engine(seed_corpus_database_url)
+    with engine.connect() as connection:
+        expected_listing_count = connection.execute(
+            select(func.count())
+            .select_from(photos)
+            .where(photos.c.deleted_ts.is_(None))
+        ).scalar_one()
+        photo_with_face_regions = connection.execute(
+            select(photos.c.photo_id)
+            .select_from(photos.join(faces, photos.c.photo_id == faces.c.photo_id))
+            .where(photos.c.deleted_ts.is_(None))
+            .where(photos.c.faces_detected_ts.is_not(None))
+            .order_by(photos.c.shot_ts.desc(), photos.c.photo_id.desc())
+            .limit(1)
+        ).scalar_one()
+
+    listing_response = deployment_api_client.get("/api/v1/photos")
+
+    assert listing_response.status_code == 200
+    listing_payload = listing_response.json()
+    assert len(listing_payload) == expected_listing_count
+    assert any(row["photo_id"] == photo_with_face_regions for row in listing_payload)
+
+    shot_timestamps = [row["shot_ts"] for row in listing_payload]
+    non_null_shot_timestamps = [value for value in shot_timestamps if value is not None]
+    assert non_null_shot_timestamps == sorted(non_null_shot_timestamps, reverse=True)
+    if None in shot_timestamps:
+        first_null_index = shot_timestamps.index(None)
+        assert all(value is None for value in shot_timestamps[first_null_index:])
+
+
+def test_deployment_photo_detail_matches_seed_corpus(
+    seed_corpus_database_url,
+    deployment_api_client,
+):
+    engine = create_db_engine(seed_corpus_database_url)
+    with engine.connect() as connection:
+        photo_with_face_regions = connection.execute(
+            select(photos.c.photo_id)
+            .select_from(photos.join(faces, photos.c.photo_id == faces.c.photo_id))
+            .where(photos.c.deleted_ts.is_(None))
+            .where(photos.c.faces_detected_ts.is_not(None))
+            .order_by(photos.c.shot_ts.desc(), photos.c.photo_id.desc())
+            .limit(1)
+        ).scalar_one()
+
+    detail_response = deployment_api_client.get(f"/api/v1/photos/{photo_with_face_regions}")
+
+    assert detail_response.status_code == 200
+    detail_payload = detail_response.json()
+    assert detail_payload["photo_id"] == photo_with_face_regions
+    assert detail_payload["metadata"]["sha256"]
+    assert detail_payload["metadata"]["faces_count"] >= 1
+    assert detail_payload["faces"]
+    assert all(face["bbox_x"] is not None for face in detail_payload["faces"])
+    assert all(face["bbox_y"] is not None for face in detail_payload["faces"])
+    assert all(face["bbox_w"] is not None for face in detail_payload["faces"])
+    assert all(face["bbox_h"] is not None for face in detail_payload["faces"])
+
+
+def test_deployment_openapi_json_and_yaml_match(deployment_api_client):
+    json_response = deployment_api_client.get("/openapi.json")
+    yaml_response = deployment_api_client.get("/openapi.yaml")
+
+    assert json_response.status_code == 200
+    assert yaml_response.status_code == 200
+    assert "application/json" in json_response.headers["content-type"]
+    assert "application/yaml" in yaml_response.headers["content-type"]
+
+    json_payload = json_response.json()
+    yaml_payload = yaml.safe_load(yaml_response.text)
+
+    assert json_payload == yaml_payload
+    assert json_payload["info"]["title"] == "Photo Organizer API"
+    assert "/api/v1/photos" in json_payload["paths"]
+    assert "/api/v1/photos/{photo_id}" in json_payload["paths"]
+
+
+def test_deployment_docs_surface_is_served(deployment_api_client):
+    docs_response = deployment_api_client.get("/docs")
+
+    assert docs_response.status_code == 200
+    assert "text/html" in docs_response.headers["content-type"]
+    assert "Swagger UI" in docs_response.text
+    assert "/openapi.json" in docs_response.text

--- a/apps/e2e/tests/test_e2e_config.py
+++ b/apps/e2e/tests/test_e2e_config.py
@@ -1,6 +1,6 @@
 import pytest
 
-from conftest import seed_corpus_database_url
+from conftest import seed_corpus_api_base_url, seed_corpus_database_url
 
 
 def test_seed_corpus_database_url_prefers_existing_database_url_env(monkeypatch, tmp_path):
@@ -15,3 +15,12 @@ def test_seed_corpus_database_url_prefers_existing_database_url_env(monkeypatch,
     finally:
         with pytest.raises(StopIteration):
             next(generator)
+
+
+def test_seed_corpus_api_base_url_prefers_existing_api_base_url_env(monkeypatch):
+    expected = "http://localhost:55123"
+    monkeypatch.setenv("PHOTO_ORG_E2E_API_BASE_URL", expected)
+
+    fixture = seed_corpus_api_base_url.__wrapped__
+
+    assert fixture() == expected

--- a/apps/e2e/tests/test_seed_corpus_workflow.py
+++ b/apps/e2e/tests/test_seed_corpus_workflow.py
@@ -1,4 +1,7 @@
+import os
+
 from fastapi.testclient import TestClient
+import pytest
 from sqlalchemy import func, select
 
 from app.dev.seed_corpus import load_seed_corpus_into_database, validate_seed_corpus
@@ -40,6 +43,9 @@ def _load_seed_corpus(seed_corpus_database_url):
 
 
 def test_seed_corpus_can_be_ingested_and_persisted_end_to_end(seed_corpus_database_url):
+    if os.getenv("PHOTO_ORG_E2E_API_BASE_URL"):
+        pytest.skip("local ingest verification is skipped when using a preloaded Compose environment")
+
     report, engine, initial_photo_count, initial_detected_photo_count, processed = _load_seed_corpus(
         seed_corpus_database_url
     )
@@ -72,6 +78,9 @@ def test_seed_corpus_can_be_ingested_and_persisted_end_to_end(seed_corpus_databa
 
 
 def test_seed_corpus_read_endpoints_reflect_ingested_catalog(seed_corpus_database_url):
+    if os.getenv("PHOTO_ORG_E2E_API_BASE_URL"):
+        pytest.skip("local read-endpoint ingest verification is skipped for Compose-backed runs")
+
     report, engine, _, _, _ = _load_seed_corpus(seed_corpus_database_url)
 
     with engine.connect() as connection:


### PR DESCRIPTION
## Summary

Extends the pytest e2e suite to verify the real HTTP surface exposed by the Compose API using `httpx`, and updates the Compose smoke workflow so seed-corpus face detection is exercised from inside the container before the deployment-facing tests run.

Closes #119.

## What Changed

- added `PHOTO_ORG_E2E_API_BASE_URL` plumbing and an `httpx` deployment client fixture for e2e tests
- added deployment-facing assertions for:
  - `GET /api/v1/photos`
  - representative photo detail
  - `GET /openapi.json`
  - `GET /openapi.yaml`
  - `GET /docs`
- updated `compose-smoke` to:
  - wait for the host-exposed API surface
  - ingest the seed corpus from inside `db-service` using `/photos`
  - fail on queue `failed` or `retryable_errors`
  - assert persisted face-detection results before handing off to pytest
- skipped the local re-ingest e2e tests when pytest is pointed at a preloaded Compose environment
- documented the new Compose e2e API base URL wiring

## Root Cause

The previous Compose smoke path loaded the seed corpus from the host CLI, which queued host filesystem paths. Queue processing then ran inside the container, where face detection could not resolve those host paths, so the smoke flow could report successful processing without actually persisting face detections. The deployment-facing suite also lacked a real HTTP base URL and therefore could not verify the published Compose API surface.

## Validation

- `uv run python -m pytest apps/e2e/tests -q`
- `make compose-e2e-smoke`