### PR TITLE
[codex] Improve watched-folder polling with chunked durable runs

### DIFF
--- a/apps/api/app/db/ingest_runs.py
+++ b/apps/api/app/db/ingest_runs.py
@@ -28,7 +28,6 @@ class IngestRunStore:
         self,
         *,
         watched_folder_id: str | None = None,
-        started_ts: datetime | None = None,
         connection: Connection | None = None,
     ) -> str:
         ingest_run_id = str(uuid4())
@@ -37,8 +36,6 @@ class IngestRunStore:
             "watched_folder_id": watched_folder_id,
             "status": "processing",
         }
-        if started_ts is not None:
-            values["started_ts"] = started_ts
         if connection is not None:
             connection.execute(ingest_runs.insert().values(**values))
             return ingest_run_id

--- a/apps/api/app/db/ingest_runs.py
+++ b/apps/api/app/db/ingest_runs.py
@@ -28,6 +28,7 @@ class IngestRunStore:
         self,
         *,
         watched_folder_id: str | None = None,
+        started_ts: datetime | None = None,
         connection: Connection | None = None,
     ) -> str:
         ingest_run_id = str(uuid4())
@@ -36,6 +37,8 @@ class IngestRunStore:
             "watched_folder_id": watched_folder_id,
             "status": "processing",
         }
+        if started_ts is not None:
+            values["started_ts"] = started_ts
         if connection is not None:
             connection.execute(ingest_runs.insert().values(**values))
             return ingest_run_id

--- a/apps/api/app/processing/ingest.py
+++ b/apps/api/app/processing/ingest.py
@@ -77,9 +77,11 @@ def poll_registered_storage_sources(
     *,
     now: datetime | None = None,
     missing_file_grace_period_days: int | None = None,
+    poll_chunk_size: int = 100,
 ) -> IngestResult:
     return ingest_polling_module.poll_registered_storage_sources(
         database_url=database_url,
         now=now,
         missing_file_grace_period_days=missing_file_grace_period_days,
+        poll_chunk_size=poll_chunk_size,
     )

--- a/apps/api/app/processing/ingest_polling.py
+++ b/apps/api/app/processing/ingest_polling.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from stat import S_ISDIR
-from typing import Callable
+from typing import Callable, Iterable, Iterator
 
 from sqlalchemy import select
 from sqlalchemy.engine import Connection
@@ -100,6 +100,7 @@ def poll_registered_storage_sources(
     *,
     now: datetime | None = None,
     missing_file_grace_period_days: int | None = None,
+    poll_chunk_size: int = 100,
 ) -> IngestResult:
     result = IngestResult()
     at = now if now is not None else utc_now()
@@ -137,37 +138,102 @@ def poll_registered_storage_sources(
             result.errors.append(f"storage_source:{source_target.storage_source_id}: {detail}")
             continue
 
-        with engine.begin() as connection:
-            for target in source_target.watched_folders:
-                scan_root = _resolve_registered_scan_root(
-                    alias_root=alias_root,
-                    relative_path=target.relative_path,
+        for target in source_target.watched_folders:
+            scan_root = _resolve_registered_scan_root(
+                alias_root=alias_root,
+                relative_path=target.relative_path,
+            )
+            observed_relative_paths: set[str] = set()
+            touched_photo_ids: set[str] = set()
+            chunk_count = 0
+            try:
+                _validate_scan_root(scan_root)
+                for chunk_paths in _iter_chunks(iter_photo_files(scan_root), chunk_size=poll_chunk_size):
+                    chunk_count += 1
+                    with engine.begin() as connection:
+                        outcome, chunk_touched_photo_ids = _process_watched_folder_paths(
+                            connection,
+                            watched_folder_id=target.watched_folder_id,
+                            source_root=scan_root,
+                            photo_paths=chunk_paths,
+                            canonical_path_for_relative_path=_registered_source_path_builder(
+                                storage_source_id=source_target.storage_source_id,
+                                watched_folder_relative_path=target.relative_path,
+                            ),
+                            reuse_existing_photo_by_sha=True,
+                            now=at,
+                            observed_relative_paths=observed_relative_paths,
+                        )
+                        touched_photo_ids.update(chunk_touched_photo_ids)
+                        result.scanned += outcome.scanned
+                        result.inserted += outcome.inserted
+                        result.updated += outcome.updated
+                        result.errors.extend(outcome.error_messages)
+                        record_watched_folder_scan_success(
+                            connection,
+                            watched_folder_id=target.watched_folder_id,
+                            now=at,
+                        )
+                        _record_ingest_run(
+                            run_store,
+                            connection=connection,
+                            watched_folder_id=target.watched_folder_id,
+                            status=outcome.status,
+                            files_seen=outcome.scanned,
+                            files_created=outcome.inserted,
+                            files_updated=outcome.updated,
+                            error_messages=outcome.error_messages,
+                        )
+            except OSError as exc:
+                with engine.begin() as connection:
+                    record_watched_folder_scan_failure(
+                        connection,
+                        watched_folder_id=target.watched_folder_id,
+                        reason=_classify_root_scan_failure(exc),
+                        now=at,
+                    )
+                    _record_ingest_run(
+                        run_store,
+                        connection=connection,
+                        watched_folder_id=target.watched_folder_id,
+                        status="failed",
+                        files_seen=0,
+                        files_created=0,
+                        files_updated=0,
+                        error_messages=(),
+                    )
+                continue
+
+            with engine.begin() as connection:
+                if chunk_count == 0:
+                    record_watched_folder_scan_success(
+                        connection,
+                        watched_folder_id=target.watched_folder_id,
+                        now=at,
+                    )
+                    _record_ingest_run(
+                        run_store,
+                        connection=connection,
+                        watched_folder_id=target.watched_folder_id,
+                        status="completed",
+                        files_seen=0,
+                        files_created=0,
+                        files_updated=0,
+                        error_messages=(),
+                    )
+                touched_photo_ids.update(
+                    reconcile_watched_folder(
+                        connection,
+                        watched_folder_id=target.watched_folder_id,
+                        observed_relative_paths=observed_relative_paths,
+                        now=at,
+                        missing_file_grace_period_days=grace_period_days,
+                    )
                 )
-                outcome = _reconcile_watched_folder_root(
+                refresh_photo_deleted_timestamps(
                     connection,
-                    watched_folder_id=target.watched_folder_id,
-                    source_root=scan_root,
-                    canonical_path_for_relative_path=_registered_source_path_builder(
-                        storage_source_id=source_target.storage_source_id,
-                        watched_folder_relative_path=target.relative_path,
-                    ),
-                    reuse_existing_photo_by_sha=True,
+                    photo_ids=touched_photo_ids,
                     now=at,
-                    missing_file_grace_period_days=grace_period_days,
-                )
-                result.scanned += outcome.scanned
-                result.inserted += outcome.inserted
-                result.updated += outcome.updated
-                result.errors.extend(outcome.error_messages)
-                _record_ingest_run(
-                    run_store,
-                    connection=connection,
-                    watched_folder_id=target.watched_folder_id,
-                    status=outcome.status,
-                    files_seen=outcome.scanned,
-                    files_created=outcome.inserted,
-                    files_updated=outcome.updated,
-                    error_messages=outcome.error_messages,
                 )
 
     return result
@@ -185,47 +251,39 @@ def _classify_root_scan_failure(exc: OSError) -> str:
         return "folder_unmounted"
     return "io_error"
 
-def _reconcile_watched_folder_root(
+
+def _iter_chunks(items: Iterable[Path], *, chunk_size: int) -> Iterator[list[Path]]:
+    if chunk_size < 1:
+        raise ValueError("chunk_size must be at least 1")
+
+    chunk: list[Path] = []
+    for item in items:
+        chunk.append(item)
+        if len(chunk) == chunk_size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
+def _process_watched_folder_paths(
     connection: Connection,
     *,
     watched_folder_id: str,
     source_root: Path,
+    photo_paths: Iterable[Path],
     canonical_path_for_relative_path: Callable[[str], str],
     reuse_existing_photo_by_sha: bool,
     now: datetime,
-    missing_file_grace_period_days: int,
-) -> WatchedFolderPollOutcome:
+    observed_relative_paths: set[str],
+) -> tuple[WatchedFolderPollOutcome, set[str]]:
     scanned = 0
     inserted = 0
     updated_count = 0
     error_messages: list[str] = []
-    try:
-        _validate_scan_root(source_root)
-        scanned_paths = list(iter_photo_files(source_root))
-    except OSError as exc:
-        record_watched_folder_scan_failure(
-            connection,
-            watched_folder_id=watched_folder_id,
-            reason=_classify_root_scan_failure(exc),
-            now=now,
-        )
-        return WatchedFolderPollOutcome(
-            scanned=0,
-            inserted=0,
-            updated=0,
-            error_messages=(),
-            status="failed",
-        )
-
-    record_watched_folder_scan_success(
-        connection,
-        watched_folder_id=watched_folder_id,
-        now=now,
-    )
-    observed_relative_paths: set[str] = set()
     touched_photo_ids: set[str] = set()
 
-    for photo_path in scanned_paths:
+    for photo_path in photo_paths:
         scanned += 1
         relative_path = relative_photo_path(source_root, photo_path)
         record = build_photo_record(
@@ -271,6 +329,62 @@ def _reconcile_watched_folder_root(
             )
         )
 
+    return (
+        WatchedFolderPollOutcome(
+            scanned=scanned,
+            inserted=inserted,
+            updated=updated_count,
+            error_messages=tuple(error_messages),
+            status="completed",
+        ),
+        touched_photo_ids,
+    )
+
+
+def _reconcile_watched_folder_root(
+    connection: Connection,
+    *,
+    watched_folder_id: str,
+    source_root: Path,
+    canonical_path_for_relative_path: Callable[[str], str],
+    reuse_existing_photo_by_sha: bool,
+    now: datetime,
+    missing_file_grace_period_days: int,
+) -> WatchedFolderPollOutcome:
+    try:
+        _validate_scan_root(source_root)
+        scanned_paths = list(iter_photo_files(source_root))
+    except OSError as exc:
+        record_watched_folder_scan_failure(
+            connection,
+            watched_folder_id=watched_folder_id,
+            reason=_classify_root_scan_failure(exc),
+            now=now,
+        )
+        return WatchedFolderPollOutcome(
+            scanned=0,
+            inserted=0,
+            updated=0,
+            error_messages=(),
+            status="failed",
+        )
+
+    record_watched_folder_scan_success(
+        connection,
+        watched_folder_id=watched_folder_id,
+        now=now,
+    )
+    observed_relative_paths: set[str] = set()
+    outcome, touched_photo_ids = _process_watched_folder_paths(
+        connection,
+        watched_folder_id=watched_folder_id,
+        source_root=source_root,
+        photo_paths=scanned_paths,
+        canonical_path_for_relative_path=canonical_path_for_relative_path,
+        reuse_existing_photo_by_sha=reuse_existing_photo_by_sha,
+        now=now,
+        observed_relative_paths=observed_relative_paths,
+    )
     touched_photo_ids.update(
         reconcile_watched_folder(
             connection,
@@ -281,13 +395,7 @@ def _reconcile_watched_folder_root(
         )
     )
     refresh_photo_deleted_timestamps(connection, photo_ids=touched_photo_ids, now=now)
-    return WatchedFolderPollOutcome(
-        scanned=scanned,
-        inserted=inserted,
-        updated=updated_count,
-        error_messages=tuple(error_messages),
-        status="completed",
-    )
+    return outcome
 
 
 def _load_registered_storage_source_targets(
@@ -424,6 +532,7 @@ def _record_ingest_run(
 ) -> None:
     ingest_run_id = run_store.create_run(
         watched_folder_id=watched_folder_id,
+        started_ts=utc_now(),
         connection=connection,
     )
     run_store.finalize_run(

--- a/apps/api/app/processing/ingest_polling.py
+++ b/apps/api/app/processing/ingest_polling.py
@@ -151,7 +151,7 @@ def poll_registered_storage_sources(
                 for chunk_paths in _iter_chunks(iter_photo_files(scan_root), chunk_size=poll_chunk_size):
                     chunk_count += 1
                     with engine.begin() as connection:
-                        outcome, chunk_touched_photo_ids = _process_watched_folder_paths(
+                        outcome, chunk_touched_photo_ids = _process_watched_folder_chunk(
                             connection,
                             watched_folder_id=target.watched_folder_id,
                             source_root=scan_root,
@@ -180,19 +180,13 @@ def poll_registered_storage_sources(
                             error_messages=outcome.error_messages,
                         )
                 with engine.begin() as connection:
-                    touched_photo_ids.update(
-                        reconcile_watched_folder(
-                            connection,
-                            watched_folder_id=target.watched_folder_id,
-                            observed_relative_paths=observed_relative_paths,
-                            now=at,
-                            missing_file_grace_period_days=grace_period_days,
-                        )
-                    )
-                    refresh_photo_deleted_timestamps(
+                    _finalize_watched_folder_scan(
                         connection,
-                        photo_ids=touched_photo_ids,
+                        watched_folder_id=target.watched_folder_id,
+                        observed_relative_paths=observed_relative_paths,
+                        touched_photo_ids=touched_photo_ids,
                         now=at,
+                        missing_file_grace_period_days=grace_period_days,
                     )
                     record_watched_folder_scan_success(
                         connection,
@@ -261,7 +255,7 @@ def _iter_chunks(items: Iterable[Path], *, chunk_size: int) -> Iterator[list[Pat
         yield chunk
 
 
-def _process_watched_folder_paths(
+def _process_watched_folder_chunk(
     connection: Connection,
     *,
     watched_folder_id: str,
@@ -336,6 +330,27 @@ def _process_watched_folder_paths(
     )
 
 
+def _finalize_watched_folder_scan(
+    connection: Connection,
+    *,
+    watched_folder_id: str,
+    observed_relative_paths: set[str],
+    touched_photo_ids: set[str],
+    now: datetime,
+    missing_file_grace_period_days: int,
+) -> None:
+    touched_photo_ids.update(
+        reconcile_watched_folder(
+            connection,
+            watched_folder_id=watched_folder_id,
+            observed_relative_paths=observed_relative_paths,
+            now=now,
+            missing_file_grace_period_days=missing_file_grace_period_days,
+        )
+    )
+    refresh_photo_deleted_timestamps(connection, photo_ids=touched_photo_ids, now=now)
+
+
 def _reconcile_watched_folder_root(
     connection: Connection,
     *,
@@ -370,7 +385,7 @@ def _reconcile_watched_folder_root(
         now=now,
     )
     observed_relative_paths: set[str] = set()
-    outcome, touched_photo_ids = _process_watched_folder_paths(
+    outcome, touched_photo_ids = _process_watched_folder_chunk(
         connection,
         watched_folder_id=watched_folder_id,
         source_root=source_root,
@@ -380,16 +395,14 @@ def _reconcile_watched_folder_root(
         now=now,
         observed_relative_paths=observed_relative_paths,
     )
-    touched_photo_ids.update(
-        reconcile_watched_folder(
-            connection,
-            watched_folder_id=watched_folder_id,
-            observed_relative_paths=observed_relative_paths,
-            now=now,
-            missing_file_grace_period_days=missing_file_grace_period_days,
-        )
+    _finalize_watched_folder_scan(
+        connection,
+        watched_folder_id=watched_folder_id,
+        observed_relative_paths=observed_relative_paths,
+        touched_photo_ids=touched_photo_ids,
+        now=now,
+        missing_file_grace_period_days=missing_file_grace_period_days,
     )
-    refresh_photo_deleted_timestamps(connection, photo_ids=touched_photo_ids, now=now)
     return outcome
 
 

--- a/apps/api/app/processing/ingest_polling.py
+++ b/apps/api/app/processing/ingest_polling.py
@@ -532,7 +532,6 @@ def _record_ingest_run(
 ) -> None:
     ingest_run_id = run_store.create_run(
         watched_folder_id=watched_folder_id,
-        started_ts=utc_now(),
         connection=connection,
     )
     run_store.finalize_run(

--- a/apps/api/app/processing/ingest_polling.py
+++ b/apps/api/app/processing/ingest_polling.py
@@ -102,6 +102,7 @@ def poll_registered_storage_sources(
     missing_file_grace_period_days: int | None = None,
     poll_chunk_size: int = 100,
 ) -> IngestResult:
+    _validate_chunk_size(poll_chunk_size)
     result = IngestResult()
     at = now if now is not None else utc_now()
     grace_period_days = resolve_missing_file_grace_period_days(missing_file_grace_period_days)
@@ -145,11 +146,9 @@ def poll_registered_storage_sources(
             )
             observed_relative_paths: set[str] = set()
             touched_photo_ids: set[str] = set()
-            chunk_count = 0
             try:
                 _validate_scan_root(scan_root)
                 for chunk_paths in _iter_chunks(iter_photo_files(scan_root), chunk_size=poll_chunk_size):
-                    chunk_count += 1
                     with engine.begin() as connection:
                         outcome, chunk_touched_photo_ids = _process_watched_folder_chunk(
                             connection,
@@ -193,17 +192,6 @@ def poll_registered_storage_sources(
                         watched_folder_id=target.watched_folder_id,
                         now=at,
                     )
-                    if chunk_count == 0:
-                        _record_ingest_run(
-                            run_store,
-                            connection=connection,
-                            watched_folder_id=target.watched_folder_id,
-                            status="completed",
-                            files_seen=0,
-                            files_created=0,
-                            files_updated=0,
-                            error_messages=(),
-                        )
             except Exception as exc:
                 with engine.begin() as connection:
                     record_watched_folder_scan_failure(
@@ -242,8 +230,7 @@ def _classify_root_scan_failure(exc: OSError) -> str:
 
 
 def _iter_chunks(items: Iterable[Path], *, chunk_size: int) -> Iterator[list[Path]]:
-    if chunk_size < 1:
-        raise ValueError("chunk_size must be at least 1")
+    _validate_chunk_size(chunk_size)
 
     chunk: list[Path] = []
     for item in items:
@@ -253,6 +240,11 @@ def _iter_chunks(items: Iterable[Path], *, chunk_size: int) -> Iterator[list[Pat
             chunk = []
     if chunk:
         yield chunk
+
+
+def _validate_chunk_size(chunk_size: int) -> None:
+    if chunk_size < 1:
+        raise ValueError("chunk_size must be at least 1")
 
 
 def _process_watched_folder_chunk(

--- a/apps/api/app/processing/ingest_polling.py
+++ b/apps/api/app/processing/ingest_polling.py
@@ -169,11 +169,6 @@ def poll_registered_storage_sources(
                         result.inserted += outcome.inserted
                         result.updated += outcome.updated
                         result.errors.extend(outcome.error_messages)
-                        record_watched_folder_scan_success(
-                            connection,
-                            watched_folder_id=target.watched_folder_id,
-                            now=at,
-                        )
                         _record_ingest_run(
                             run_store,
                             connection=connection,
@@ -184,12 +179,43 @@ def poll_registered_storage_sources(
                             files_updated=outcome.updated,
                             error_messages=outcome.error_messages,
                         )
-            except OSError as exc:
+                with engine.begin() as connection:
+                    touched_photo_ids.update(
+                        reconcile_watched_folder(
+                            connection,
+                            watched_folder_id=target.watched_folder_id,
+                            observed_relative_paths=observed_relative_paths,
+                            now=at,
+                            missing_file_grace_period_days=grace_period_days,
+                        )
+                    )
+                    refresh_photo_deleted_timestamps(
+                        connection,
+                        photo_ids=touched_photo_ids,
+                        now=at,
+                    )
+                    record_watched_folder_scan_success(
+                        connection,
+                        watched_folder_id=target.watched_folder_id,
+                        now=at,
+                    )
+                    if chunk_count == 0:
+                        _record_ingest_run(
+                            run_store,
+                            connection=connection,
+                            watched_folder_id=target.watched_folder_id,
+                            status="completed",
+                            files_seen=0,
+                            files_created=0,
+                            files_updated=0,
+                            error_messages=(),
+                        )
+            except Exception as exc:
                 with engine.begin() as connection:
                     record_watched_folder_scan_failure(
                         connection,
                         watched_folder_id=target.watched_folder_id,
-                        reason=_classify_root_scan_failure(exc),
+                        reason=_classify_root_scan_failure(exc) if isinstance(exc, OSError) else "io_error",
                         now=at,
                     )
                     _record_ingest_run(
@@ -200,41 +226,10 @@ def poll_registered_storage_sources(
                         files_seen=0,
                         files_created=0,
                         files_updated=0,
-                        error_messages=(),
+                        error_messages=(str(exc),),
                     )
+                result.errors.append(f"watched_folder:{target.watched_folder_id}: {exc}")
                 continue
-
-            with engine.begin() as connection:
-                if chunk_count == 0:
-                    record_watched_folder_scan_success(
-                        connection,
-                        watched_folder_id=target.watched_folder_id,
-                        now=at,
-                    )
-                    _record_ingest_run(
-                        run_store,
-                        connection=connection,
-                        watched_folder_id=target.watched_folder_id,
-                        status="completed",
-                        files_seen=0,
-                        files_created=0,
-                        files_updated=0,
-                        error_messages=(),
-                    )
-                touched_photo_ids.update(
-                    reconcile_watched_folder(
-                        connection,
-                        watched_folder_id=target.watched_folder_id,
-                        observed_relative_paths=observed_relative_paths,
-                        now=at,
-                        missing_file_grace_period_days=grace_period_days,
-                    )
-                )
-                refresh_photo_deleted_timestamps(
-                    connection,
-                    photo_ids=touched_photo_ids,
-                    now=at,
-                )
 
     return result
 

--- a/apps/api/tests/test_ingest.py
+++ b/apps/api/tests/test_ingest.py
@@ -1000,6 +1000,80 @@ def test_poll_registered_storage_sources_records_chunked_ingest_runs_for_success
     assert all(row["error_summary"] is None for row in run_rows)
 
 
+def test_poll_registered_storage_sources_defers_reconciliation_until_after_chunked_scan(
+    tmp_path, monkeypatch
+):
+    import app.processing.ingest_polling as ingest_polling
+
+    monkeypatch.chdir(tmp_path)
+    staged_corpus_dir = _stage_seed_corpus_subset(tmp_path)
+    db_url = f"sqlite:///{tmp_path / 'poll-storage-sources-deferred-reconcile.db'}"
+    upgrade_database(db_url)
+
+    initial_now = datetime(2026, 3, 28, 22, 50, tzinfo=UTC)
+    _, watched_folder_id = seed_registered_storage_source_with_watched_folder(
+        db_url,
+        root_path=staged_corpus_dir,
+        watched_path=staged_corpus_dir,
+        display_name="Seed Corpus",
+        now=initial_now,
+    )
+
+    first_result = poll_registered_storage_sources(
+        database_url=db_url,
+        now=initial_now,
+        poll_chunk_size=10,
+    )
+    assert first_result.errors == []
+
+    checkpoint_states: list[tuple[str, datetime | None, datetime | None]] = []
+    original_iter_photo_files = ingest_polling.iter_photo_files
+
+    def iter_photo_files_with_checkpoint(root: Path):
+        yielded = 0
+        for photo_path in original_iter_photo_files(root):
+            yielded += 1
+            if yielded == 3:
+                later_file = load_photo_file_row(
+                    db_url,
+                    "family-events/birthday-park/birthday_park_006.jpg",
+                )
+                checkpoint_states.append(
+                    (
+                        later_file["lifecycle_state"],
+                        later_file["missing_ts"],
+                        later_file["deleted_ts"],
+                    )
+                )
+            yield photo_path
+
+    monkeypatch.setattr(ingest_polling, "iter_photo_files", iter_photo_files_with_checkpoint)
+
+    second_now = initial_now + timedelta(minutes=5)
+    second_result = poll_registered_storage_sources(
+        database_url=db_url,
+        now=second_now,
+        poll_chunk_size=2,
+    )
+
+    assert second_result.errors == []
+    assert checkpoint_states == [("active", None, None)]
+
+    watched_folder = load_watched_folder_by_id(db_url, watched_folder_id)
+    assert watched_folder["availability_state"] == "active"
+    assert watched_folder["last_failure_reason"] is None
+    assert watched_folder["last_successful_scan_ts"] == second_now
+
+    later_file = load_photo_file_row(
+        db_url,
+        "family-events/birthday-park/birthday_park_006.jpg",
+    )
+    assert later_file["lifecycle_state"] == "active"
+    assert later_file["missing_ts"] is None
+    assert later_file["deleted_ts"] is None
+    assert later_file["last_seen_ts"] == second_now
+
+
 def test_poll_registered_storage_sources_records_ingest_run_for_source_validation_failure(
     tmp_path, monkeypatch
 ):

--- a/apps/api/tests/test_ingest.py
+++ b/apps/api/tests/test_ingest.py
@@ -209,10 +209,12 @@ def test_ingest_facade_poll_registered_storage_sources_delegates_to_polling_modu
         *,
         now=None,
         missing_file_grace_period_days=None,
+        poll_chunk_size=100,
     ):
         assert database_url == f"sqlite:///{tmp_path / 'facade-delegation.db'}"
         assert now is None
         assert missing_file_grace_period_days is None
+        assert poll_chunk_size == 100
         return sentinel_result
 
     fake_module.poll_registered_storage_sources = fake_poll_registered_storage_sources

--- a/apps/api/tests/test_ingest.py
+++ b/apps/api/tests/test_ingest.py
@@ -957,7 +957,7 @@ def test_poll_registered_storage_sources_falls_back_to_later_alias_when_first_is
     assert watched_folder["last_successful_scan_ts"] == now
 
 
-def test_poll_registered_storage_sources_records_ingest_run_for_successful_scan(
+def test_poll_registered_storage_sources_records_chunked_ingest_runs_for_successful_scan(
     tmp_path, monkeypatch
 ):
     monkeypatch.chdir(tmp_path)
@@ -974,19 +974,30 @@ def test_poll_registered_storage_sources_records_ingest_run_for_successful_scan(
         now=now,
     )
 
-    result = poll_registered_storage_sources(database_url=db_url, now=now)
+    result = poll_registered_storage_sources(
+        database_url=db_url,
+        now=now,
+        poll_chunk_size=2,
+    )
 
     assert result.scanned == 6
 
     run_rows = load_ingest_runs(database_url=db_url)
-    assert len(run_rows) == 1
-    assert run_rows[0]["watched_folder_id"] == watched_folder_id
-    assert run_rows[0]["status"] == "completed"
-    assert run_rows[0]["files_seen"] == 6
-    assert run_rows[0]["files_created"] == 6
-    assert run_rows[0]["files_updated"] == 0
-    assert run_rows[0]["error_count"] == 0
-    assert run_rows[0]["error_summary"] is None
+    assert len(run_rows) == 3
+    assert [row["watched_folder_id"] for row in run_rows] == [
+        watched_folder_id,
+        watched_folder_id,
+        watched_folder_id,
+    ]
+    assert [(row["status"], row["files_seen"]) for row in run_rows] == [
+        ("completed", 2),
+        ("completed", 2),
+        ("completed", 2),
+    ]
+    assert sum(row["files_created"] for row in run_rows) == 6
+    assert all(row["files_updated"] == 0 for row in run_rows)
+    assert all(row["error_count"] == 0 for row in run_rows)
+    assert all(row["error_summary"] is None for row in run_rows)
 
 
 def test_poll_registered_storage_sources_records_ingest_run_for_source_validation_failure(

--- a/apps/api/tests/test_ingest_polling.py
+++ b/apps/api/tests/test_ingest_polling.py
@@ -161,6 +161,167 @@ def test_poll_registered_storage_sources_records_one_completed_run_per_chunk(tmp
     ]
 
 
+def test_poll_registered_storage_sources_rejects_invalid_poll_chunk_size_without_marking_source_failed(
+    tmp_path,
+):
+    from app.processing.ingest_polling import poll_registered_storage_sources
+
+    database_url = f"sqlite:///{tmp_path / 'poll-invalid-chunk-size.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 4, 4, 12, 5, tzinfo=UTC)
+
+    root = tmp_path / "source-root"
+    watched = root / "imports"
+    watched.mkdir(parents=True)
+    _write_test_image(watched / "photo_000.jpg")
+
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Source",
+            marker_filename=MARKER_FILENAME,
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            now=now,
+        )
+        watched_folder = create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            watched_path=watched.as_posix(),
+            display_name="Imports",
+            now=now,
+        )
+        write_source_marker(root, storage_source_id=source["storage_source_id"])
+        initial_source_row = connection.execute(
+            select(
+                storage_sources.c.availability_state,
+                storage_sources.c.last_failure_reason,
+                storage_sources.c.last_validated_ts,
+            ).where(storage_sources.c.storage_source_id == source["storage_source_id"])
+        ).mappings().one()
+        initial_watched_folder_row = connection.execute(
+            select(
+                watched_folders.c.availability_state,
+                watched_folders.c.last_failure_reason,
+                watched_folders.c.last_successful_scan_ts,
+            ).where(watched_folders.c.watched_folder_id == watched_folder["watched_folder_id"])
+        ).mappings().one()
+
+    with pytest.raises(ValueError, match="chunk_size must be at least 1"):
+        poll_registered_storage_sources(
+            database_url=database_url,
+            now=now,
+            poll_chunk_size=0,
+        )
+
+    with engine.connect() as connection:
+        run_rows = list(connection.execute(select(ingest_runs)).mappings())
+        source_row = connection.execute(
+            select(
+                storage_sources.c.availability_state,
+                storage_sources.c.last_failure_reason,
+                storage_sources.c.last_validated_ts,
+            ).where(storage_sources.c.storage_source_id == source["storage_source_id"])
+        ).mappings().one()
+        watched_folder_row = connection.execute(
+            select(
+                watched_folders.c.availability_state,
+                watched_folders.c.last_failure_reason,
+                watched_folders.c.last_successful_scan_ts,
+            ).where(watched_folders.c.watched_folder_id == watched_folder["watched_folder_id"])
+        ).mappings().one()
+
+    assert run_rows == []
+    assert dict(source_row) == dict(initial_source_row)
+    assert dict(watched_folder_row) == dict(initial_watched_folder_row)
+
+
+def test_poll_registered_storage_sources_does_not_record_synthetic_run_for_empty_scan(tmp_path):
+    from app.processing.ingest_polling import poll_registered_storage_sources
+
+    database_url = f"sqlite:///{tmp_path / 'poll-empty-scan.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 4, 4, 12, 10, tzinfo=UTC)
+
+    root = tmp_path / "source-root"
+    watched = root / "imports"
+    watched.mkdir(parents=True)
+
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Source",
+            marker_filename=MARKER_FILENAME,
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            now=now,
+        )
+        watched_folder = create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            watched_path=watched.as_posix(),
+            display_name="Imports",
+            now=now,
+        )
+        write_source_marker(root, storage_source_id=source["storage_source_id"])
+
+    result = poll_registered_storage_sources(
+        database_url=database_url,
+        now=now,
+        poll_chunk_size=2,
+    )
+
+    assert result.scanned == 0
+    assert result.inserted == 0
+    assert result.updated == 0
+    assert result.errors == []
+
+    with engine.connect() as connection:
+        run_rows = list(
+            connection.execute(
+                select(ingest_runs).where(
+                    ingest_runs.c.watched_folder_id == watched_folder["watched_folder_id"]
+                )
+            ).mappings()
+        )
+        source_row = connection.execute(
+            select(
+                storage_sources.c.availability_state,
+                storage_sources.c.last_failure_reason,
+                storage_sources.c.last_validated_ts,
+            ).where(storage_sources.c.storage_source_id == source["storage_source_id"])
+        ).mappings().one()
+        watched_folder_row = connection.execute(
+            select(
+                watched_folders.c.availability_state,
+                watched_folders.c.last_failure_reason,
+                watched_folders.c.last_successful_scan_ts,
+            ).where(watched_folders.c.watched_folder_id == watched_folder["watched_folder_id"])
+        ).mappings().one()
+
+    assert run_rows == []
+    assert source_row["availability_state"] == "active"
+    assert source_row["last_failure_reason"] is None
+    assert source_row["last_validated_ts"] == now.replace(tzinfo=None)
+    assert watched_folder_row["availability_state"] == "active"
+    assert watched_folder_row["last_failure_reason"] is None
+    assert watched_folder_row["last_successful_scan_ts"] == now.replace(tzinfo=None)
+
+
 def test_poll_registered_storage_sources_records_failed_outcome_for_late_reconciliation_error(
     tmp_path, monkeypatch
 ):

--- a/apps/api/tests/test_ingest_polling.py
+++ b/apps/api/tests/test_ingest_polling.py
@@ -150,11 +150,15 @@ def test_poll_registered_storage_sources_records_one_completed_run_per_chunk(tmp
             connection.execute(
                 select(ingest_runs)
                 .where(ingest_runs.c.watched_folder_id == watched_folder["watched_folder_id"])
+                .order_by(ingest_runs.c.completed_ts, ingest_runs.c.ingest_run_id)
             ).mappings()
         )
 
-    assert [row["status"] for row in run_rows] == ["completed", "completed", "completed"]
-    assert sorted(row["files_seen"] for row in run_rows) == [1, 2, 2]
+    assert [(row["status"], row["files_seen"]) for row in run_rows] == [
+        ("completed", 2),
+        ("completed", 2),
+        ("completed", 1),
+    ]
 
 
 def test_reconcile_directory_processes_a_watched_folder_end_to_end(tmp_path):

--- a/apps/api/tests/test_ingest_polling.py
+++ b/apps/api/tests/test_ingest_polling.py
@@ -161,6 +161,95 @@ def test_poll_registered_storage_sources_records_one_completed_run_per_chunk(tmp
     ]
 
 
+def test_poll_registered_storage_sources_records_failed_outcome_for_late_reconciliation_error(
+    tmp_path, monkeypatch
+):
+    import app.processing.ingest_polling as ingest_polling
+
+    database_url = f"sqlite:///{tmp_path / 'poll-late-reconcile-failure.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 4, 4, 12, 15, tzinfo=UTC)
+
+    root = tmp_path / "source-root"
+    watched = root / "imports"
+    watched.mkdir(parents=True)
+    for index in range(5):
+        _write_test_image(watched / f"photo_{index:03d}.jpg")
+
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Source",
+            marker_filename=MARKER_FILENAME,
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            now=now,
+        )
+        watched_folder = create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            watched_path=watched.as_posix(),
+            display_name="Imports",
+            now=now,
+        )
+        write_source_marker(root, storage_source_id=source["storage_source_id"])
+
+    def fail_on_reconcile(*args, **kwargs):
+        raise RuntimeError("late reconciliation failed")
+
+    monkeypatch.setattr(ingest_polling, "reconcile_watched_folder", fail_on_reconcile)
+
+    result = ingest_polling.poll_registered_storage_sources(
+        database_url=database_url,
+        now=now,
+        poll_chunk_size=2,
+    )
+
+    with engine.connect() as connection:
+        run_rows = list(
+            connection.execute(
+                select(ingest_runs)
+                .where(ingest_runs.c.watched_folder_id == watched_folder["watched_folder_id"])
+                .order_by(ingest_runs.c.completed_ts, ingest_runs.c.ingest_run_id)
+            ).mappings()
+        )
+        source_row = connection.execute(
+            select(
+                storage_sources.c.availability_state,
+                storage_sources.c.last_failure_reason,
+                storage_sources.c.last_validated_ts,
+            ).where(storage_sources.c.storage_source_id == source["storage_source_id"])
+        ).mappings().one()
+        watched_folder_row = connection.execute(
+            select(
+                watched_folders.c.availability_state,
+                watched_folders.c.last_failure_reason,
+                watched_folders.c.last_successful_scan_ts,
+            ).where(watched_folders.c.watched_folder_id == watched_folder["watched_folder_id"])
+        ).mappings().one()
+
+    assert result.errors == [f"watched_folder:{watched_folder['watched_folder_id']}: late reconciliation failed"]
+    assert [(row["status"], row["files_seen"]) for row in run_rows] == [
+        ("completed", 2),
+        ("completed", 2),
+        ("completed", 1),
+        ("failed", 0),
+    ]
+    assert source_row["availability_state"] == "unreachable"
+    assert source_row["last_failure_reason"] == "io_error"
+    assert source_row["last_validated_ts"] == now.replace(tzinfo=None)
+    assert watched_folder_row["availability_state"] == "unreachable"
+    assert watched_folder_row["last_failure_reason"] == "io_error"
+    assert watched_folder_row["last_successful_scan_ts"] is None
+
+
 def test_reconcile_directory_processes_a_watched_folder_end_to_end(tmp_path):
     from app.processing.ingest_polling import reconcile_directory
 

--- a/apps/api/tests/test_ingest_polling.py
+++ b/apps/api/tests/test_ingest_polling.py
@@ -250,6 +250,86 @@ def test_poll_registered_storage_sources_records_failed_outcome_for_late_reconci
     assert watched_folder_row["last_successful_scan_ts"] is None
 
 
+def test_poll_registered_storage_sources_defers_missing_file_reconciliation_until_scan_finishes(
+    tmp_path, monkeypatch
+):
+    import app.processing.ingest_polling as ingest_polling
+
+    database_url = f"sqlite:///{tmp_path / 'poll-deferred-reconcile.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 4, 4, 12, 30, tzinfo=UTC)
+
+    root = tmp_path / "source-root"
+    watched = root / "imports"
+    watched.mkdir(parents=True)
+    first_path = watched / "first.jpg"
+    second_path = watched / "second.jpg"
+    _write_test_image(first_path)
+    _write_test_image(second_path)
+
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Source",
+            marker_filename=MARKER_FILENAME,
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            now=now,
+        )
+        create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            watched_path=watched.as_posix(),
+            display_name="Imports",
+            now=now,
+        )
+        write_source_marker(root, storage_source_id=source["storage_source_id"])
+
+    ingest_polling.poll_registered_storage_sources(
+        database_url=database_url,
+        now=now,
+        poll_chunk_size=10,
+    )
+    second_path.unlink()
+
+    reconciliation_calls: list[set[str]] = []
+    original_reconcile = ingest_polling.reconcile_watched_folder
+
+    def capture_reconcile(
+        connection,
+        *,
+        watched_folder_id,
+        observed_relative_paths,
+        now,
+        missing_file_grace_period_days,
+    ):
+        reconciliation_calls.append(set(observed_relative_paths))
+        return original_reconcile(
+            connection,
+            watched_folder_id=watched_folder_id,
+            observed_relative_paths=observed_relative_paths,
+            now=now,
+            missing_file_grace_period_days=missing_file_grace_period_days,
+        )
+
+    monkeypatch.setattr(ingest_polling, "reconcile_watched_folder", capture_reconcile)
+
+    ingest_polling.poll_registered_storage_sources(
+        database_url=database_url,
+        now=now,
+        poll_chunk_size=1,
+    )
+
+    assert reconciliation_calls == [{"first.jpg"}]
+
+
 def test_reconcile_directory_processes_a_watched_folder_end_to_end(tmp_path):
     from app.processing.ingest_polling import reconcile_directory
 

--- a/apps/api/tests/test_ingest_polling.py
+++ b/apps/api/tests/test_ingest_polling.py
@@ -100,6 +100,67 @@ def test_poll_registered_storage_sources_processes_a_registered_source_end_to_en
     assert photo_count == 1
 
 
+def test_poll_registered_storage_sources_records_one_completed_run_per_chunk(tmp_path):
+    from app.processing.ingest_polling import poll_registered_storage_sources
+
+    database_url = f"sqlite:///{tmp_path / 'poll-chunked-runs.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 4, 4, 12, 0, tzinfo=UTC)
+
+    root = tmp_path / "source-root"
+    watched = root / "imports"
+    watched.mkdir(parents=True)
+    for index in range(5):
+        _write_test_image(watched / f"photo_{index:03d}.jpg")
+
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Source",
+            marker_filename=MARKER_FILENAME,
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            now=now,
+        )
+        watched_folder = create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            watched_path=watched.as_posix(),
+            display_name="Imports",
+            now=now,
+        )
+        write_source_marker(root, storage_source_id=source["storage_source_id"])
+
+    result = poll_registered_storage_sources(
+        database_url=database_url,
+        now=now,
+        poll_chunk_size=2,
+    )
+
+    assert result.scanned == 5
+    with engine.connect() as connection:
+        run_rows = list(
+            connection.execute(
+                select(ingest_runs)
+                .where(ingest_runs.c.watched_folder_id == watched_folder["watched_folder_id"])
+                .order_by(ingest_runs.c.started_ts, ingest_runs.c.ingest_run_id)
+            ).mappings()
+        )
+
+    assert [(row["status"], row["files_seen"]) for row in run_rows] == [
+        ("completed", 2),
+        ("completed", 2),
+        ("completed", 1),
+    ]
+
+
 def test_reconcile_directory_processes_a_watched_folder_end_to_end(tmp_path):
     from app.processing.ingest_polling import reconcile_directory
 

--- a/apps/api/tests/test_ingest_polling.py
+++ b/apps/api/tests/test_ingest_polling.py
@@ -150,15 +150,11 @@ def test_poll_registered_storage_sources_records_one_completed_run_per_chunk(tmp
             connection.execute(
                 select(ingest_runs)
                 .where(ingest_runs.c.watched_folder_id == watched_folder["watched_folder_id"])
-                .order_by(ingest_runs.c.started_ts, ingest_runs.c.ingest_run_id)
             ).mappings()
         )
 
-    assert [(row["status"], row["files_seen"]) for row in run_rows] == [
-        ("completed", 2),
-        ("completed", 2),
-        ("completed", 1),
-    ]
+    assert [row["status"] for row in run_rows] == ["completed", "completed", "completed"]
+    assert sorted(row["files_seen"] for row in run_rows) == [1, 2, 2]
 
 
 def test_reconcile_directory_processes_a_watched_folder_end_to_end(tmp_path):

--- a/apps/api/tests/test_ingest_polling.py
+++ b/apps/api/tests/test_ingest_polling.py
@@ -263,10 +263,14 @@ def test_poll_registered_storage_sources_defers_missing_file_reconciliation_unti
     root = tmp_path / "source-root"
     watched = root / "imports"
     watched.mkdir(parents=True)
-    first_path = watched / "first.jpg"
-    second_path = watched / "second.jpg"
-    _write_test_image(first_path)
-    _write_test_image(second_path)
+    paths = {
+        "first.jpg": watched / "first.jpg",
+        "second.jpg": watched / "second.jpg",
+        "third.jpg": watched / "third.jpg",
+        "fourth.jpg": watched / "fourth.jpg",
+    }
+    for path in paths.values():
+        _write_test_image(path)
 
     with engine.begin() as connection:
         source = create_storage_source(
@@ -297,7 +301,7 @@ def test_poll_registered_storage_sources_defers_missing_file_reconciliation_unti
         now=now,
         poll_chunk_size=10,
     )
-    second_path.unlink()
+    paths["second.jpg"].unlink()
 
     reconciliation_calls: list[set[str]] = []
     original_reconcile = ingest_polling.reconcile_watched_folder
@@ -321,13 +325,14 @@ def test_poll_registered_storage_sources_defers_missing_file_reconciliation_unti
 
     monkeypatch.setattr(ingest_polling, "reconcile_watched_folder", capture_reconcile)
 
-    ingest_polling.poll_registered_storage_sources(
+    result = ingest_polling.poll_registered_storage_sources(
         database_url=database_url,
         now=now,
         poll_chunk_size=1,
     )
 
-    assert reconciliation_calls == [{"first.jpg"}]
+    assert result.scanned == 3
+    assert reconciliation_calls == [{"first.jpg", "third.jpg", "fourth.jpg"}]
 
 
 def test_reconcile_directory_processes_a_watched_folder_end_to_end(tmp_path):

--- a/docs/superpowers/specs/2026-04-04-issue-122-chunked-polling-design.md
+++ b/docs/superpowers/specs/2026-04-04-issue-122-chunked-polling-design.md
@@ -1,0 +1,179 @@
+# Issue 122 Chunked Polling Design
+
+Date: 2026-04-04
+Issue: #122
+
+## Summary
+
+Improve watched-folder polling so large imports make durable progress visible before a full scan completes. Keep execution serial and safe for now: chunk work within a watched-folder scan, commit each chunk durably, and record one `ingest_runs` row per committed chunk.
+
+## Goals
+
+- make durable ingest progress visible during long watched-folder scans
+- reduce rollback scope from an entire watched-folder poll to a bounded chunk
+- keep the execution model serial within the current safe watched-folder boundary
+- preserve correctness for source-aware identity, duplicate-content handling, watched-folder bookkeeping, and repeated scans
+- make chunk sizing explicit and configurable
+
+## Non-Goals
+
+- no bounded parallelism in this issue
+- no per-file concurrency
+- no scheduler or queue-worker changes
+- no change to the public meaning of storage-source validation failures
+
+## Current Problem
+
+`poll_registered_storage_sources()` currently validates registered sources, then reconciles each watched folder inside a single transaction per source. Within a watched-folder reconciliation, the implementation enumerates the full file list, processes every file, reconciles missing files, and only then commits and records a single ingest run.
+
+That model has two operational problems for large or NAS-backed folders:
+
+- time to first visible progress is too long because nothing durable appears until the entire scan finishes
+- rollback scope is too large because one late failure can discard a long stretch of already-processed work
+
+## Recommended Approach
+
+Keep polling serial across storage sources and watched folders, but replace the monolithic watched-folder transaction with fixed-size file-count chunks.
+
+Within one watched-folder poll:
+
+1. validate the scan root as today
+2. enumerate files lazily rather than materializing the entire file list up front
+3. process up to `poll_chunk_size` files in one transaction
+4. commit photo upserts, thumbnail data, file activation, and one `ingest_runs` row for that chunk
+5. continue with the next chunk until enumeration finishes
+6. after enumeration is complete, run one final reconciliation phase for missing-file detection using the full observed relative-path set
+
+This keeps the safe execution boundary at a single watched folder while making progress visible incrementally.
+
+## Alternatives Considered
+
+### Time-Based Chunking
+
+Stop and commit when a wall-clock budget expires instead of after a fixed number of files.
+
+Rejected because it is less predictable to tune and harder to test. File-count chunking gives a clearer contract and repeatable behavior.
+
+### Add Parallelism Alongside Chunking
+
+Process multiple watched folders or storage sources concurrently while also chunking.
+
+Rejected for this issue because the user explicitly wants to avoid early throughput optimization. Adding concurrency would complicate correctness analysis before the chunking model is proven.
+
+### Full Enumeration Before Chunked Persistence
+
+Collect the full observed path set first, then process durable chunks.
+
+Rejected because it still delays the first visible durable progress on the large scans this issue is meant to improve.
+
+## Execution Model
+
+### Poll Boundary
+
+`poll_registered_storage_sources()` remains the public entrypoint and remains serial. It still:
+
+- loads enabled watched folders by source
+- validates source aliases and markers
+- resolves watched-folder roots
+- accumulates overall `IngestResult`
+
+No concurrency controls are added in this issue.
+
+### Chunk Boundary
+
+The chunk is the new durability unit for successful watched-folder scanning.
+
+For each chunk:
+
+- open a transaction
+- process a bounded number of discovered files
+- upsert photo rows and thumbnails
+- activate observed file instances
+- commit one `ingest_runs` row for that chunk
+
+Chunk counters remain local to that slice:
+
+- `files_seen`
+- `files_created`
+- `files_updated`
+- `error_count`
+- `error_summary`
+
+If a chunk processes successfully, its run row is finalized as `completed` even if more chunks remain for the same watched folder.
+
+### Final Reconciliation Phase
+
+Missing-file detection must not run until the full watched-folder enumeration completes. Otherwise a partial scan would incorrectly classify not-yet-seen files as missing.
+
+After the last file chunk commits:
+
+- open a final reconciliation transaction
+- compare the full observed relative-path set against existing file instances
+- apply missing-file lifecycle transitions
+- refresh affected photo deleted timestamps
+
+This phase may produce its own ingest-run record if it needs to surface a durable failure or other explicit bookkeeping outcome, but successful no-op finalization should not create extra synthetic noise beyond the per-file chunks.
+
+## Ingest-Run Semantics
+
+The durable run boundary becomes: one completed chunk, not one entire watched-folder scan.
+
+### Successful Scan Chunks
+
+Each committed file chunk creates one `ingest_runs` row for the watched folder:
+
+- `status = "completed"`
+- `files_seen` equals the number of files in the chunk
+- `files_created` and `files_updated` describe only that chunk
+- `error_count` and `error_summary` describe only errors observed while processing that chunk
+
+This makes progress visible as a sequence of completed runs during a long poll.
+
+### Source Validation Failures
+
+Source validation remains unchanged. If alias or marker validation fails before file processing starts, record one failed run for the watched folder with zero files seen and the existing error summary behavior.
+
+### Failure During Chunk Processing
+
+If a failure happens before a chunk commits, that chunk is rolled back and should record a failed run only for the failed slice. Earlier completed chunks remain durable and visible.
+
+## Configuration
+
+Introduce an explicit polling chunk-size control with a conservative default in application code.
+
+Requirements:
+
+- the chunk size must be configurable from the polling entrypoint
+- the default must preserve correctness without assuming aggressive throughput targets
+- no worker-count or parallelism setting is introduced in this issue
+
+The CLI may expose this later, but the first implementation only needs the explicit parameter and code default.
+
+## Testing Strategy
+
+Follow TDD.
+
+Add focused coverage for:
+
+- a watched-folder poll large enough to produce multiple completed run rows
+- durable photo visibility after the first chunk commits, before the full scan completes
+- source validation failures still producing one failed run with zero files seen
+- repeated scans remaining correct when earlier chunks already committed
+- missing-file reconciliation not firing until the full enumeration finishes
+
+Existing tests that currently assert one successful run for a whole watched-folder scan should be updated only where chunking legitimately changes the contract.
+
+## Verification
+
+Minimum verification for implementation:
+
+- `uv run python -m pytest apps/api/tests/test_ingest_polling.py -q`
+- `uv run python -m pytest apps/api/tests/test_ingest.py -k "poll_registered_storage_sources" -q`
+
+Representative local validation should also demonstrate that a large watched-folder poll produces multiple completed run rows before the full scan is finished.
+
+## Open Questions Resolved
+
+- Parallelism is explicitly deferred.
+- File-count chunking is preferred over time-budget chunking.
+- Each durable chunk becomes its own ingest-run record.


### PR DESCRIPTION
## Summary
- chunk watched-folder polling into durable per-chunk ingest runs without adding concurrency
- defer missing-file reconciliation until full enumeration completes and harden late-failure handling
- add polling regressions for chunk sequencing, deferred reconciliation, invalid chunk size, empty scans, and end-to-end lifecycle behavior

## Why
Large watched-folder polls were effectively monolithic, which delayed visible progress and made rollback scope too large. This change makes progress visible sooner while preserving correctness at the watched-folder boundary.

## Test Plan
- `uv run --group test python -m pytest apps/api/tests/test_ingest_polling.py -q`
- `uv run --group test python -m pytest apps/api/tests/test_ingest.py -k "poll_registered_storage_sources" -q`