### PR TITLE
[codex] Add operational activity endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Typical usage is expected to be:
 - authorized users confirm or correct face associations
 - users monitor ingestion status and recent issues from the UI
 
+For operator troubleshooting during long imports or background processing, the API also exposes `GET /api/v1/operations/activity`.
+That endpoint is read-only and intended for repeated polling by a UI or CLI.
+It summarizes whether the system is currently idle, actively polling watched folders, actively processing queued ingest work, or surfacing attention signals such as recent failures or stalled queue work.
+
 ## Current Documentation
 
 - [DESIGN.md](DESIGN.md): how the system is structured and how components interact

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 
 from app.routers.ingest_queue import router as ingest_queue_router
+from app.routers.operations import router as operations_router
 from app.routers.photos import router as photos_router
 from app.routers.storage_sources import router as storage_sources_router
 from app.openapi_docs import openapi_yaml_response
@@ -30,11 +31,16 @@ app = FastAPI(
             "name": "internal-ingest-queue",
             "description": "Worker-only queue processing endpoint.",
         },
+        {
+            "name": "operations",
+            "description": "Read-only operational activity and troubleshooting signals.",
+        },
     ],
     redoc_url=None,
 )
 
 app.include_router(ingest_queue_router, prefix="/api/v1")
+app.include_router(operations_router, prefix="/api/v1")
 app.include_router(photos_router, prefix="/api/v1")
 app.include_router(storage_sources_router, prefix="/api/v1")
 

--- a/apps/api/app/routers/operations.py
+++ b/apps/api/app/routers/operations.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_db
+from app.services.operational_activity import get_operational_activity
+
+
+router = APIRouter(prefix="/operations", tags=["operations"])
+
+
+class ActiveWatchedFolderResponse(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Watched folder currently associated with an in-progress polling run."
+        }
+    )
+
+    watched_folder_id: str
+    storage_source_id: str
+    display_name: str | None = None
+    scan_path: str
+    started_ts: datetime | None = None
+
+
+class PollingActivityResponse(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={"description": "Current watched-folder polling activity."}
+    )
+
+    active_count: int = Field(description="Number of watched folders with an active polling run.")
+    active_watched_folders: list[ActiveWatchedFolderResponse]
+
+
+class IngestQueueActivityResponse(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={"description": "Current queue backlog and processing summary."}
+    )
+
+    pending_count: int
+    processing_count: int
+    failed_count: int
+    stalled_count: int
+    lease_timeout_seconds: int
+    oldest_pending_ts: datetime | None = None
+
+
+class ActivitySignalsResponse(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={"description": "Operator-facing warning signals derived from current state."}
+    )
+
+    recent_failure_count: int
+    stalled_count: int
+
+
+class RecentFailureResponse(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={"description": "Recent ingest failure surfaced for operator troubleshooting."}
+    )
+
+    kind: str
+    watched_folder_id: str
+    display_name: str | None = None
+    status: str
+    error_summary: str | None = None
+    completed_ts: datetime | None = None
+
+
+class OperationalActivityResponse(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Read-only operational summary for polling and ingest queue activity."
+        }
+    )
+
+    state: str = Field(description="High-level operator state: idle, polling, processing_queue, or attention_required.")
+    observed_at: datetime
+    polling: PollingActivityResponse
+    ingest_queue: IngestQueueActivityResponse
+    signals: ActivitySignalsResponse
+    recent_failures: list[RecentFailureResponse]
+
+
+@router.get(
+    "/activity",
+    summary="Get operational activity",
+    description=(
+        "Return a read-only summary of current polling activity, queue backlog, and recent failure signals "
+        "so operators can tell whether the system is idle, busy, or needs attention."
+    ),
+    response_model=OperationalActivityResponse,
+)
+def get_operational_activity_endpoint(
+    db: Session = Depends(get_db),
+) -> OperationalActivityResponse:
+    payload = get_operational_activity(db.connection())
+    return OperationalActivityResponse.model_validate(payload)

--- a/apps/api/app/services/operational_activity.py
+++ b/apps/api/app/services/operational_activity.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.engine import Connection
+
+from app.db.queue import PROCESSING_LEASE_SECONDS, _processing_lease_cutoff
+from app.storage import ingest_queue, ingest_runs, watched_folders
+
+
+def get_operational_activity(
+    connection: Connection,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    observed_at = _normalize_timestamp(now or datetime.now(tz=UTC))
+    lease_cutoff = _processing_lease_cutoff(observed_at)
+    active_polling = _list_active_polling(connection)
+    queue_status = _load_ingest_queue_status(connection, lease_cutoff=lease_cutoff)
+    recent_failures = _list_recent_failures(connection)
+    signals = {
+        "recent_failure_count": len(recent_failures),
+        "stalled_count": queue_status["stalled_count"],
+    }
+
+    return {
+        "state": _derive_activity_state(
+            active_polling_count=len(active_polling),
+            processing_queue_count=queue_status["processing_count"],
+            signal_counts=signals,
+        ),
+        "observed_at": _iso_utc(observed_at),
+        "polling": {
+            "active_count": len(active_polling),
+            "active_watched_folders": active_polling,
+        },
+        "ingest_queue": queue_status,
+        "signals": signals,
+        "recent_failures": recent_failures,
+    }
+
+
+def _list_active_polling(connection: Connection) -> list[dict[str, Any]]:
+    rows = connection.execute(
+        select(
+            ingest_runs.c.watched_folder_id,
+            watched_folders.c.storage_source_id,
+            watched_folders.c.display_name,
+            watched_folders.c.scan_path,
+            ingest_runs.c.started_ts,
+        )
+        .select_from(
+            ingest_runs.join(
+                watched_folders,
+                ingest_runs.c.watched_folder_id == watched_folders.c.watched_folder_id,
+            )
+        )
+        .where(ingest_runs.c.status == "processing")
+        .where(ingest_runs.c.watched_folder_id.is_not(None))
+        .order_by(ingest_runs.c.started_ts.desc(), ingest_runs.c.ingest_run_id.desc())
+    ).mappings()
+    return [
+        {
+            "watched_folder_id": str(row["watched_folder_id"]),
+            "storage_source_id": str(row["storage_source_id"]),
+            "display_name": row["display_name"],
+            "scan_path": str(row["scan_path"]),
+            "started_ts": _iso_utc(row["started_ts"]),
+        }
+        for row in rows
+    ]
+
+
+def _load_ingest_queue_status(
+    connection: Connection,
+    *,
+    lease_cutoff: datetime,
+) -> dict[str, Any]:
+    pending_count = _count_rows(connection, ingest_queue.c.status == "pending")
+    processing_count = _count_rows(
+        connection,
+        (ingest_queue.c.status == "processing")
+        & ingest_queue.c.last_attempt_ts.is_not(None)
+        & (ingest_queue.c.last_attempt_ts > lease_cutoff),
+    )
+    stalled_count = _count_rows(
+        connection,
+        (ingest_queue.c.status == "processing")
+        & (
+            ingest_queue.c.last_attempt_ts.is_(None)
+            | (ingest_queue.c.last_attempt_ts <= lease_cutoff)
+        ),
+    )
+    failed_count = _count_rows(connection, ingest_queue.c.status == "failed")
+    oldest_pending_ts = connection.execute(
+        select(func.min(ingest_queue.c.enqueued_ts)).where(ingest_queue.c.status == "pending")
+    ).scalar_one()
+    return {
+        "pending_count": pending_count,
+        "processing_count": processing_count,
+        "failed_count": failed_count,
+        "stalled_count": stalled_count,
+        "lease_timeout_seconds": PROCESSING_LEASE_SECONDS,
+        "oldest_pending_ts": _iso_utc(oldest_pending_ts),
+    }
+
+
+def _count_rows(connection: Connection, criterion) -> int:
+    return int(connection.execute(select(func.count()).select_from(ingest_queue).where(criterion)).scalar_one())
+
+
+def _list_recent_failures(connection: Connection) -> list[dict[str, Any]]:
+    rows = connection.execute(
+        select(
+            ingest_runs.c.watched_folder_id,
+            watched_folders.c.display_name,
+            ingest_runs.c.status,
+            ingest_runs.c.error_summary,
+            ingest_runs.c.completed_ts,
+        )
+        .select_from(
+            ingest_runs.join(
+                watched_folders,
+                ingest_runs.c.watched_folder_id == watched_folders.c.watched_folder_id,
+            )
+        )
+        .where(ingest_runs.c.error_count > 0)
+        .order_by(
+            ingest_runs.c.completed_ts.desc().nullslast(),
+            ingest_runs.c.started_ts.desc(),
+            ingest_runs.c.ingest_run_id.desc(),
+        )
+        .limit(5)
+    ).mappings()
+    return [
+        {
+            "kind": "watched_folder_ingest",
+            "watched_folder_id": str(row["watched_folder_id"]),
+            "display_name": row["display_name"],
+            "status": str(row["status"]),
+            "error_summary": row["error_summary"],
+            "completed_ts": _iso_utc(row["completed_ts"]),
+        }
+        for row in rows
+    ]
+
+
+def _derive_activity_state(
+    *,
+    active_polling_count: int,
+    processing_queue_count: int,
+    signal_counts: dict[str, int],
+) -> str:
+    if active_polling_count > 0:
+        return "polling"
+    if processing_queue_count > 0:
+        return "processing_queue"
+    if signal_counts["recent_failure_count"] > 0 or signal_counts["stalled_count"] > 0:
+        return "attention_required"
+    return "idle"
+
+
+def _normalize_timestamp(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _iso_utc(value: datetime | None) -> str | None:
+    normalized = _normalize_timestamp(value)
+    if normalized is None:
+        return None
+    return normalized.isoformat().replace("+00:00", "Z")

--- a/apps/api/tests/test_main.py
+++ b/apps/api/tests/test_main.py
@@ -76,6 +76,8 @@ class TestHealthEndpoint:
         assert schema["paths"]["/api/v1/storage-sources/{storage_source_id}/watched-folders"]["post"][
             "responses"
         ]["400"]["description"] == "Watched folder validation failed"
+        assert "/api/v1/operations/activity" in schema["paths"]
+        assert any(tag["name"] == "operations" for tag in schema["tags"])
         watched_folder_mutation_responses = schema["paths"][
             "/api/v1/storage-sources/{storage_source_id}/watched-folders/{watched_folder_id}"
         ]
@@ -88,12 +90,14 @@ class TestHealthEndpoint:
         assert schema["paths"]["/api/v1/internal/ingest-queue/process"]["post"]["responses"]["403"][
             "description"
         ] == "Worker role required"
+        assert schema["paths"]["/api/v1/operations/activity"]["get"]["summary"] == "Get operational activity"
         assert (
             schema["components"]["schemas"]["RegisterStorageSourceRequest"]["properties"]["root_path"][
                 "description"
             ]
             == "Absolute path to the storage root on the host."
         )
+        assert any(tag["name"] == "operations" for tag in schema["tags"])
 
     def test_given_docs_route_when_fetching_then_serves_swagger_ui(self):
         client = TestClient(app)

--- a/apps/api/tests/test_operational_activity_api.py
+++ b/apps/api/tests/test_operational_activity_api.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, insert
+
+from app.db.queue import PROCESSING_LEASE_SECONDS
+from app.dependencies import _get_session_factory
+from app.main import app
+from app.migrations import upgrade_database
+from app.storage import ingest_queue, ingest_runs
+
+
+def test_operational_activity_api_reports_idle_when_no_current_work(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'operational-activity-idle.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    client = TestClient(app)
+
+    response = client.get("/api/v1/operations/activity")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "idle"
+    assert payload["polling"]["active_count"] == 0
+    assert payload["ingest_queue"]["pending_count"] == 0
+    assert payload["ingest_queue"]["processing_count"] == 0
+    assert payload["signals"]["recent_failure_count"] == 0
+    assert payload["signals"]["stalled_count"] == 0
+    assert payload["recent_failures"] == []
+
+
+def test_operational_activity_api_reports_active_polling(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'operational-activity-polling.db'}"
+    source, watched_folder = _seed_source_with_watched_folder(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        database_name="operational-activity-polling.db",
+        database_url=database_url,
+    )
+    now = datetime(2026, 4, 4, 15, 30, tzinfo=UTC)
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(ingest_runs).values(
+                ingest_run_id="run-polling",
+                watched_folder_id=watched_folder["watched_folder_id"],
+                status="processing",
+                started_ts=now,
+                completed_ts=None,
+                files_seen=42,
+                files_created=10,
+                files_updated=3,
+                files_missing=0,
+                error_count=0,
+                error_summary=None,
+            )
+        )
+
+    client = TestClient(app)
+
+    response = client.get("/api/v1/operations/activity")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "polling"
+    assert payload["polling"]["active_count"] == 1
+    assert payload["polling"]["active_watched_folders"] == [
+        {
+            "watched_folder_id": watched_folder["watched_folder_id"],
+            "storage_source_id": source["storage_source_id"],
+            "display_name": "Trips",
+            "scan_path": str(tmp_path / "family-share" / "2024" / "trips"),
+            "started_ts": "2026-04-04T15:30:00Z",
+        }
+    ]
+    assert payload["ingest_queue"]["processing_count"] == 0
+
+
+def test_operational_activity_api_reports_active_queue_processing(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'operational-activity-queue.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    now = datetime.now(tz=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(ingest_queue).values(
+                ingest_queue_id="queue-processing",
+                payload_type="photo_metadata",
+                payload_json={"path": "queued/active.jpg"},
+                idempotency_key="active.jpg",
+                status="processing",
+                attempt_count=1,
+                enqueued_ts=now - timedelta(minutes=2),
+                last_attempt_ts=now - timedelta(seconds=30),
+                processed_ts=None,
+                last_error=None,
+            )
+        )
+        connection.execute(
+            insert(ingest_queue).values(
+                ingest_queue_id="queue-pending",
+                payload_type="photo_metadata",
+                payload_json={"path": "queued/pending.jpg"},
+                idempotency_key="pending.jpg",
+                status="pending",
+                attempt_count=0,
+                enqueued_ts=now - timedelta(minutes=5),
+                last_attempt_ts=None,
+                processed_ts=None,
+                last_error=None,
+            )
+        )
+
+    client = TestClient(app)
+
+    response = client.get("/api/v1/operations/activity")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "processing_queue"
+    assert payload["polling"]["active_count"] == 0
+    assert payload["ingest_queue"]["pending_count"] == 1
+    assert payload["ingest_queue"]["processing_count"] == 1
+    assert payload["ingest_queue"]["failed_count"] == 0
+    assert payload["ingest_queue"]["stalled_count"] == 0
+    assert payload["ingest_queue"]["oldest_pending_ts"] == (
+        now - timedelta(minutes=5)
+    ).isoformat().replace("+00:00", "Z")
+
+
+def test_operational_activity_api_reports_attention_required_for_failed_or_stalled_work(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'operational-activity-attention.db'}"
+    _, watched_folder = _seed_source_with_watched_folder(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        database_name="operational-activity-attention.db",
+        database_url=database_url,
+    )
+    now = datetime.now(tz=UTC)
+    stale_attempt_ts = now - timedelta(seconds=PROCESSING_LEASE_SECONDS + 60)
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(ingest_runs).values(
+                ingest_run_id="run-failed",
+                watched_folder_id=watched_folder["watched_folder_id"],
+                status="failed",
+                started_ts=now - timedelta(minutes=2),
+                completed_ts=now - timedelta(minutes=1),
+                files_seen=12,
+                files_created=2,
+                files_updated=1,
+                files_missing=0,
+                error_count=1,
+                error_summary="marker mismatch on alias //nas/family-share",
+            )
+        )
+        connection.execute(
+            insert(ingest_queue).values(
+                ingest_queue_id="queue-stalled",
+                payload_type="photo_metadata",
+                payload_json={"path": "queued/stalled.jpg"},
+                idempotency_key="stalled.jpg",
+                status="processing",
+                attempt_count=2,
+                enqueued_ts=now - timedelta(minutes=8),
+                last_attempt_ts=stale_attempt_ts,
+                processed_ts=None,
+                last_error="temporary timeout",
+            )
+        )
+
+    client = TestClient(app)
+
+    response = client.get("/api/v1/operations/activity")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["state"] == "attention_required"
+    assert payload["signals"]["recent_failure_count"] == 1
+    assert payload["signals"]["stalled_count"] == 1
+    assert payload["ingest_queue"]["stalled_count"] == 1
+    assert payload["recent_failures"][0]["kind"] == "watched_folder_ingest"
+    assert payload["recent_failures"][0]["watched_folder_id"] == watched_folder["watched_folder_id"]
+    assert payload["recent_failures"][0]["error_summary"] == "marker mismatch on alias //nas/family-share"
+
+
+def _seed_source_with_watched_folder(*, tmp_path, monkeypatch, database_name: str, database_url: str):
+    from app.services.storage_sources import attach_storage_source_alias, create_storage_source
+    from app.services.watched_folders import create_watched_folder
+
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    root = tmp_path / "family-share"
+    watched_root = root / "2024" / "trips"
+    watched_root.mkdir(parents=True, exist_ok=True)
+    now = datetime(2026, 4, 4, 14, 0, tzinfo=UTC)
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Family Share",
+            marker_filename=".photo-org-source.json",
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=str(root),
+            now=now,
+        )
+        watched_folder = create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=str(root),
+            watched_path=str(watched_root),
+            display_name="Trips",
+            now=now,
+        )
+
+    return source, watched_folder


### PR DESCRIPTION
Closes #121

## Summary
- add a read-only `GET /api/v1/operations/activity` endpoint for current polling, ingest queue, and operator attention signals
- derive operational state from existing `ingest_runs`, `ingest_queue`, and watched-folder metadata without schema changes
- document the endpoint in the runtime API surface and README, with focused API and OpenAPI coverage

## Test Plan
- `uv run --group test python -m pytest apps/api/tests/test_operational_activity_api.py apps/api/tests/test_main.py -q`
- `uv run --group test python -m pytest apps/api/tests/test_storage_source_api.py apps/api/tests/test_ingest_queue_api.py apps/api/tests/test_operational_activity_api.py apps/api/tests/test_main.py -q`
- `uv run --group test python -m pytest apps/api/tests -q`