### PR TITLE
[codex] Implement staged ingest analysis pipeline for issue 126

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ packages/*/.venv/
 .env.*
 .envrc
 .local/
+.codex
 apps/api/.generated/
 *.egg-info/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,9 @@ The current ingest development path uses an API-owned persistence boundary.
 
 Contributors should assume:
 
-- worker-side ingest code queues `photo_metadata` submissions instead of mutating catalog tables directly
+- `poll-storage-sources` performs discovery and candidate scheduling only
+- queued workers hash content and, when needed, run metadata extraction, thumbnail generation, and face detection before persistence
+- duplicate-content files should reuse existing extracted artifacts by SHA instead of re-running full analysis
 - the API service owns processing queued submissions and writing domain tables
 - internal queue processing is triggered through the bounded API endpoint rather than ad hoc direct DB writes
 
@@ -222,7 +224,7 @@ For missing-file reconciliation verification, run `uv run python -m pytest apps/
 That targeted suite exercises a temporary watched-folder fixture and simulated time so contributors can verify `active`, `missing`, `deleted`, and recovery transitions without bringing up the full worker stack.
 
 For the source-aware central polling loop, register a storage source plus watched folder first, then run `uv run python -m app.cli poll-storage-sources --database-url <url>`.
-That command validates the source marker before scanning, surfaces source-aware failures in its exit code and stdout, and reconciles only enabled watched folders attached to registered storage sources.
+That command validates the source marker before scanning, surfaces source-aware failures in its exit code and stdout, reconciles only enabled watched folders attached to registered storage sources, and enqueues candidate work for downstream extraction instead of performing inline media analysis.
 
 ### Automated Version Updates
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ The project is still being shaped and documented. The architecture, operational 
 
 The current Phase 0 development path now uses an API-owned persistence boundary for ingest work:
 
-- the worker-side ingest flow queues `photo_metadata` submissions instead of writing catalog tables directly
+- `poll-storage-sources` now performs discovery and candidate scheduling only
+- queued workers hash content and, when needed, run metadata extraction, thumbnail generation, and face detection before persistence
+- duplicate-content files reuse existing extracted artifacts by SHA instead of re-running full analysis
 - the API owns queue processing and domain-table mutation
 - internal queue processing can be triggered through a bounded API endpoint for worker use
 

--- a/apps/api/app/db/queue.py
+++ b/apps/api/app/db/queue.py
@@ -137,6 +137,26 @@ class IngestQueueStore:
         )
         return bool(result.rowcount)
 
+    def requeue_terminal_in_transaction(
+        self,
+        ingest_queue_id: str,
+        *,
+        payload: dict,
+        connection: Connection,
+    ) -> bool:
+        result = connection.execute(
+            update(ingest_queue)
+            .where(ingest_queue.c.ingest_queue_id == ingest_queue_id)
+            .where(ingest_queue.c.status.in_(("failed", "completed")))
+            .values(
+                status="pending",
+                payload_json=payload,
+                processed_ts=None,
+                last_error=None,
+            )
+        )
+        return bool(result.rowcount)
+
     def list_pending(self) -> list[QueueRow]:
         return self.list_by_status("pending")
 

--- a/apps/api/app/db/queue.py
+++ b/apps/api/app/db/queue.py
@@ -157,6 +157,19 @@ class IngestQueueStore:
         )
         return bool(result.rowcount)
 
+    def get_row_in_transaction(
+        self,
+        ingest_queue_id: str,
+        *,
+        connection: Connection,
+    ) -> QueueRow | None:
+        row = connection.execute(
+            select(ingest_queue).where(ingest_queue.c.ingest_queue_id == ingest_queue_id)
+        ).mappings().one_or_none()
+        if row is None:
+            return None
+        return QueueRow(**row)
+
     def list_pending(self) -> list[QueueRow]:
         return self.list_by_status("pending")
 

--- a/apps/api/app/db/queue.py
+++ b/apps/api/app/db/queue.py
@@ -137,7 +137,7 @@ class IngestQueueStore:
         )
         return bool(result.rowcount)
 
-    def requeue_terminal_in_transaction(
+    def refresh_nonprocessing_in_transaction(
         self,
         ingest_queue_id: str,
         *,
@@ -147,7 +147,7 @@ class IngestQueueStore:
         result = connection.execute(
             update(ingest_queue)
             .where(ingest_queue.c.ingest_queue_id == ingest_queue_id)
-            .where(ingest_queue.c.status.in_(("failed", "completed")))
+            .where(ingest_queue.c.status.in_(("pending", "failed", "completed")))
             .values(
                 status="pending",
                 payload_json=payload,

--- a/apps/api/app/db/queue.py
+++ b/apps/api/app/db/queue.py
@@ -117,6 +117,26 @@ class IngestQueueStore:
             )
         return EnqueueResult(ingest_queue_id=existing_id, created=False)
 
+    def revive_failed_in_transaction(
+        self,
+        ingest_queue_id: str,
+        *,
+        payload: dict,
+        connection: Connection,
+    ) -> bool:
+        result = connection.execute(
+            update(ingest_queue)
+            .where(ingest_queue.c.ingest_queue_id == ingest_queue_id)
+            .where(ingest_queue.c.status == "failed")
+            .values(
+                status="pending",
+                payload_json=payload,
+                processed_ts=None,
+                last_error=None,
+            )
+        )
+        return bool(result.rowcount)
+
     def list_pending(self) -> list[QueueRow]:
         return self.list_by_status("pending")
 

--- a/apps/api/app/db/queue.py
+++ b/apps/api/app/db/queue.py
@@ -5,6 +5,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from uuid import uuid4
 
+from sqlalchemy.dialects.postgresql import insert as postgresql_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy import select, update
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
@@ -27,6 +29,12 @@ class QueueRow:
     last_attempt_ts: datetime | None
     processed_ts: datetime | None
     last_error: str | None
+
+
+@dataclass(frozen=True)
+class EnqueueResult:
+    ingest_queue_id: str
+    created: bool
 
 
 class IngestQueueStore:
@@ -60,6 +68,54 @@ class IngestQueueStore:
                 if existing_id is None:
                     raise exc
                 return existing_id
+
+    def enqueue_in_transaction(
+        self,
+        *,
+        payload_type: str,
+        payload: dict,
+        idempotency_key: str,
+        connection: Connection,
+    ) -> EnqueueResult:
+        queue_id = str(uuid4())
+        values = {
+            "ingest_queue_id": queue_id,
+            "payload_type": payload_type,
+            "payload_json": payload,
+            "idempotency_key": idempotency_key,
+        }
+        dialect_name = connection.dialect.name
+
+        if dialect_name == "sqlite":
+            inserted_id = connection.execute(
+                sqlite_insert(ingest_queue)
+                .values(**values)
+                .on_conflict_do_nothing(index_elements=[ingest_queue.c.idempotency_key])
+                .returning(ingest_queue.c.ingest_queue_id)
+            ).scalar_one_or_none()
+        elif dialect_name == "postgresql":
+            inserted_id = connection.execute(
+                postgresql_insert(ingest_queue)
+                .values(**values)
+                .on_conflict_do_nothing(index_elements=[ingest_queue.c.idempotency_key])
+                .returning(ingest_queue.c.ingest_queue_id)
+            ).scalar_one_or_none()
+        else:
+            inserted_id = _enqueue_with_integrity_fallback(connection=connection, values=values)
+
+        if inserted_id is not None:
+            return EnqueueResult(ingest_queue_id=inserted_id, created=True)
+
+        existing_id = connection.execute(
+            select(ingest_queue.c.ingest_queue_id).where(
+                ingest_queue.c.idempotency_key == idempotency_key
+            )
+        ).scalar_one_or_none()
+        if existing_id is None:
+            raise RuntimeError(
+                f"queue row lookup failed for idempotency key {idempotency_key}"
+            )
+        return EnqueueResult(ingest_queue_id=existing_id, created=False)
 
     def list_pending(self) -> list[QueueRow]:
         return self.list_by_status("pending")
@@ -218,6 +274,24 @@ def _is_duplicate_idempotency_key_error(exc: IntegrityError) -> bool:
         "unique constraint failed" in message
         or "duplicate key value violates unique constraint" in message
     )
+
+
+def _enqueue_with_integrity_fallback(
+    *,
+    connection: Connection,
+    values: dict[str, object],
+) -> str | None:
+    nested = connection.begin_nested()
+    try:
+        connection.execute(ingest_queue.insert().values(**values))
+    except IntegrityError as exc:
+        nested.rollback()
+        if not _is_duplicate_idempotency_key_error(exc):
+            raise exc
+        return None
+
+    nested.commit()
+    return str(values["ingest_queue_id"])
 
 
 def _processing_lease_cutoff(now: datetime | None = None) -> datetime:

--- a/apps/api/app/processing/ingest_persistence.py
+++ b/apps/api/app/processing/ingest_persistence.py
@@ -44,6 +44,25 @@ def build_photo_record(path: Path, *, canonical_path: str) -> PhotoRecord:
     stat = path.stat()
     image_metadata = extract_image_metadata(path)
     sha256 = _sha256_file(path)
+    return build_photo_record_from_sha(
+        path,
+        canonical_path=canonical_path,
+        sha256=sha256,
+        stat=stat,
+        image_metadata=image_metadata,
+    )
+
+
+def build_photo_record_from_sha(
+    path: Path,
+    *,
+    canonical_path: str,
+    sha256: str,
+    stat=None,
+    image_metadata=None,
+) -> PhotoRecord:
+    stat = stat or path.stat()
+    image_metadata = image_metadata or extract_image_metadata(path)
     photo_id = str(uuid5(NAMESPACE_URL, f"{canonical_path}:{sha256}"))
 
     return PhotoRecord(
@@ -64,6 +83,10 @@ def build_photo_record(path: Path, *, canonical_path: str) -> PhotoRecord:
         gps_longitude=image_metadata.gps_longitude,
         gps_altitude=image_metadata.gps_altitude,
     )
+
+
+def compute_photo_sha256(path: Path) -> str:
+    return _sha256_file(path)
 
 
 def build_ingest_submission(
@@ -135,6 +158,7 @@ def serialize_reused_content_submission(
     record: PhotoRecord,
     candidate_payload: dict,
     warnings: list[str],
+    detections: list[dict] | None = None,
 ) -> dict:
     payload = _serialize_record(record)
     payload.update(
@@ -143,11 +167,44 @@ def serialize_reused_content_submission(
             "storage_source_id": candidate_payload["storage_source_id"],
             "watched_folder_id": candidate_payload["watched_folder_id"],
             "relative_path": candidate_payload["relative_path"],
-            "detections": [],
+            "detections": _serialize_detections(detections or []),
             "warnings": warnings,
         }
     )
     return payload
+
+
+def lookup_existing_artifacts_by_sha(
+    connection: Connection,
+    sha256: str,
+) -> dict[str, object | None] | None:
+    rows = connection.execute(
+        select(
+            photos.c.photo_id,
+            photos.c.shot_ts,
+            photos.c.shot_ts_source,
+            photos.c.camera_make,
+            photos.c.camera_model,
+            photos.c.software,
+            photos.c.orientation,
+            photos.c.gps_latitude,
+            photos.c.gps_longitude,
+            photos.c.gps_altitude,
+            photos.c.thumbnail_jpeg,
+            photos.c.thumbnail_mime_type,
+            photos.c.thumbnail_width,
+            photos.c.thumbnail_height,
+            photos.c.faces_count,
+            photos.c.faces_detected_ts,
+        ).where(photos.c.sha256 == sha256)
+    ).mappings().all()
+
+    for row in rows:
+        reusable = _build_reusable_artifacts_payload(connection, row)
+        if reusable is not None:
+            return reusable
+
+    return None
 
 
 def upsert_photo(connection: Connection, record: PhotoRecord) -> bool:
@@ -338,6 +395,59 @@ def _face_row(photo_id: str, detection: dict) -> dict[str, object]:
     }
 
 
+def _build_reusable_artifacts_payload(
+    connection: Connection,
+    row: dict[str, object | None],
+) -> dict[str, object | None] | None:
+    if (
+        row["thumbnail_jpeg"] is None
+        or row["thumbnail_mime_type"] is None
+        or row["thumbnail_width"] is None
+        or row["thumbnail_height"] is None
+        or row["faces_detected_ts"] is None
+    ):
+        return None
+
+    detections = connection.execute(
+        select(
+            faces.c.face_id,
+            faces.c.person_id,
+            faces.c.bbox_x,
+            faces.c.bbox_y,
+            faces.c.bbox_w,
+            faces.c.bbox_h,
+            faces.c.bitmap,
+            faces.c.embedding,
+            faces.c.provenance,
+        )
+        .where(faces.c.photo_id == row["photo_id"])
+        .order_by(faces.c.face_id)
+    ).mappings().all()
+
+    if int(row["faces_count"] or 0) != len(detections):
+        return None
+
+    return {
+        "photo_id": row["photo_id"],
+        "shot_ts": row["shot_ts"],
+        "shot_ts_source": row["shot_ts_source"],
+        "camera_make": row["camera_make"],
+        "camera_model": row["camera_model"],
+        "software": row["software"],
+        "orientation": row["orientation"],
+        "gps_latitude": row["gps_latitude"],
+        "gps_longitude": row["gps_longitude"],
+        "gps_altitude": row["gps_altitude"],
+        "thumbnail_jpeg": row["thumbnail_jpeg"],
+        "thumbnail_mime_type": row["thumbnail_mime_type"],
+        "thumbnail_width": row["thumbnail_width"],
+        "thumbnail_height": row["thumbnail_height"],
+        "faces_count": int(row["faces_count"] or 0),
+        "faces_detected_ts": row["faces_detected_ts"],
+        "detections": [dict(detection) for detection in detections],
+    }
+
+
 def _sha256_file(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -401,6 +511,9 @@ __all__ = [
     "build_ingest_candidate_submission",
     "build_ingest_submission",
     "build_photo_record",
+    "build_photo_record_from_sha",
+    "compute_photo_sha256",
+    "lookup_existing_artifacts_by_sha",
     "serialize_extracted_content_submission",
     "serialize_reused_content_submission",
     "store_face_detections",

--- a/apps/api/app/processing/ingest_persistence.py
+++ b/apps/api/app/processing/ingest_persistence.py
@@ -199,7 +199,7 @@ def lookup_existing_artifacts_by_sha(
         ).where(photos.c.sha256 == sha256)
     ).mappings().all()
 
-    for row in rows:
+    for row in sorted(rows, key=_sha_reuse_sort_key):
         reusable = _build_reusable_artifacts_payload(connection, row)
         if reusable is not None:
             return reusable
@@ -482,6 +482,39 @@ def _build_reusable_artifacts_payload(
         "faces_detected_ts": row["faces_detected_ts"],
         "detections": [dict(detection) for detection in detections],
     }
+
+
+def _sha_reuse_sort_key(row: dict[str, object | None]) -> tuple[int, int, str]:
+    thumbnail_complete = all(
+        row[column] is not None
+        for column in (
+            "thumbnail_jpeg",
+            "thumbnail_mime_type",
+            "thumbnail_width",
+            "thumbnail_height",
+        )
+    )
+    faces_complete = row["faces_detected_ts"] is not None
+    metadata_score = sum(
+        1
+        for column in (
+            "shot_ts",
+            "shot_ts_source",
+            "camera_make",
+            "camera_model",
+            "software",
+            "orientation",
+            "gps_latitude",
+            "gps_longitude",
+            "gps_altitude",
+        )
+        if row[column] is not None
+    )
+    return (
+        0 if thumbnail_complete and faces_complete else 1,
+        -metadata_score,
+        str(row["photo_id"]),
+    )
 
 
 def _sha256_file(path: Path) -> str:

--- a/apps/api/app/processing/ingest_persistence.py
+++ b/apps/api/app/processing/ingest_persistence.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
@@ -78,6 +79,74 @@ def build_ingest_submission(
     )
     payload = _serialize_record(record)
     payload["idempotency_key"] = record.photo_id
+    return payload
+
+
+def build_ingest_candidate_submission(
+    path: Path,
+    *,
+    scan_root: Path,
+    canonical_path: str,
+    storage_source_id: str,
+    watched_folder_id: str,
+) -> dict:
+    relative_path = relative_photo_path(scan_root, path)
+    stat = path.stat()
+    modified_ts = _normalize_timestamp(_parse_timestamp(stat_timestamp_to_iso(stat.st_mtime))).isoformat()
+    return {
+        "payload_version": 1,
+        "storage_source_id": storage_source_id,
+        "watched_folder_id": watched_folder_id,
+        "canonical_path": canonical_path,
+        "runtime_path": str(path.resolve()),
+        "relative_path": relative_path,
+        "filesize": stat.st_size,
+        "modified_ts": modified_ts,
+        "modified_mtime_ns": stat.st_mtime_ns,
+        "idempotency_key": f"{watched_folder_id}:{relative_path}:{stat.st_size}:{stat.st_mtime_ns}",
+    }
+
+
+def serialize_extracted_content_submission(
+    *,
+    record: PhotoRecord,
+    storage_source_id: str,
+    watched_folder_id: str,
+    relative_path: str,
+    detections: list[dict],
+    warnings: list[str],
+) -> dict:
+    payload = _serialize_record(record)
+    payload.update(
+        {
+            "payload_version": 1,
+            "storage_source_id": storage_source_id,
+            "watched_folder_id": watched_folder_id,
+            "relative_path": relative_path,
+            "detections": _serialize_detections(detections),
+            "warnings": warnings,
+        }
+    )
+    return payload
+
+
+def serialize_reused_content_submission(
+    *,
+    record: PhotoRecord,
+    candidate_payload: dict,
+    warnings: list[str],
+) -> dict:
+    payload = _serialize_record(record)
+    payload.update(
+        {
+            "payload_version": 1,
+            "storage_source_id": candidate_payload["storage_source_id"],
+            "watched_folder_id": candidate_payload["watched_folder_id"],
+            "relative_path": candidate_payload["relative_path"],
+            "detections": [],
+            "warnings": warnings,
+        }
+    )
     return payload
 
 
@@ -184,8 +253,22 @@ def _serialize_record(record: PhotoRecord) -> dict:
         "gps_latitude": record.gps_latitude,
         "gps_longitude": record.gps_longitude,
         "gps_altitude": record.gps_altitude,
+        "thumbnail_jpeg": _encode_optional_thumbnail(record.thumbnail_jpeg),
+        "thumbnail_mime_type": record.thumbnail_mime_type,
+        "thumbnail_width": record.thumbnail_width,
+        "thumbnail_height": record.thumbnail_height,
         "faces_count": record.faces_count,
     }
+
+
+def _serialize_detections(detections: list[dict]) -> list[dict]:
+    return [
+        {
+            **detection,
+            "bitmap": _encode_optional_bytes(detection.get("bitmap")),
+        }
+        for detection in detections
+    ]
 
 
 def _photo_row_payload(
@@ -269,6 +352,16 @@ def _parse_timestamp(value: str | None) -> datetime | None:
     return datetime.fromisoformat(value)
 
 
+def _encode_optional_bytes(value: bytes | None) -> str | None:
+    if value is None:
+        return None
+    return base64.b64encode(value).decode("ascii")
+
+
+def _encode_optional_thumbnail(value: bytes | None) -> str | None:
+    return _encode_optional_bytes(value)
+
+
 def _format_optional_timestamp(value: datetime | None) -> str | None:
     if value is None:
         return None
@@ -305,8 +398,11 @@ def _update_photo_row(
 
 __all__ = [
     "PhotoRecord",
+    "build_ingest_candidate_submission",
     "build_ingest_submission",
     "build_photo_record",
+    "serialize_extracted_content_submission",
+    "serialize_reused_content_submission",
     "store_face_detections",
     "upsert_photo",
     "upsert_source_photo",

--- a/apps/api/app/processing/ingest_persistence.py
+++ b/apps/api/app/processing/ingest_persistence.py
@@ -292,6 +292,42 @@ def store_face_detections(connection: Connection, photo_id: str, detections: lis
     )
 
 
+def deserialize_photo_record(payload: dict) -> PhotoRecord:
+    return PhotoRecord(
+        photo_id=payload["photo_id"],
+        path=payload["path"],
+        sha256=payload["sha256"],
+        filesize=payload["filesize"],
+        ext=payload["ext"],
+        created_ts=_parse_timestamp(payload["created_ts"]),
+        modified_ts=_parse_timestamp(payload["modified_ts"]),
+        shot_ts=_parse_timestamp(payload.get("shot_ts")),
+        shot_ts_source=payload.get("shot_ts_source"),
+        camera_make=payload.get("camera_make"),
+        camera_model=payload.get("camera_model"),
+        software=payload.get("software"),
+        orientation=payload.get("orientation"),
+        gps_latitude=payload.get("gps_latitude"),
+        gps_longitude=payload.get("gps_longitude"),
+        gps_altitude=payload.get("gps_altitude"),
+        thumbnail_jpeg=_decode_optional_bytes(payload.get("thumbnail_jpeg")),
+        thumbnail_mime_type=payload.get("thumbnail_mime_type"),
+        thumbnail_width=payload.get("thumbnail_width"),
+        thumbnail_height=payload.get("thumbnail_height"),
+        faces_count=payload.get("faces_count", 0),
+    )
+
+
+def deserialize_detections(payload: list[dict] | None) -> list[dict]:
+    return [
+        {
+            **detection,
+            "bitmap": _decode_optional_bytes(detection.get("bitmap")),
+        }
+        for detection in (payload or [])
+    ]
+
+
 def _serialize_record(record: PhotoRecord) -> dict:
     return {
         "photo_id": record.photo_id,
@@ -472,6 +508,12 @@ def _encode_optional_thumbnail(value: bytes | None) -> str | None:
     return _encode_optional_bytes(value)
 
 
+def _decode_optional_bytes(value: str | None) -> bytes | None:
+    if value is None:
+        return None
+    return base64.b64decode(value)
+
+
 def _format_optional_timestamp(value: datetime | None) -> str | None:
     if value is None:
         return None
@@ -513,6 +555,8 @@ __all__ = [
     "build_photo_record",
     "build_photo_record_from_sha",
     "compute_photo_sha256",
+    "deserialize_detections",
+    "deserialize_photo_record",
     "lookup_existing_artifacts_by_sha",
     "serialize_extracted_content_submission",
     "serialize_reused_content_submission",

--- a/apps/api/app/processing/ingest_polling.py
+++ b/apps/api/app/processing/ingest_polling.py
@@ -12,13 +12,14 @@ from sqlalchemy.engine import Connection
 
 from app.db.config import resolve_missing_file_grace_period_days
 from app.db.ingest_runs import IngestRunStore
+from app.db.queue import IngestQueueStore
 from app.path_contract import build_rooted_photo_path, build_source_aware_photo_path, relative_photo_path
 from app.processing.ingest_common import IngestResult, iter_photo_files
 from app.processing.ingest_persistence import (
     PhotoRecord,
+    build_ingest_candidate_submission,
     build_photo_record,
     upsert_photo,
-    upsert_source_photo,
 )
 from app.services.file_reconciliation import (
     activate_observed_file,
@@ -31,7 +32,7 @@ from app.services.file_reconciliation import (
 )
 from app.services.source_registration import SourceRegistrationError, read_source_marker
 from app.services.thumbnails import generate_thumbnail
-from app.storage import create_db_engine, storage_source_aliases, watched_folders
+from app.storage import create_db_engine, photo_files, storage_source_aliases, watched_folders
 
 @dataclass(frozen=True)
 class RegisteredWatchedFolderTarget:
@@ -50,6 +51,7 @@ class RegisteredStorageSourceTarget:
 @dataclass(frozen=True)
 class WatchedFolderPollOutcome:
     scanned: int
+    enqueued: int
     inserted: int
     updated: int
     error_messages: tuple[str, ...]
@@ -108,6 +110,7 @@ def poll_registered_storage_sources(
     grace_period_days = resolve_missing_file_grace_period_days(missing_file_grace_period_days)
     engine = create_db_engine(database_url)
     run_store = IngestRunStore(database_url)
+    queue_store = IngestQueueStore(database_url)
 
     with engine.begin() as connection:
         targets = _load_registered_storage_source_targets(connection)
@@ -149,6 +152,8 @@ def poll_registered_storage_sources(
             try:
                 _validate_scan_root(scan_root)
                 for chunk_paths in _iter_chunks(iter_photo_files(scan_root), chunk_size=poll_chunk_size):
+                    outcome: WatchedFolderPollOutcome
+                    chunk_touched_photo_ids: set[str]
                     with engine.begin() as connection:
                         outcome, chunk_touched_photo_ids = _process_watched_folder_chunk(
                             connection,
@@ -162,12 +167,9 @@ def poll_registered_storage_sources(
                             reuse_existing_photo_by_sha=True,
                             now=at,
                             observed_relative_paths=observed_relative_paths,
+                            queue_store=queue_store,
+                            storage_source_id=source_target.storage_source_id,
                         )
-                        touched_photo_ids.update(chunk_touched_photo_ids)
-                        result.scanned += outcome.scanned
-                        result.inserted += outcome.inserted
-                        result.updated += outcome.updated
-                        result.errors.extend(outcome.error_messages)
                         _record_ingest_run(
                             run_store,
                             connection=connection,
@@ -178,6 +180,12 @@ def poll_registered_storage_sources(
                             files_updated=outcome.updated,
                             error_messages=outcome.error_messages,
                         )
+                    touched_photo_ids.update(chunk_touched_photo_ids)
+                    result.scanned += outcome.scanned
+                    result.enqueued += outcome.enqueued
+                    result.inserted += outcome.inserted
+                    result.updated += outcome.updated
+                    result.errors.extend(outcome.error_messages)
                 with engine.begin() as connection:
                     _finalize_watched_folder_scan(
                         connection,
@@ -257,8 +265,11 @@ def _process_watched_folder_chunk(
     reuse_existing_photo_by_sha: bool,
     now: datetime,
     observed_relative_paths: set[str],
+    queue_store: IngestQueueStore | None = None,
+    storage_source_id: str | None = None,
 ) -> tuple[WatchedFolderPollOutcome, set[str]]:
     scanned = 0
+    enqueued = 0
     inserted = 0
     updated_count = 0
     error_messages: list[str] = []
@@ -267,6 +278,52 @@ def _process_watched_folder_chunk(
     for photo_path in photo_paths:
         scanned += 1
         relative_path = relative_photo_path(source_root, photo_path)
+        observed_relative_paths.add(relative_path)
+        if reuse_existing_photo_by_sha:
+            assert queue_store is not None
+            assert storage_source_id is not None
+            payload = build_ingest_candidate_submission(
+                photo_path,
+                scan_root=source_root,
+                canonical_path=canonical_path_for_relative_path(relative_path),
+                storage_source_id=storage_source_id,
+                watched_folder_id=watched_folder_id,
+            )
+            enqueue_result = queue_store.enqueue_in_transaction(
+                payload_type="ingest_candidate",
+                payload=payload,
+                idempotency_key=payload["idempotency_key"],
+                connection=connection,
+            )
+            if enqueue_result.created:
+                enqueued += 1
+            existing_file = connection.execute(
+                select(
+                    photo_files.c.photo_id,
+                    photo_files.c.created_ts,
+                ).where(
+                    photo_files.c.watched_folder_id == watched_folder_id,
+                    photo_files.c.relative_path == relative_path,
+                )
+            ).mappings().one_or_none()
+            if existing_file is not None:
+                stat = photo_path.stat()
+                touched_photo_ids.add(
+                    activate_observed_file(
+                        connection,
+                        watched_folder_id=watched_folder_id,
+                        photo_id=existing_file["photo_id"],
+                        relative_path=relative_path,
+                        filename=photo_path.name,
+                        extension=photo_path.suffix.lower().removeprefix(".") or None,
+                        filesize=stat.st_size,
+                        created_ts=existing_file["created_ts"],
+                        modified_ts=datetime.fromtimestamp(stat.st_mtime, tz=now.tzinfo),
+                        now=now,
+                    )
+                )
+            continue
+
         record = build_photo_record(
             photo_path,
             canonical_path=canonical_path_for_relative_path(relative_path),
@@ -285,12 +342,7 @@ def _process_watched_folder_chunk(
                     "thumbnail_height": thumbnail.height,
                 }
             )
-        observed_relative_paths.add(relative_path)
-        if reuse_existing_photo_by_sha:
-            created, photo_id = upsert_source_photo(connection, record)
-        else:
-            created = upsert_photo(connection, record)
-            photo_id = record.photo_id
+        created = upsert_photo(connection, record)
         if created:
             inserted += 1
         else:
@@ -299,7 +351,7 @@ def _process_watched_folder_chunk(
             activate_observed_file(
                 connection,
                 watched_folder_id=watched_folder_id,
-                photo_id=photo_id,
+                photo_id=record.photo_id,
                 relative_path=relative_path,
                 filename=photo_path.name,
                 extension=record.ext,
@@ -313,6 +365,7 @@ def _process_watched_folder_chunk(
     return (
         WatchedFolderPollOutcome(
             scanned=scanned,
+            enqueued=enqueued,
             inserted=inserted,
             updated=updated_count,
             error_messages=tuple(error_messages),
@@ -365,6 +418,7 @@ def _reconcile_watched_folder_root(
         )
         return WatchedFolderPollOutcome(
             scanned=0,
+            enqueued=0,
             inserted=0,
             updated=0,
             error_messages=(),

--- a/apps/api/app/services/ingest_extraction_worker.py
+++ b/apps/api/app/services/ingest_extraction_worker.py
@@ -50,12 +50,17 @@ def process_candidate_payload(
         existing_artifacts = lookup_existing_artifacts_by_sha(connection, sha256)
 
     if existing_artifacts is not None:
-        reused_record = _build_reused_photo_record(
-            runtime_path,
-            canonical_path=payload["canonical_path"],
-            sha256=sha256,
-            existing_artifacts=existing_artifacts,
-        )
+        try:
+            reused_record = _build_reused_photo_record(
+                runtime_path,
+                canonical_path=payload["canonical_path"],
+                sha256=sha256,
+                existing_artifacts=existing_artifacts,
+            )
+        except OSError as exc:
+            if _is_missing_file_error(exc):
+                raise CandidateFileMissingError(f"candidate file missing: {runtime_path}") from exc
+            raise
         return ExtractionResult(
             extracted_payload=serialize_reused_content_submission(
                 record=reused_record,

--- a/apps/api/app/services/ingest_extraction_worker.py
+++ b/apps/api/app/services/ingest_extraction_worker.py
@@ -26,6 +26,10 @@ class ExtractionResult:
     analysis_performed: bool
 
 
+class CandidateFileMissingError(ValueError):
+    pass
+
+
 def process_candidate_payload(
     database_url,
     *,
@@ -33,7 +37,12 @@ def process_candidate_payload(
     face_detector=None,
 ) -> ExtractionResult:
     runtime_path = Path(payload["runtime_path"]).expanduser().resolve()
-    sha256 = compute_photo_sha256(runtime_path)
+    try:
+        sha256 = compute_photo_sha256(runtime_path)
+    except OSError as exc:
+        if _is_missing_file_error(exc):
+            raise CandidateFileMissingError(f"candidate file missing: {runtime_path}") from exc
+        raise
     warnings: list[str] = []
 
     engine = create_db_engine(database_url)
@@ -58,11 +67,16 @@ def process_candidate_payload(
             analysis_performed=False,
         )
 
-    record = build_photo_record_from_sha(
-        runtime_path,
-        canonical_path=payload["canonical_path"],
-        sha256=sha256,
-    )
+    try:
+        record = build_photo_record_from_sha(
+            runtime_path,
+            canonical_path=payload["canonical_path"],
+            sha256=sha256,
+        )
+    except OSError as exc:
+        if _is_missing_file_error(exc):
+            raise CandidateFileMissingError(f"candidate file missing: {runtime_path}") from exc
+        raise
 
     thumbnail_jpeg = None
     thumbnail_mime_type = None
@@ -71,6 +85,8 @@ def process_candidate_payload(
     try:
         thumbnail = generate_thumbnail(runtime_path)
     except Exception as exc:
+        if _is_missing_file_error(exc):
+            raise CandidateFileMissingError(f"candidate file missing: {runtime_path}") from exc
         warnings.append(f"thumbnail generation failed: {exc}")
     else:
         thumbnail_jpeg = thumbnail.jpeg_bytes
@@ -82,6 +98,8 @@ def process_candidate_payload(
     try:
         detections = detector.detect(runtime_path)
     except Exception as exc:
+        if _is_missing_file_error(exc):
+            raise CandidateFileMissingError(f"candidate file missing: {runtime_path}") from exc
         warnings.append(f"face detection failed: {exc}")
         detections = []
     extracted_record = PhotoRecord(
@@ -108,7 +126,7 @@ def process_candidate_payload(
     )
 
 
-__all__ = ["ExtractionResult", "process_candidate_payload"]
+__all__ = ["CandidateFileMissingError", "ExtractionResult", "process_candidate_payload"]
 
 
 def _build_reused_photo_record(
@@ -154,3 +172,7 @@ def _parse_optional_datetime(value: str | datetime | None) -> datetime | None:
     if value is None:
         return None
     return _parse_datetime(value)
+
+
+def _is_missing_file_error(exc: BaseException) -> bool:
+    return isinstance(exc, (FileNotFoundError, NotADirectoryError))

--- a/apps/api/app/services/ingest_extraction_worker.py
+++ b/apps/api/app/services/ingest_extraction_worker.py
@@ -34,6 +34,7 @@ def process_candidate_payload(
 ) -> ExtractionResult:
     runtime_path = Path(payload["runtime_path"]).expanduser().resolve()
     sha256 = compute_photo_sha256(runtime_path)
+    warnings: list[str] = []
 
     engine = create_db_engine(database_url)
     with engine.begin() as connection:
@@ -63,16 +64,33 @@ def process_candidate_payload(
         sha256=sha256,
     )
 
-    thumbnail = generate_thumbnail(runtime_path)
+    thumbnail_jpeg = None
+    thumbnail_mime_type = None
+    thumbnail_width = None
+    thumbnail_height = None
+    try:
+        thumbnail = generate_thumbnail(runtime_path)
+    except Exception as exc:
+        warnings.append(f"thumbnail generation failed: {exc}")
+    else:
+        thumbnail_jpeg = thumbnail.jpeg_bytes
+        thumbnail_mime_type = thumbnail.mime_type
+        thumbnail_width = thumbnail.width
+        thumbnail_height = thumbnail.height
+
     detector = face_detector if face_detector is not None else OpenCvFaceDetector()
-    detections = detector.detect(runtime_path)
+    try:
+        detections = detector.detect(runtime_path)
+    except Exception as exc:
+        warnings.append(f"face detection failed: {exc}")
+        detections = []
     extracted_record = PhotoRecord(
         **{
             **record.__dict__,
-            "thumbnail_jpeg": thumbnail.jpeg_bytes,
-            "thumbnail_mime_type": thumbnail.mime_type,
-            "thumbnail_width": thumbnail.width,
-            "thumbnail_height": thumbnail.height,
+            "thumbnail_jpeg": thumbnail_jpeg,
+            "thumbnail_mime_type": thumbnail_mime_type,
+            "thumbnail_width": thumbnail_width,
+            "thumbnail_height": thumbnail_height,
             "faces_count": len(detections),
         }
     )
@@ -83,7 +101,7 @@ def process_candidate_payload(
             watched_folder_id=payload["watched_folder_id"],
             relative_path=payload["relative_path"],
             detections=detections,
-            warnings=[],
+            warnings=warnings,
         ),
         reused_existing_artifacts=False,
         analysis_performed=True,

--- a/apps/api/app/services/ingest_extraction_worker.py
+++ b/apps/api/app/services/ingest_extraction_worker.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from uuid import NAMESPACE_URL, uuid5
+
+from app.db.session import create_db_engine
+from app.processing.faces import OpenCvFaceDetector
+from app.processing.ingest_persistence import (
+    PhotoRecord,
+    build_photo_record_from_sha,
+    compute_photo_sha256,
+    lookup_existing_artifacts_by_sha,
+    serialize_extracted_content_submission,
+    serialize_reused_content_submission,
+)
+from app.processing.metadata import stat_timestamp_to_iso
+from app.services.thumbnails import generate_thumbnail
+
+
+@dataclass(frozen=True)
+class ExtractionResult:
+    extracted_payload: dict
+    reused_existing_artifacts: bool
+    analysis_performed: bool
+
+
+def process_candidate_payload(
+    database_url,
+    *,
+    payload: dict,
+    face_detector=None,
+) -> ExtractionResult:
+    runtime_path = Path(payload["runtime_path"]).expanduser().resolve()
+    sha256 = compute_photo_sha256(runtime_path)
+
+    engine = create_db_engine(database_url)
+    with engine.begin() as connection:
+        existing_artifacts = lookup_existing_artifacts_by_sha(connection, sha256)
+
+    if existing_artifacts is not None:
+        reused_record = _build_reused_photo_record(
+            runtime_path,
+            canonical_path=payload["canonical_path"],
+            sha256=sha256,
+            existing_artifacts=existing_artifacts,
+        )
+        return ExtractionResult(
+            extracted_payload=serialize_reused_content_submission(
+                record=reused_record,
+                candidate_payload=payload,
+                warnings=[],
+                detections=existing_artifacts["detections"],
+            ),
+            reused_existing_artifacts=True,
+            analysis_performed=False,
+        )
+
+    record = build_photo_record_from_sha(
+        runtime_path,
+        canonical_path=payload["canonical_path"],
+        sha256=sha256,
+    )
+
+    thumbnail = generate_thumbnail(runtime_path)
+    detector = face_detector if face_detector is not None else OpenCvFaceDetector()
+    detections = detector.detect(runtime_path)
+    extracted_record = PhotoRecord(
+        **{
+            **record.__dict__,
+            "thumbnail_jpeg": thumbnail.jpeg_bytes,
+            "thumbnail_mime_type": thumbnail.mime_type,
+            "thumbnail_width": thumbnail.width,
+            "thumbnail_height": thumbnail.height,
+            "faces_count": len(detections),
+        }
+    )
+    return ExtractionResult(
+        extracted_payload=serialize_extracted_content_submission(
+            record=extracted_record,
+            storage_source_id=payload["storage_source_id"],
+            watched_folder_id=payload["watched_folder_id"],
+            relative_path=payload["relative_path"],
+            detections=detections,
+            warnings=[],
+        ),
+        reused_existing_artifacts=False,
+        analysis_performed=True,
+    )
+
+
+__all__ = ["ExtractionResult", "process_candidate_payload"]
+
+
+def _build_reused_photo_record(
+    path: Path,
+    *,
+    canonical_path: str,
+    sha256: str,
+    existing_artifacts: dict[str, object | None],
+) -> PhotoRecord:
+    stat = path.stat()
+    return PhotoRecord(
+        photo_id=str(uuid5(NAMESPACE_URL, f"{canonical_path}:{sha256}")),
+        path=canonical_path,
+        sha256=sha256,
+        filesize=stat.st_size,
+        ext=path.suffix.lower().lstrip("."),
+        created_ts=_parse_datetime(stat_timestamp_to_iso(stat.st_ctime)),
+        modified_ts=_parse_datetime(stat_timestamp_to_iso(stat.st_mtime)),
+        shot_ts=_parse_optional_datetime(existing_artifacts.get("shot_ts")),
+        shot_ts_source=existing_artifacts.get("shot_ts_source"),
+        camera_make=existing_artifacts.get("camera_make"),
+        camera_model=existing_artifacts.get("camera_model"),
+        software=existing_artifacts.get("software"),
+        orientation=existing_artifacts.get("orientation"),
+        gps_latitude=existing_artifacts.get("gps_latitude"),
+        gps_longitude=existing_artifacts.get("gps_longitude"),
+        gps_altitude=existing_artifacts.get("gps_altitude"),
+        thumbnail_jpeg=existing_artifacts["thumbnail_jpeg"],
+        thumbnail_mime_type=existing_artifacts["thumbnail_mime_type"],
+        thumbnail_width=existing_artifacts["thumbnail_width"],
+        thumbnail_height=existing_artifacts["thumbnail_height"],
+        faces_count=int(existing_artifacts["faces_count"] or 0),
+    )
+
+
+def _parse_datetime(value: str | datetime) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    return datetime.fromisoformat(value)
+
+
+def _parse_optional_datetime(value: str | datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    return _parse_datetime(value)

--- a/apps/api/app/services/ingest_queue_processor.py
+++ b/apps/api/app/services/ingest_queue_processor.py
@@ -21,7 +21,7 @@ from app.processing.ingest_persistence import (
     upsert_source_photo,
 )
 from app.services.file_reconciliation import activate_observed_file
-from app.services.ingest_extraction_worker import process_candidate_payload
+from app.services.ingest_extraction_worker import CandidateFileMissingError, process_candidate_payload
 from app.storage import photo_files
 
 
@@ -109,7 +109,7 @@ def process_pending_ingest_queue(
                         claimed_row,
                         detector=detector,
                     )
-                except (KeyError, TypeError, ValueError) as exc:
+                except (KeyError, TypeError, ValueError, CandidateFileMissingError) as exc:
                     error_detail = str(exc)
                     ingest_run_id, run_created_in_transaction = _ensure_ingest_run(
                         run_store,
@@ -281,11 +281,15 @@ def _process_claimed_row(
             payload=claimed_row.payload_json,
             record=record,
         )
-        store_face_detections(
-            connection,
-            record.photo_id,
-            deserialize_detections(claimed_row.payload_json.get("detections")),
-        )
+        if not _payload_has_warning_prefix(
+            claimed_row.payload_json,
+            "face detection failed:",
+        ):
+            store_face_detections(
+                connection,
+                record.photo_id,
+                deserialize_detections(claimed_row.payload_json.get("detections")),
+            )
         return created, _payload_warning_detail(claimed_row.payload_json)
 
     created = upsert_photo(connection, record)
@@ -347,6 +351,16 @@ def _payload_warning_detail(payload: dict) -> str | None:
     if not warning_messages:
         return None
     return "\n".join(warning_messages)
+
+
+def _payload_has_warning_prefix(payload: dict, prefix: str) -> bool:
+    warnings = payload.get("warnings")
+    if not isinstance(warnings, list):
+        return False
+    return any(
+        isinstance(warning, str) and warning.startswith(prefix)
+        for warning in warnings
+    )
 
 
 def _extracted_payload_idempotency_key(payload: dict) -> str:

--- a/apps/api/app/services/ingest_queue_processor.py
+++ b/apps/api/app/services/ingest_queue_processor.py
@@ -32,6 +32,10 @@ class ProcessQueueResult:
     retryable_errors: int = 0
 
 
+class ExtractedPayloadStillProcessingError(RuntimeError):
+    pass
+
+
 def process_pending_ingest_queue(
     database_url: str | Path | None = None,
     *,
@@ -265,11 +269,23 @@ def _process_claimed_row(
             connection=connection,
         )
         if not enqueue_result.created:
-            queue_store.refresh_nonprocessing_in_transaction(
+            refreshed = queue_store.refresh_nonprocessing_in_transaction(
                 enqueue_result.ingest_queue_id,
                 payload=extraction.extracted_payload,
                 connection=connection,
             )
+            if not refreshed:
+                collided_row = queue_store.get_row_in_transaction(
+                    enqueue_result.ingest_queue_id,
+                    connection=connection,
+                )
+                if collided_row is not None and collided_row.status == "processing":
+                    raise ExtractedPayloadStillProcessingError(
+                        "extracted payload row is currently processing; retry candidate later"
+                    )
+                raise RuntimeError(
+                    "failed to refresh collided extracted payload row"
+                )
         return None, _payload_warning_detail(extraction.extracted_payload)
 
     record = payload_to_photo_record(claimed_row.payload_json)

--- a/apps/api/app/services/ingest_queue_processor.py
+++ b/apps/api/app/services/ingest_queue_processor.py
@@ -265,7 +265,7 @@ def _process_claimed_row(
             connection=connection,
         )
         if not enqueue_result.created:
-            queue_store.revive_failed_in_transaction(
+            queue_store.requeue_terminal_in_transaction(
                 enqueue_result.ingest_queue_id,
                 payload=extraction.extracted_payload,
                 connection=connection,

--- a/apps/api/app/services/ingest_queue_processor.py
+++ b/apps/api/app/services/ingest_queue_processor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 
 from sqlalchemy.exc import IntegrityError
@@ -11,7 +10,14 @@ from app.db import IngestRunFileOutcome, IngestRunStore
 from app.db.queue import IngestQueueStore, PROCESSING_LEASE_SECONDS
 from app.db.session import create_db_engine
 from app.processing.faces import OpenCvFaceDetector
-from app.processing.ingest import PhotoRecord, store_face_detections, upsert_photo
+from app.processing.ingest_persistence import (
+    PhotoRecord,
+    deserialize_detections,
+    deserialize_photo_record,
+    store_face_detections,
+    upsert_photo,
+)
+from app.services.ingest_extraction_worker import process_candidate_payload
 
 
 @dataclass(frozen=True)
@@ -48,7 +54,7 @@ def process_pending_ingest_queue(
     file_outcomes: list[str] = []
     for row in processable_rows:
         claimed_row = None
-        claimed_path = _payload_path(row.payload_json)
+        claimed_path = _file_outcome_path(row)
         run_created_in_transaction = False
         try:
             with engine.begin() as connection:
@@ -59,8 +65,12 @@ def process_pending_ingest_queue(
                 if claimed_row is None:
                     continue
                 files_seen += 1
-                claimed_path = _payload_path(claimed_row.payload_json)
-                if claimed_row.payload_type != "photo_metadata":
+                claimed_path = _file_outcome_path(claimed_row)
+                if claimed_row.payload_type not in {
+                    "photo_metadata",
+                    "ingest_candidate",
+                    "extracted_photo",
+                }:
                     error_detail = f"Unsupported payload_type: {claimed_row.payload_type}"
                     ingest_run_id, run_created_in_transaction = _ensure_ingest_run(
                         run_store,
@@ -87,7 +97,13 @@ def process_pending_ingest_queue(
                     error_messages.append(error_detail)
                     continue
                 try:
-                    record = payload_to_photo_record(claimed_row.payload_json)
+                    created, completion_warning = _process_claimed_row(
+                        database_url,
+                        queue_store,
+                        connection,
+                        claimed_row,
+                        detector=detector,
+                    )
                 except (KeyError, TypeError, ValueError) as exc:
                     error_detail = str(exc)
                     ingest_run_id, run_created_in_transaction = _ensure_ingest_run(
@@ -114,12 +130,6 @@ def process_pending_ingest_queue(
                     failed += 1
                     error_messages.append(error_detail)
                     continue
-                created = upsert_photo(connection, record)
-                detection_warning = _apply_face_detection(
-                    connection,
-                    record,
-                    detector,
-                )
                 ingest_run_id, run_created_in_transaction = _ensure_ingest_run(
                     run_store,
                     ingest_run_id,
@@ -127,26 +137,26 @@ def process_pending_ingest_queue(
                 )
                 run_store.append_file_outcome(
                     ingest_run_id,
-                    IngestRunFileOutcome(
-                        ingest_queue_id=claimed_row.ingest_queue_id,
-                        path=record.path,
-                        outcome="completed",
-                        error_detail=detection_warning,
-                    ),
-                    connection=connection,
-                )
+                        IngestRunFileOutcome(
+                            ingest_queue_id=claimed_row.ingest_queue_id,
+                            path=_file_outcome_path(claimed_row),
+                            outcome="completed",
+                            error_detail=completion_warning,
+                        ),
+                        connection=connection,
+                    )
                 queue_store.mark_completed(
                     claimed_row.ingest_queue_id,
-                    last_error=detection_warning,
+                    last_error=completion_warning,
                     connection=connection,
                 )
                 file_outcomes.append("completed")
-                if created:
+                if created is True:
                     files_created += 1
-                else:
+                elif created is False:
                     files_updated += 1
-                if detection_warning is not None:
-                    error_messages.append(detection_warning)
+                if completion_warning is not None:
+                    error_messages.append(completion_warning)
             processed += 1
         except IntegrityError as exc:
             if run_created_in_transaction:
@@ -207,31 +217,7 @@ def process_pending_ingest_queue(
 
 
 def payload_to_photo_record(payload: dict) -> PhotoRecord:
-    return PhotoRecord(
-        photo_id=payload["photo_id"],
-        path=payload["path"],
-        sha256=payload["sha256"],
-        filesize=payload["filesize"],
-        ext=payload["ext"],
-        created_ts=datetime.fromisoformat(payload["created_ts"]),
-        modified_ts=datetime.fromisoformat(payload["modified_ts"]),
-        shot_ts=_parse_optional_timestamp(payload.get("shot_ts")),
-        shot_ts_source=payload.get("shot_ts_source"),
-        camera_make=payload.get("camera_make"),
-        camera_model=payload.get("camera_model"),
-        software=payload.get("software"),
-        orientation=payload.get("orientation"),
-        gps_latitude=payload.get("gps_latitude"),
-        gps_longitude=payload.get("gps_longitude"),
-        gps_altitude=payload.get("gps_altitude"),
-        faces_count=payload.get("faces_count", 0),
-    )
-
-
-def _parse_optional_timestamp(value: str | None) -> datetime | None:
-    if value is None:
-        return None
-    return datetime.fromisoformat(value)
+    return deserialize_photo_record(payload)
 
 
 def _payload_path(payload: object) -> str:
@@ -253,12 +239,69 @@ def _ensure_ingest_run(
     return run_store.create_run(connection=connection), True
 
 
+def _process_claimed_row(
+    database_url,
+    queue_store: IngestQueueStore,
+    connection: Connection,
+    claimed_row,
+    *,
+    detector,
+) -> tuple[bool | None, str | None]:
+    if claimed_row.payload_type == "ingest_candidate":
+        extraction = process_candidate_payload(
+            database_url,
+            payload=claimed_row.payload_json,
+            face_detector=detector,
+        )
+        enqueue_result = queue_store.enqueue_in_transaction(
+            payload_type="extracted_photo",
+            payload=extraction.extracted_payload,
+            idempotency_key=_extracted_payload_idempotency_key(extraction.extracted_payload),
+            connection=connection,
+        )
+        if not enqueue_result.created:
+            queue_store.revive_failed_in_transaction(
+                enqueue_result.ingest_queue_id,
+                payload=extraction.extracted_payload,
+                connection=connection,
+            )
+        return None, _payload_warning_detail(extraction.extracted_payload)
+
+    record = payload_to_photo_record(claimed_row.payload_json)
+    created = upsert_photo(connection, record)
+
+    if claimed_row.payload_type == "extracted_photo":
+        store_face_detections(
+            connection,
+            record.photo_id,
+            deserialize_detections(claimed_row.payload_json.get("detections")),
+        )
+        return created, _payload_warning_detail(claimed_row.payload_json)
+
+    detection_warning = _apply_face_detection(
+        connection,
+        record,
+        detector,
+    )
+    return created, detection_warning
+
+
 def _run_status(file_outcomes: list[str]) -> str:
     if file_outcomes and all(outcome == "completed" for outcome in file_outcomes):
         return "completed"
     if file_outcomes and all(outcome == "failed" for outcome in file_outcomes):
         return "failed"
     return "partial"
+
+
+def _file_outcome_path(claimed_row) -> str:
+    payload_type = getattr(claimed_row, "payload_type", None)
+    payload_json = getattr(claimed_row, "payload_json", None)
+    if payload_type == "ingest_candidate" and isinstance(payload_json, dict):
+        canonical_path = payload_json.get("canonical_path")
+        if isinstance(canonical_path, str) and canonical_path:
+            return canonical_path
+    return _payload_path(payload_json)
 
 
 def _error_summary(error_messages: list[str]) -> str | None:
@@ -283,6 +326,20 @@ def _distinct_error_messages(error_messages: list[str]) -> list[str]:
         seen.add(error_message)
         distinct_messages.append(error_message)
     return distinct_messages
+
+
+def _payload_warning_detail(payload: dict) -> str | None:
+    warnings = payload.get("warnings")
+    if not isinstance(warnings, list):
+        return None
+    warning_messages = [warning for warning in warnings if isinstance(warning, str) and warning]
+    if not warning_messages:
+        return None
+    return "\n".join(warning_messages)
+
+
+def _extracted_payload_idempotency_key(payload: dict) -> str:
+    return f"extracted:{payload['photo_id']}"
 
 
 def _apply_face_detection(connection, record: PhotoRecord, detector) -> str | None:

--- a/apps/api/app/services/ingest_queue_processor.py
+++ b/apps/api/app/services/ingest_queue_processor.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from dataclasses import dataclass
 from pathlib import Path
 
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.engine import Connection
 
@@ -16,8 +18,11 @@ from app.processing.ingest_persistence import (
     deserialize_photo_record,
     store_face_detections,
     upsert_photo,
+    upsert_source_photo,
 )
+from app.services.file_reconciliation import activate_observed_file
 from app.services.ingest_extraction_worker import process_candidate_payload
+from app.storage import photo_files
 
 
 @dataclass(frozen=True)
@@ -268,9 +273,14 @@ def _process_claimed_row(
         return None, _payload_warning_detail(extraction.extracted_payload)
 
     record = payload_to_photo_record(claimed_row.payload_json)
-    created = upsert_photo(connection, record)
-
     if claimed_row.payload_type == "extracted_photo":
+        created, photo_id = upsert_source_photo(connection, record)
+        record = PhotoRecord(**{**record.__dict__, "photo_id": photo_id})
+        _activate_source_backed_file_instance(
+            connection,
+            payload=claimed_row.payload_json,
+            record=record,
+        )
         store_face_detections(
             connection,
             record.photo_id,
@@ -278,6 +288,7 @@ def _process_claimed_row(
         )
         return created, _payload_warning_detail(claimed_row.payload_json)
 
+    created = upsert_photo(connection, record)
     detection_warning = _apply_face_detection(
         connection,
         record,
@@ -340,6 +351,37 @@ def _payload_warning_detail(payload: dict) -> str | None:
 
 def _extracted_payload_idempotency_key(payload: dict) -> str:
     return f"extracted:{payload['photo_id']}"
+
+
+def _activate_source_backed_file_instance(
+    connection: Connection,
+    *,
+    payload: dict,
+    record: PhotoRecord,
+) -> None:
+    watched_folder_id = payload.get("watched_folder_id")
+    relative_path = payload.get("relative_path")
+    if not isinstance(watched_folder_id, str) or not isinstance(relative_path, str):
+        return
+
+    existing_created_ts = connection.execute(
+        select(photo_files.c.created_ts).where(
+            photo_files.c.watched_folder_id == watched_folder_id,
+            photo_files.c.relative_path == relative_path,
+        )
+    ).scalar_one_or_none()
+    activate_observed_file(
+        connection,
+        watched_folder_id=watched_folder_id,
+        photo_id=record.photo_id,
+        relative_path=relative_path,
+        filename=Path(relative_path).name,
+        extension=record.ext or None,
+        filesize=record.filesize,
+        created_ts=existing_created_ts or record.created_ts,
+        modified_ts=record.modified_ts,
+        now=datetime.now(tz=UTC),
+    )
 
 
 def _apply_face_detection(connection, record: PhotoRecord, detector) -> str | None:

--- a/apps/api/app/services/ingest_queue_processor.py
+++ b/apps/api/app/services/ingest_queue_processor.py
@@ -265,7 +265,7 @@ def _process_claimed_row(
             connection=connection,
         )
         if not enqueue_result.created:
-            queue_store.requeue_terminal_in_transaction(
+            queue_store.refresh_nonprocessing_in_transaction(
                 enqueue_result.ingest_queue_id,
                 payload=extraction.extracted_payload,
                 connection=connection,

--- a/apps/api/tests/test_ingest.py
+++ b/apps/api/tests/test_ingest.py
@@ -1428,6 +1428,10 @@ def test_duplicate_sha_candidate_reuses_complete_artifacts_even_when_an_incomple
     original_photo = load_photo_row(db_url, original_canonical_path)
     assert original_photo["thumbnail_mime_type"] == "image/jpeg"
     assert original_photo["faces_count"] == 1
+    original_file = load_photo_file_row(db_url, "original.jpg")
+    assert original_file["photo_id"] == original_photo["photo_id"]
+    assert original_file["watched_folder_id"] == _watched_folder_id
+    assert original_file["lifecycle_state"] == "active"
 
     shutil.copy2(source_asset, duplicate_path)
     result = poll_registered_storage_sources(database_url=db_url, now=now + timedelta(minutes=1))
@@ -1443,30 +1447,36 @@ def test_duplicate_sha_candidate_reuses_complete_artifacts_even_when_an_incomple
         limit=10,
         face_detector=RaisingFaceDetector(),
     )
+    persist_reuse_pass = process_pending_ingest_queue(
+        db_url,
+        limit=10,
+        face_detector=RaisingFaceDetector(),
+    )
 
     assert reuse_pass.processed == 1
+    assert persist_reuse_pass.processed == 1
     pending_rows = load_pending_queue_rows(db_url)
-    reused_payload = next(
-        row.payload_json
-        for row in pending_rows
-        if row.payload_type == "extracted_photo" and row.payload_json["relative_path"] == "dup.jpg"
-    )
-    assert reused_payload["path"] == duplicate_canonical_path
-    assert base64.b64decode(reused_payload["thumbnail_jpeg"]) == original_photo["thumbnail_jpeg"]
-    assert reused_payload["faces_count"] == 1
-    assert reused_payload["detections"] == [
-        {
-            "face_id": "face-1",
-            "bbox_x": 10,
-            "bbox_y": 11,
-            "bbox_w": 12,
-            "bbox_h": 13,
-            "bitmap": "ZXhpc3RpbmctZmFjZQ==",
-            "embedding": None,
-            "provenance": {"detector": "existing"},
-            "person_id": None,
-        }
-    ]
+    assert pending_rows == []
+
+    engine = create_engine(db_url, future=True)
+    with engine.connect() as connection:
+        same_sha_count = connection.execute(
+            select(func.count())
+            .select_from(photos)
+            .where(photos.c.sha256 == original_photo["sha256"])
+        ).scalar_one()
+    assert same_sha_count == 1
+
+    updated_photo = load_photo_row_by_id(db_url, original_photo["photo_id"])
+    assert updated_photo["path"] == duplicate_canonical_path
+
+    duplicate_file = load_photo_file_row(db_url, "dup.jpg")
+    assert duplicate_file["photo_id"] == original_photo["photo_id"]
+    assert duplicate_file["watched_folder_id"] == _watched_folder_id
+    assert duplicate_file["lifecycle_state"] == "active"
+
+    file_rows = load_photo_file_rows(db_url, original_photo["photo_id"])
+    assert [row["relative_path"] for row in file_rows] == ["dup.jpg", "original.jpg"]
 
 
 def test_poll_registered_storage_sources_preserves_existing_face_detection_timestamp(

--- a/apps/api/tests/test_ingest.py
+++ b/apps/api/tests/test_ingest.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime, timedelta
+import base64
 import posixpath
 import shutil
 from pathlib import Path
@@ -20,6 +21,7 @@ from app.services.file_reconciliation import (
     reconcile_watched_folder,
     refresh_photo_deleted_timestamps,
 )
+from app.services.ingest_queue_processor import process_pending_ingest_queue
 from app.services.source_registration import MARKER_FILENAME
 from app.services.storage_sources import attach_storage_source_alias, create_storage_source
 from app.services.watched_folders import create_watched_folder
@@ -1353,6 +1355,118 @@ def test_poll_registered_storage_sources_reassesses_existing_locations_for_same_
         source_id,
         f"exports/{asset_name}",
     )
+
+
+def test_duplicate_sha_candidate_reuses_complete_artifacts_even_when_an_incomplete_row_exists_first(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    source_root = tmp_path / "library"
+    watched_path = source_root / "imports"
+    watched_path.mkdir(parents=True)
+    asset_name = "birthday_park_001.jpg"
+    source_asset = SEED_CORPUS_DIR / "family-events" / "birthday-park" / asset_name
+    original_path = watched_path / "original.jpg"
+    duplicate_path = watched_path / "dup.jpg"
+    shutil.copy2(source_asset, original_path)
+
+    db_url = f"sqlite:///{tmp_path / 'duplicate-sha-reuse.db'}"
+    upgrade_database(db_url)
+
+    now = datetime(2026, 3, 29, 14, 0, tzinfo=UTC)
+    source_id, _watched_folder_id = seed_registered_storage_source_with_watched_folder(
+        db_url,
+        root_path=source_root,
+        watched_path=watched_path,
+        display_name="Library Imports",
+        now=now,
+    )
+    original_canonical_path = _source_aware_photo_path(source_id, "imports/original.jpg")
+    duplicate_canonical_path = _source_aware_photo_path(source_id, "imports/dup.jpg")
+
+    class StaticFaceDetector:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def detect(self, path: Path) -> list[dict]:
+            self.calls += 1
+            return [
+                {
+                    "face_id": "face-1",
+                    "bbox_x": 10,
+                    "bbox_y": 11,
+                    "bbox_w": 12,
+                    "bbox_h": 13,
+                    "bitmap": b"existing-face",
+                    "embedding": None,
+                    "provenance": {"detector": "existing"},
+                    "person_id": None,
+                }
+            ]
+
+    detector = StaticFaceDetector()
+
+    result = poll_registered_storage_sources(database_url=db_url, now=now)
+    assert result.scanned == 1
+    assert result.enqueued == 1
+
+    first_pass = process_pending_ingest_queue(
+        db_url,
+        limit=10,
+        face_detector=detector,
+    )
+    second_pass = process_pending_ingest_queue(
+        db_url,
+        limit=10,
+        face_detector=detector,
+    )
+
+    assert detector.calls == 1
+    assert first_pass.processed == 1
+    assert second_pass.processed == 1
+
+    original_photo = load_photo_row(db_url, original_canonical_path)
+    assert original_photo["thumbnail_mime_type"] == "image/jpeg"
+    assert original_photo["faces_count"] == 1
+
+    shutil.copy2(source_asset, duplicate_path)
+    result = poll_registered_storage_sources(database_url=db_url, now=now + timedelta(minutes=1))
+    assert result.scanned == 2
+    assert result.enqueued == 1
+
+    class RaisingFaceDetector:
+        def detect(self, path: Path) -> list[dict]:
+            raise AssertionError("face detector should not run for reusable duplicate content")
+
+    reuse_pass = process_pending_ingest_queue(
+        db_url,
+        limit=10,
+        face_detector=RaisingFaceDetector(),
+    )
+
+    assert reuse_pass.processed == 1
+    pending_rows = load_pending_queue_rows(db_url)
+    reused_payload = next(
+        row.payload_json
+        for row in pending_rows
+        if row.payload_type == "extracted_photo" and row.payload_json["relative_path"] == "dup.jpg"
+    )
+    assert reused_payload["path"] == duplicate_canonical_path
+    assert base64.b64decode(reused_payload["thumbnail_jpeg"]) == original_photo["thumbnail_jpeg"]
+    assert reused_payload["faces_count"] == 1
+    assert reused_payload["detections"] == [
+        {
+            "face_id": "face-1",
+            "bbox_x": 10,
+            "bbox_y": 11,
+            "bbox_w": 12,
+            "bbox_h": 13,
+            "bitmap": "ZXhpc3RpbmctZmFjZQ==",
+            "embedding": None,
+            "provenance": {"detector": "existing"},
+            "person_id": None,
+        }
+    ]
 
 
 def test_poll_registered_storage_sources_preserves_existing_face_detection_timestamp(

--- a/apps/api/tests/test_ingest.py
+++ b/apps/api/tests/test_ingest.py
@@ -738,7 +738,8 @@ def test_poll_registered_storage_sources_scans_enabled_registered_watched_folder
     result = poll_registered_storage_sources(database_url=db_url, now=now)
 
     assert result.scanned == 6
-    assert result.inserted == 6
+    assert result.enqueued == 6
+    assert result.inserted == 0
     assert result.updated == 0
     assert result.errors == []
 
@@ -752,14 +753,19 @@ def test_poll_registered_storage_sources_scans_enabled_registered_watched_folder
     assert source["last_failure_reason"] is None
     assert source["last_validated_ts"] == now
 
-    photo = load_photo_row(
-        db_url,
-        _source_aware_photo_path(
-            source_id,
-            "family-events/birthday-park/birthday_park_001.jpg",
-        ),
+    queue_rows = load_pending_queue_rows(db_url)
+    assert len(queue_rows) == 6
+    sample = next(
+        row
+        for row in queue_rows
+        if row.payload_json["relative_path"] == "family-events/birthday-park/birthday_park_001.jpg"
     )
-    assert photo["thumbnail_mime_type"] == "image/jpeg"
+    assert sample.payload_type == "ingest_candidate"
+    assert sample.payload_json["canonical_path"] == _source_aware_photo_path(
+        source_id,
+        "family-events/birthday-park/birthday_park_001.jpg",
+    )
+    assert "thumbnail_jpeg" not in sample.payload_json
 
 
 def test_poll_registered_storage_sources_ignores_legacy_scan_path_for_identity(
@@ -789,18 +795,17 @@ def test_poll_registered_storage_sources_ignores_legacy_scan_path_for_identity(
     result = poll_registered_storage_sources(database_url=db_url, now=now)
 
     assert result.errors == []
-    photo = load_photo_row(
-        db_url,
-        _source_aware_photo_path(
-            source_id,
-            "family-events/birthday-park/birthday_park_001.jpg",
-        ),
+    queue_rows = load_pending_queue_rows(db_url)
+    sample = next(
+        row
+        for row in queue_rows
+        if row.payload_json["relative_path"] == "family-events/birthday-park/birthday_park_001.jpg"
     )
-    assert photo["path"] == _source_aware_photo_path(
+    assert sample.payload_json["canonical_path"] == _source_aware_photo_path(
         source_id,
         "family-events/birthday-park/birthday_park_001.jpg",
     )
-    assert not photo["path"].startswith("/legacy/photos/")
+    assert not sample.payload_json["canonical_path"].startswith("/legacy/photos/")
 
 
 def test_poll_registered_storage_sources_aborts_reconciliation_on_marker_mismatch(
@@ -833,6 +838,7 @@ def test_poll_registered_storage_sources_aborts_reconciliation_on_marker_mismatc
     failed_result = poll_registered_storage_sources(database_url=db_url, now=failed_now)
 
     assert failed_result.scanned == 0
+    assert failed_result.enqueued == 0
     assert failed_result.inserted == 0
     assert failed_result.updated == 0
     assert failed_result.errors == [
@@ -849,13 +855,7 @@ def test_poll_registered_storage_sources_aborts_reconciliation_on_marker_mismatc
     assert watched_folder["last_failure_reason"] == "marker_mismatch"
     assert watched_folder["last_successful_scan_ts"] == healthy_now
 
-    photo_file = load_photo_file_row(
-        db_url,
-        "family-events/birthday-park/birthday_park_006.jpg",
-    )
-    assert photo_file["lifecycle_state"] == "active"
-    assert photo_file["missing_ts"] is None
-    assert photo_file["deleted_ts"] is None
+    assert load_pending_queue_count(db_url) == 6
 
 
 def test_poll_registered_storage_sources_reports_missing_marker_file(
@@ -966,7 +966,7 @@ def test_poll_registered_storage_sources_records_chunked_ingest_runs_for_success
     upgrade_database(db_url)
 
     now = datetime(2026, 3, 28, 22, 45, tzinfo=UTC)
-    _, watched_folder_id = seed_registered_storage_source_with_watched_folder(
+    source_id, watched_folder_id = seed_registered_storage_source_with_watched_folder(
         db_url,
         root_path=staged_corpus_dir,
         watched_path=staged_corpus_dir,
@@ -981,6 +981,7 @@ def test_poll_registered_storage_sources_records_chunked_ingest_runs_for_success
     )
 
     assert result.scanned == 6
+    assert result.enqueued == 6
 
     run_rows = load_ingest_runs(database_url=db_url)
     assert len(run_rows) == 3
@@ -994,7 +995,7 @@ def test_poll_registered_storage_sources_records_chunked_ingest_runs_for_success
         ("completed", 2),
         ("completed", 2),
     ]
-    assert sum(row["files_created"] for row in run_rows) == 6
+    assert sum(row["files_created"] for row in run_rows) == 0
     assert all(row["files_updated"] == 0 for row in run_rows)
     assert all(row["error_count"] == 0 for row in run_rows)
     assert all(row["error_summary"] is None for row in run_rows)
@@ -1011,7 +1012,7 @@ def test_poll_registered_storage_sources_defers_reconciliation_until_after_chunk
     upgrade_database(db_url)
 
     initial_now = datetime(2026, 3, 28, 22, 50, tzinfo=UTC)
-    _, watched_folder_id = seed_registered_storage_source_with_watched_folder(
+    source_id, watched_folder_id = seed_registered_storage_source_with_watched_folder(
         db_url,
         root_path=staged_corpus_dir,
         watched_path=staged_corpus_dir,
@@ -1025,6 +1026,69 @@ def test_poll_registered_storage_sources_defers_reconciliation_until_after_chunk
         poll_chunk_size=10,
     )
     assert first_result.errors == []
+    assert load_pending_queue_count(db_url) == 6
+
+    existing_relative_path = "family-events/birthday-park/birthday_park_006.jpg"
+    existing_asset = staged_corpus_dir / existing_relative_path
+    existing_record = ingest_module.build_photo_record(
+        existing_asset,
+        canonical_path=_source_aware_photo_path(source_id, existing_relative_path),
+    )
+    engine = create_engine(db_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id=existing_record.photo_id,
+                path=existing_record.path,
+                sha256=existing_record.sha256,
+                phash=None,
+                filesize=existing_record.filesize,
+                ext=existing_record.ext,
+                created_ts=existing_record.created_ts,
+                modified_ts=existing_record.modified_ts,
+                shot_ts=existing_record.shot_ts,
+                shot_ts_source=existing_record.shot_ts_source,
+                camera_make=existing_record.camera_make,
+                camera_model=existing_record.camera_model,
+                software=existing_record.software,
+                orientation=existing_record.orientation,
+                gps_latitude=existing_record.gps_latitude,
+                gps_longitude=existing_record.gps_longitude,
+                gps_altitude=existing_record.gps_altitude,
+                thumbnail_jpeg=None,
+                thumbnail_mime_type=None,
+                thumbnail_width=None,
+                thumbnail_height=None,
+                updated_ts=existing_record.modified_ts,
+                deleted_ts=None,
+                faces_count=0,
+                faces_detected_ts=None,
+            )
+        )
+        connection.execute(
+            insert(photo_files).values(
+                photo_file_id=str(
+                    uuid5(
+                        NAMESPACE_URL,
+                        f"photo-file:{watched_folder_id}:{existing_relative_path}",
+                    )
+                ),
+                photo_id=existing_record.photo_id,
+                watched_folder_id=watched_folder_id,
+                relative_path=existing_relative_path,
+                filename=existing_asset.name,
+                extension=existing_record.ext,
+                filesize=existing_record.filesize,
+                created_ts=existing_record.created_ts,
+                modified_ts=existing_record.modified_ts,
+                first_seen_ts=initial_now,
+                last_seen_ts=initial_now,
+                missing_ts=None,
+                deleted_ts=None,
+                lifecycle_state="active",
+                absence_reason=None,
+            )
+        )
 
     checkpoint_states: list[tuple[str, datetime | None, datetime | None]] = []
     original_iter_photo_files = ingest_polling.iter_photo_files
@@ -1036,7 +1100,7 @@ def test_poll_registered_storage_sources_defers_reconciliation_until_after_chunk
             if yielded == 3:
                 later_file = load_photo_file_row(
                     db_url,
-                    "family-events/birthday-park/birthday_park_006.jpg",
+                    existing_relative_path,
                 )
                 checkpoint_states.append(
                     (
@@ -1063,11 +1127,7 @@ def test_poll_registered_storage_sources_defers_reconciliation_until_after_chunk
     assert watched_folder["availability_state"] == "active"
     assert watched_folder["last_failure_reason"] is None
     assert watched_folder["last_successful_scan_ts"] == second_now
-
-    later_file = load_photo_file_row(
-        db_url,
-        "family-events/birthday-park/birthday_park_006.jpg",
-    )
+    later_file = load_photo_file_row(db_url, existing_relative_path)
     assert later_file["lifecycle_state"] == "active"
     assert later_file["missing_ts"] is None
     assert later_file["deleted_ts"] is None
@@ -1147,16 +1207,14 @@ def test_poll_registered_storage_sources_preserves_multiple_locations_for_same_h
 
     assert result.errors == []
     assert result.scanned == 2
-    photo_rows = load_photo_rows(db_url)
-    assert len(photo_rows) == 1
-    file_rows = load_photo_file_rows(db_url, photo_rows[0]["photo_id"])
-    assert len(file_rows) == 2
-    assert {row["watched_folder_id"] for row in file_rows} == {
+    assert result.enqueued == 2
+    queue_rows = load_pending_queue_rows(db_url)
+    assert len(queue_rows) == 2
+    assert {row.payload_json["watched_folder_id"] for row in queue_rows} == {
         watched_folder_a_id,
         watched_folder_b["watched_folder_id"],
     }
-    assert {row["relative_path"] for row in file_rows} == {asset_name}
-    assert {row["lifecycle_state"] for row in file_rows} == {"active"}
+    assert {row.payload_json["relative_path"] for row in queue_rows} == {asset_name}
 
 
 def test_poll_registered_storage_sources_reassesses_existing_locations_for_same_hash(
@@ -1281,13 +1339,20 @@ def test_poll_registered_storage_sources_reassesses_existing_locations_for_same_
     )
 
     assert result.errors == []
+    assert result.enqueued == 1
     file_rows = load_photo_file_rows(db_url, record.photo_id)
     assert len(file_rows) == 2
     rows_by_folder = {row["watched_folder_id"]: row for row in file_rows}
     assert rows_by_folder[watched_folder_a_id]["lifecycle_state"] == "deleted"
     assert rows_by_folder[watched_folder_b["watched_folder_id"]]["lifecycle_state"] == "active"
     photo = load_photo_row_by_id(db_url, record.photo_id)
-    assert photo["path"] == _source_aware_photo_path(source_id, f"exports/{asset_name}")
+    assert photo["path"] == _source_aware_photo_path(source_id, f"imports/{asset_name}")
+    queue_rows = load_pending_queue_rows(db_url)
+    assert len(queue_rows) == 1
+    assert queue_rows[0].payload_json["canonical_path"] == _source_aware_photo_path(
+        source_id,
+        f"exports/{asset_name}",
+    )
 
 
 def test_poll_registered_storage_sources_preserves_existing_face_detection_timestamp(

--- a/apps/api/tests/test_ingest_extraction_worker.py
+++ b/apps/api/tests/test_ingest_extraction_worker.py
@@ -467,3 +467,60 @@ def test_process_candidate_payload_keeps_face_detection_failure_as_warning(tmp_p
     assert result.extracted_payload["warnings"] == [
         "face detection failed: detector exploded"
     ]
+
+
+def test_process_candidate_payload_converts_sha_reuse_stat_race_into_missing_file_error(
+    tmp_path, monkeypatch
+):
+    from app.services.ingest_extraction_worker import (
+        CandidateFileMissingError,
+        process_candidate_payload,
+    )
+
+    database_url = f"sqlite:///{tmp_path / 'ingest-worker-reuse-missing-file.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
+
+    photo_path = tmp_path / "sample.jpg"
+    _write_test_image(photo_path)
+    record_sha = hashlib.sha256(photo_path.read_bytes()).hexdigest()
+
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                _photo_row_values(
+                    photo_id="existing-photo",
+                    path="/library/already-imported.jpg",
+                    sha256=record_sha,
+                    now=now,
+                    thumbnail_jpeg=b"existing-thumbnail",
+                    thumbnail_mime_type="image/jpeg",
+                    thumbnail_width=64,
+                    thumbnail_height=64,
+                    faces_count=0,
+                    faces_detected_ts=now,
+                )
+            )
+        )
+
+    def _raise_missing_stat(*args, **kwargs):
+        raise FileNotFoundError("gone")
+
+    monkeypatch.setattr(
+        "app.services.ingest_extraction_worker._build_reused_photo_record",
+        _raise_missing_stat,
+    )
+
+    with pytest.raises(CandidateFileMissingError, match="candidate file missing"):
+        process_candidate_payload(
+            database_url,
+            payload={
+                "storage_source_id": "source-1",
+                "watched_folder_id": "wf-1",
+                "canonical_path": "/library/sample.jpg",
+                "runtime_path": str(photo_path),
+                "relative_path": "sample.jpg",
+            },
+            face_detector=RaisingFaceDetector(),
+        )

--- a/apps/api/tests/test_ingest_extraction_worker.py
+++ b/apps/api/tests/test_ingest_extraction_worker.py
@@ -75,6 +75,14 @@ class RaisingFaceDetector:
         raise AssertionError("face detector should not have been called")
 
 
+class RuntimeErrorFaceDetector:
+    def __init__(self, message: str) -> None:
+        self._message = message
+
+    def detect(self, path: Path) -> list[dict]:
+        raise RuntimeError(self._message)
+
+
 class FakeMappingsResult:
     def __init__(self, rows: list[dict]) -> None:
         self._rows = rows
@@ -384,4 +392,78 @@ def test_process_candidate_payload_extracts_new_sha_and_returns_detections(tmp_p
             "provenance": {"detector": "test"},
             "person_id": None,
         }
+    ]
+
+
+def test_process_candidate_payload_keeps_thumbnail_failure_as_warning(tmp_path, monkeypatch):
+    from app.services.ingest_extraction_worker import process_candidate_payload
+
+    database_url = f"sqlite:///{tmp_path / 'ingest-worker-thumbnail-warning.db'}"
+    upgrade_database(database_url)
+
+    photo_path = tmp_path / "sample.jpg"
+    _write_test_image(photo_path)
+    detector = StaticFaceDetector(detections=[])
+
+    def _raise_thumbnail_failure(path: Path):
+        raise RuntimeError("thumbnail exploded")
+
+    monkeypatch.setattr(
+        "app.services.ingest_extraction_worker.generate_thumbnail",
+        _raise_thumbnail_failure,
+    )
+
+    result = process_candidate_payload(
+        database_url,
+        payload={
+            "storage_source_id": "source-1",
+            "watched_folder_id": "wf-1",
+            "canonical_path": "/library/sample.jpg",
+            "runtime_path": str(photo_path),
+            "relative_path": "sample.jpg",
+        },
+        face_detector=detector,
+    )
+
+    assert detector.calls == 1
+    assert result.reused_existing_artifacts is False
+    assert result.analysis_performed is True
+    assert result.extracted_payload["thumbnail_jpeg"] is None
+    assert result.extracted_payload["thumbnail_mime_type"] is None
+    assert result.extracted_payload["thumbnail_width"] is None
+    assert result.extracted_payload["thumbnail_height"] is None
+    assert result.extracted_payload["faces_count"] == 0
+    assert result.extracted_payload["warnings"] == [
+        "thumbnail generation failed: thumbnail exploded"
+    ]
+
+
+def test_process_candidate_payload_keeps_face_detection_failure_as_warning(tmp_path):
+    from app.services.ingest_extraction_worker import process_candidate_payload
+
+    database_url = f"sqlite:///{tmp_path / 'ingest-worker-face-warning.db'}"
+    upgrade_database(database_url)
+
+    photo_path = tmp_path / "sample.jpg"
+    _write_test_image(photo_path)
+
+    result = process_candidate_payload(
+        database_url,
+        payload={
+            "storage_source_id": "source-1",
+            "watched_folder_id": "wf-1",
+            "canonical_path": "/library/sample.jpg",
+            "runtime_path": str(photo_path),
+            "relative_path": "sample.jpg",
+        },
+        face_detector=RuntimeErrorFaceDetector("detector exploded"),
+    )
+
+    assert result.reused_existing_artifacts is False
+    assert result.analysis_performed is True
+    assert result.extracted_payload["thumbnail_jpeg"] is not None
+    assert result.extracted_payload["faces_count"] == 0
+    assert result.extracted_payload["detections"] == []
+    assert result.extracted_payload["warnings"] == [
+        "face detection failed: detector exploded"
     ]

--- a/apps/api/tests/test_ingest_extraction_worker.py
+++ b/apps/api/tests/test_ingest_extraction_worker.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, insert
+
+from app.migrations import upgrade_database
+from app.storage import faces, photos
+
+pytest.importorskip("PIL")
+from PIL import Image
+
+
+def _write_test_image(path: Path) -> None:
+    image = Image.new("RGB", (4, 4), color=(255, 0, 0))
+    image.save(path, format="JPEG")
+
+
+def _photo_row_values(
+    *,
+    photo_id: str,
+    path: str,
+    sha256: str,
+    now: datetime,
+    thumbnail_jpeg: bytes | None,
+    thumbnail_mime_type: str | None,
+    thumbnail_width: int | None,
+    thumbnail_height: int | None,
+    faces_count: int,
+    faces_detected_ts: datetime | None,
+) -> dict[str, object]:
+    return {
+        "photo_id": photo_id,
+        "path": path,
+        "sha256": sha256,
+        "phash": None,
+        "filesize": 123,
+        "ext": "jpg",
+        "created_ts": now,
+        "modified_ts": now,
+        "shot_ts": None,
+        "shot_ts_source": None,
+        "camera_make": None,
+        "camera_model": None,
+        "software": None,
+        "orientation": None,
+        "gps_latitude": None,
+        "gps_longitude": None,
+        "gps_altitude": None,
+        "thumbnail_jpeg": thumbnail_jpeg,
+        "thumbnail_mime_type": thumbnail_mime_type,
+        "thumbnail_width": thumbnail_width,
+        "thumbnail_height": thumbnail_height,
+        "updated_ts": now,
+        "faces_count": faces_count,
+        "faces_detected_ts": faces_detected_ts,
+    }
+
+
+class StaticFaceDetector:
+    def __init__(self, detections: list[dict]) -> None:
+        self._detections = detections
+        self.calls = 0
+
+    def detect(self, path: Path) -> list[dict]:
+        self.calls += 1
+        return list(self._detections)
+
+
+class RaisingFaceDetector:
+    def detect(self, path: Path) -> list[dict]:
+        raise AssertionError("face detector should not have been called")
+
+
+class FakeMappingsResult:
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[dict]:
+        return list(self._rows)
+
+
+class FakeExecuteResult:
+    def __init__(self, rows: list[dict]) -> None:
+        self._rows = rows
+
+    def mappings(self) -> FakeMappingsResult:
+        return FakeMappingsResult(self._rows)
+
+
+class FakeLookupConnection:
+    def __init__(self, photo_rows: list[dict], face_rows_by_photo_id: dict[str, list[dict]]) -> None:
+        self._photo_rows = photo_rows
+        self._face_rows_by_photo_id = face_rows_by_photo_id
+        self.photo_query_count = 0
+
+    def execute(self, statement):
+        compiled = str(statement)
+        if "FROM photos" in compiled:
+            self.photo_query_count += 1
+            return FakeExecuteResult(self._photo_rows)
+
+        if "FROM faces" in compiled:
+            photo_id = statement.whereclause.right.value
+            return FakeExecuteResult(self._face_rows_by_photo_id.get(photo_id, []))
+
+        raise AssertionError(f"unexpected statement: {compiled}")
+
+
+def test_lookup_existing_artifacts_by_sha_prefers_complete_row_when_first_match_is_incomplete():
+    from app.processing.ingest_persistence import lookup_existing_artifacts_by_sha
+
+    connection = FakeLookupConnection(
+        photo_rows=[
+            {
+                "photo_id": "incomplete-photo",
+                "shot_ts": None,
+                "shot_ts_source": None,
+                "camera_make": None,
+                "camera_model": None,
+                "software": None,
+                "orientation": None,
+                "gps_latitude": None,
+                "gps_longitude": None,
+                "gps_altitude": None,
+                "thumbnail_jpeg": None,
+                "thumbnail_mime_type": None,
+                "thumbnail_width": None,
+                "thumbnail_height": None,
+                "faces_count": 0,
+                "faces_detected_ts": None,
+            },
+            {
+                "photo_id": "complete-photo",
+                "shot_ts": None,
+                "shot_ts_source": None,
+                "camera_make": "Canon",
+                "camera_model": "EOS",
+                "software": None,
+                "orientation": "1",
+                "gps_latitude": None,
+                "gps_longitude": None,
+                "gps_altitude": None,
+                "thumbnail_jpeg": b"complete-thumbnail",
+                "thumbnail_mime_type": "image/jpeg",
+                "thumbnail_width": 64,
+                "thumbnail_height": 64,
+                "faces_count": 1,
+                "faces_detected_ts": datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
+            },
+        ],
+        face_rows_by_photo_id={
+            "complete-photo": [
+                {
+                    "face_id": "face-1",
+                    "person_id": None,
+                    "bbox_x": 10,
+                    "bbox_y": 11,
+                    "bbox_w": 12,
+                    "bbox_h": 13,
+                    "bitmap": b"existing-face",
+                    "embedding": None,
+                    "provenance": {"detector": "existing"},
+                }
+            ]
+        },
+    )
+
+    result = lookup_existing_artifacts_by_sha(connection, "same-sha")
+
+    assert connection.photo_query_count == 1
+    assert result is not None
+    assert result["photo_id"] == "complete-photo"
+    assert result["thumbnail_jpeg"] == b"complete-thumbnail"
+    assert result["faces_count"] == 1
+    assert result["detections"] == [
+        {
+            "face_id": "face-1",
+            "person_id": None,
+            "bbox_x": 10,
+            "bbox_y": 11,
+            "bbox_w": 12,
+            "bbox_h": 13,
+            "bitmap": b"existing-face",
+            "embedding": None,
+            "provenance": {"detector": "existing"},
+        }
+    ]
+
+
+def test_process_candidate_payload_reuses_known_sha_without_invoking_metadata_extraction(tmp_path, monkeypatch):
+    from app.services.ingest_extraction_worker import process_candidate_payload
+
+    database_url = f"sqlite:///{tmp_path / 'ingest-worker-reuse.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
+
+    photo_path = tmp_path / "sample.jpg"
+    _write_test_image(photo_path)
+    record_sha = hashlib.sha256(photo_path.read_bytes()).hexdigest()
+
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                _photo_row_values(
+                    photo_id="existing-photo",
+                    path="/library/already-imported.jpg",
+                    sha256=record_sha,
+                    now=now,
+                    thumbnail_jpeg=b"existing-thumbnail",
+                    thumbnail_mime_type="image/jpeg",
+                    thumbnail_width=64,
+                    thumbnail_height=64,
+                    faces_count=0,
+                    faces_detected_ts=now,
+                )
+            )
+        )
+
+    def _unexpected_build_photo_record_from_sha(*args, **kwargs):
+        raise AssertionError("build_photo_record_from_sha should not run on the SHA reuse path")
+
+    monkeypatch.setattr(
+        "app.services.ingest_extraction_worker.build_photo_record_from_sha",
+        _unexpected_build_photo_record_from_sha,
+    )
+
+    result = process_candidate_payload(
+        database_url,
+        payload={
+            "storage_source_id": "source-1",
+            "watched_folder_id": "wf-1",
+            "canonical_path": "/library/sample.jpg",
+            "runtime_path": str(photo_path),
+            "relative_path": "sample.jpg",
+        },
+        face_detector=RaisingFaceDetector(),
+    )
+
+    assert result.reused_existing_artifacts is True
+    assert result.analysis_performed is False
+    assert not hasattr(result, "payload")
+    assert not hasattr(result, "reused_existing")
+    assert result.extracted_payload["sha256"] == record_sha
+    assert result.extracted_payload["path"] == "/library/sample.jpg"
+    assert result.extracted_payload["thumbnail_jpeg"] == "ZXhpc3RpbmctdGh1bWJuYWls"
+    assert result.extracted_payload["faces_count"] == 0
+    assert result.extracted_payload["detections"] == []
+
+
+def test_process_candidate_payload_reuses_existing_detections_with_known_sha(tmp_path):
+    from app.services.ingest_extraction_worker import process_candidate_payload
+
+    database_url = f"sqlite:///{tmp_path / 'ingest-worker-reuse-detections.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 4, 5, 12, 0, tzinfo=UTC)
+
+    photo_path = tmp_path / "sample.jpg"
+    _write_test_image(photo_path)
+    record_sha = hashlib.sha256(photo_path.read_bytes()).hexdigest()
+
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                _photo_row_values(
+                    photo_id="existing-photo",
+                    path="/library/already-imported.jpg",
+                    sha256=record_sha,
+                    now=now,
+                    thumbnail_jpeg=b"existing-thumbnail",
+                    thumbnail_mime_type="image/jpeg",
+                    thumbnail_width=64,
+                    thumbnail_height=64,
+                    faces_count=1,
+                    faces_detected_ts=now,
+                )
+            )
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="existing-photo",
+                person_id=None,
+                bbox_x=10,
+                bbox_y=11,
+                bbox_w=12,
+                bbox_h=13,
+                bitmap=b"existing-face",
+                embedding=None,
+                provenance={"detector": "existing"},
+            )
+        )
+
+    result = process_candidate_payload(
+        database_url,
+        payload={
+            "storage_source_id": "source-1",
+            "watched_folder_id": "wf-1",
+            "canonical_path": "/library/sample.jpg",
+            "runtime_path": str(photo_path),
+            "relative_path": "sample.jpg",
+        },
+        face_detector=RaisingFaceDetector(),
+    )
+
+    assert result.reused_existing_artifacts is True
+    assert result.analysis_performed is False
+    assert result.extracted_payload["faces_count"] == 1
+    assert result.extracted_payload["detections"] == [
+        {
+            "face_id": "face-1",
+            "person_id": None,
+            "bbox_x": 10,
+            "bbox_y": 11,
+            "bbox_w": 12,
+            "bbox_h": 13,
+            "bitmap": "ZXhpc3RpbmctZmFjZQ==",
+            "embedding": None,
+            "provenance": {"detector": "existing"},
+        }
+    ]
+
+
+def test_process_candidate_payload_extracts_new_sha_and_returns_detections(tmp_path):
+    from app.services.ingest_extraction_worker import process_candidate_payload
+
+    database_url = f"sqlite:///{tmp_path / 'ingest-worker-new.db'}"
+    upgrade_database(database_url)
+
+    photo_path = tmp_path / "sample.jpg"
+    _write_test_image(photo_path)
+    detector = StaticFaceDetector(
+        detections=[
+            {
+                "face_id": "face-1",
+                "bbox_x": 1,
+                "bbox_y": 2,
+                "bbox_w": 3,
+                "bbox_h": 4,
+                "bitmap": b"face-bitmap",
+                "embedding": None,
+                "provenance": {"detector": "test"},
+                "person_id": None,
+            }
+        ]
+    )
+
+    result = process_candidate_payload(
+        database_url,
+        payload={
+            "storage_source_id": "source-1",
+            "watched_folder_id": "wf-1",
+            "canonical_path": "/library/sample.jpg",
+            "runtime_path": str(photo_path),
+            "relative_path": "sample.jpg",
+        },
+        face_detector=detector,
+    )
+
+    assert detector.calls == 1
+    assert result.reused_existing_artifacts is False
+    assert result.analysis_performed is True
+    assert not hasattr(result, "payload")
+    assert not hasattr(result, "reused_existing")
+    assert len(result.extracted_payload["sha256"]) == 64
+    assert result.extracted_payload["path"] == "/library/sample.jpg"
+    assert result.extracted_payload["thumbnail_jpeg"] is not None
+    assert result.extracted_payload["thumbnail_mime_type"] == "image/jpeg"
+    assert result.extracted_payload["faces_count"] == 1
+    assert result.extracted_payload["detections"] == [
+        {
+            "face_id": "face-1",
+            "bbox_x": 1,
+            "bbox_y": 2,
+            "bbox_w": 3,
+            "bbox_h": 4,
+            "bitmap": "ZmFjZS1iaXRtYXA=",
+            "embedding": None,
+            "provenance": {"detector": "test"},
+            "person_id": None,
+        }
+    ]

--- a/apps/api/tests/test_ingest_persistence.py
+++ b/apps/api/tests/test_ingest_persistence.py
@@ -289,6 +289,112 @@ def test_serialize_reused_content_submission_includes_json_safe_thumbnail_fields
     assert payload["warnings"] == ["reused existing content"]
 
 
+def test_lookup_existing_artifacts_by_sha_prefers_complete_duplicate_row(tmp_path):
+    from app.processing.ingest_persistence import lookup_existing_artifacts_by_sha
+
+    class FakeMappingsResult:
+        def __init__(self, rows: list[dict]) -> None:
+            self._rows = rows
+
+        def all(self) -> list[dict]:
+            return list(self._rows)
+
+    class FakeExecuteResult:
+        def __init__(self, rows: list[dict]) -> None:
+            self._rows = rows
+
+        def mappings(self) -> FakeMappingsResult:
+            return FakeMappingsResult(self._rows)
+
+    class FakeConnection:
+        def __init__(self) -> None:
+            self.photo_query_count = 0
+
+        def execute(self, statement):
+            compiled = str(statement)
+            if "FROM photos" in compiled:
+                self.photo_query_count += 1
+                return FakeExecuteResult(
+                    [
+                        {
+                            "photo_id": "incomplete-photo",
+                            "shot_ts": None,
+                            "shot_ts_source": None,
+                            "camera_make": None,
+                            "camera_model": None,
+                            "software": None,
+                            "orientation": None,
+                            "gps_latitude": None,
+                            "gps_longitude": None,
+                            "gps_altitude": None,
+                            "thumbnail_jpeg": None,
+                            "thumbnail_mime_type": None,
+                            "thumbnail_width": None,
+                            "thumbnail_height": None,
+                            "faces_count": 0,
+                            "faces_detected_ts": None,
+                        },
+                        {
+                            "photo_id": "complete-photo",
+                            "shot_ts": None,
+                            "shot_ts_source": None,
+                            "camera_make": "Canon",
+                            "camera_model": "EOS",
+                            "software": None,
+                            "orientation": "1",
+                            "gps_latitude": None,
+                            "gps_longitude": None,
+                            "gps_altitude": None,
+                            "thumbnail_jpeg": b"complete-thumbnail",
+                            "thumbnail_mime_type": "image/jpeg",
+                            "thumbnail_width": 64,
+                            "thumbnail_height": 64,
+                            "faces_count": 1,
+                            "faces_detected_ts": datetime(2026, 4, 5, 12, 30, tzinfo=UTC),
+                        },
+                    ]
+                )
+            if "FROM faces" in compiled:
+                return FakeExecuteResult(
+                    [
+                        {
+                            "face_id": "face-1",
+                            "person_id": None,
+                            "bbox_x": 10,
+                            "bbox_y": 11,
+                            "bbox_w": 12,
+                            "bbox_h": 13,
+                            "bitmap": b"existing-face",
+                            "embedding": None,
+                            "provenance": {"detector": "existing"},
+                        }
+                    ]
+                )
+            raise AssertionError(f"unexpected statement: {compiled}")
+
+    connection = FakeConnection()
+    result = lookup_existing_artifacts_by_sha(connection, "same-sha")
+
+    assert connection.photo_query_count == 1
+    assert result is not None
+    assert result["photo_id"] == "complete-photo"
+    assert result["thumbnail_jpeg"] == b"complete-thumbnail"
+    assert result["faces_count"] == 1
+    assert result["detections"] == [
+        {
+            "face_id": "face-1",
+            "person_id": None,
+            "bbox_x": 10,
+            "bbox_y": 11,
+            "bbox_w": 12,
+            "bbox_h": 13,
+            "bitmap": b"existing-face",
+            "embedding": None,
+            "provenance": {"detector": "existing"},
+        }
+    ]
+
+
 def test_upsert_photo_preserves_existing_thumbnail_when_new_record_lacks_one(tmp_path):
     from app.processing.ingest_persistence import PhotoRecord, upsert_photo
 

--- a/apps/api/tests/test_ingest_persistence.py
+++ b/apps/api/tests/test_ingest_persistence.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -66,6 +67,12 @@ def _normalize_timestamp(value: datetime | None) -> datetime | None:
     return value
 
 
+def _decode_base64_text(value: str | None) -> bytes | None:
+    if value is None:
+        return None
+    return base64.b64decode(value)
+
+
 def test_build_photo_record_returns_stable_identity_for_same_file_and_path(tmp_path):
     from app.processing.ingest_persistence import build_photo_record
 
@@ -126,6 +133,160 @@ def test_build_ingest_submission_serializes_expected_payload_fields(tmp_path):
     assert payload["gps_longitude"] is None
     assert payload["gps_altitude"] is None
     assert payload["faces_count"] == 0
+
+
+def test_build_ingest_candidate_submission_serializes_discovery_only_fields(tmp_path):
+    from app.processing.ingest_persistence import build_ingest_candidate_submission
+
+    scan_root = tmp_path / "library"
+    scan_root.mkdir()
+    photo_path = scan_root / "sample.jpg"
+    photo_path.write_bytes(b"candidate-bytes")
+
+    payload = build_ingest_candidate_submission(
+        photo_path,
+        scan_root=scan_root,
+        canonical_path="/library/sample.jpg",
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+    )
+
+    assert payload["payload_version"] == 1
+    assert payload["storage_source_id"] == "source-1"
+    assert payload["watched_folder_id"] == "wf-1"
+    assert payload["canonical_path"] == "/library/sample.jpg"
+    assert payload["runtime_path"] == str(photo_path.resolve())
+    assert payload["relative_path"] == "sample.jpg"
+    assert payload["modified_mtime_ns"] == photo_path.stat().st_mtime_ns
+    assert payload["idempotency_key"] == (
+        f"wf-1:sample.jpg:{photo_path.stat().st_size}:{photo_path.stat().st_mtime_ns}"
+    )
+    assert payload["filesize"] == photo_path.stat().st_size
+    assert "sha256" not in payload
+    assert "thumbnail_jpeg" not in payload
+    assert "thumbnail_mime_type" not in payload
+    assert "thumbnail_width" not in payload
+    assert "thumbnail_height" not in payload
+    assert "faces_count" not in payload
+    assert "detections" not in payload
+    assert "modified_mtime_ns" in payload
+
+
+def test_serialize_extracted_content_submission_includes_face_and_thumbnail_fields():
+    from app.processing.ingest_persistence import (
+        PhotoRecord,
+        serialize_extracted_content_submission,
+    )
+
+    record = PhotoRecord(
+        photo_id="photo-1",
+        path="/library/sample.jpg",
+        sha256="abc123",
+        filesize=123,
+        ext="jpg",
+        created_ts=datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
+        modified_ts=datetime(2026, 4, 5, 12, 1, tzinfo=UTC),
+        shot_ts=None,
+        shot_ts_source=None,
+        camera_make="Canon",
+        camera_model="EOS",
+        software=None,
+        orientation="1",
+        gps_latitude=None,
+        gps_longitude=None,
+        gps_altitude=None,
+        thumbnail_jpeg=b"thumb",
+        thumbnail_mime_type="image/jpeg",
+        thumbnail_width=128,
+        thumbnail_height=128,
+        faces_count=1,
+    )
+
+    payload = serialize_extracted_content_submission(
+        record=record,
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="sample.jpg",
+        detections=[
+            {
+                "face_id": "face-1",
+                "bbox_x": 1,
+                "bbox_y": 2,
+                "bbox_w": 3,
+                "bbox_h": 4,
+                "bitmap": b"face-bytes",
+                "embedding": None,
+                "provenance": {"detector": "opencv"},
+            }
+        ],
+        warnings=["face detection failed for sidecar"],
+    )
+
+    assert payload["payload_version"] == 1
+    assert payload["storage_source_id"] == "source-1"
+    assert payload["watched_folder_id"] == "wf-1"
+    assert payload["relative_path"] == "sample.jpg"
+    assert payload["sha256"] == "abc123"
+    assert payload["faces_count"] == 1
+    assert payload["thumbnail_jpeg"] == "dGh1bWI="
+    assert _decode_base64_text(payload["thumbnail_jpeg"]) == b"thumb"
+    assert payload["thumbnail_mime_type"] == "image/jpeg"
+    assert payload["thumbnail_width"] == 128
+    assert payload["thumbnail_height"] == 128
+    assert payload["detections"][0]["face_id"] == "face-1"
+    assert payload["detections"][0]["bitmap"] == "ZmFjZS1ieXRlcw=="
+    assert _decode_base64_text(payload["detections"][0]["bitmap"]) == b"face-bytes"
+    assert payload["warnings"] == ["face detection failed for sidecar"]
+
+
+def test_serialize_reused_content_submission_includes_json_safe_thumbnail_fields():
+    from app.processing.ingest_persistence import (
+        PhotoRecord,
+        serialize_reused_content_submission,
+    )
+
+    record = PhotoRecord(
+        photo_id="photo-1",
+        path="/library/sample.jpg",
+        sha256="abc123",
+        filesize=123,
+        ext="jpg",
+        created_ts=datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
+        modified_ts=datetime(2026, 4, 5, 12, 1, tzinfo=UTC),
+        shot_ts=None,
+        shot_ts_source=None,
+        camera_make=None,
+        camera_model=None,
+        software=None,
+        orientation=None,
+        gps_latitude=None,
+        gps_longitude=None,
+        gps_altitude=None,
+        thumbnail_jpeg=b"thumb",
+        thumbnail_mime_type="image/jpeg",
+        thumbnail_width=128,
+        thumbnail_height=128,
+        faces_count=1,
+    )
+
+    payload = serialize_reused_content_submission(
+        record=record,
+        candidate_payload={
+            "storage_source_id": "source-1",
+            "watched_folder_id": "wf-1",
+            "relative_path": "sample.jpg",
+        },
+        warnings=["reused existing content"],
+    )
+
+    assert payload["payload_version"] == 1
+    assert payload["storage_source_id"] == "source-1"
+    assert payload["watched_folder_id"] == "wf-1"
+    assert payload["relative_path"] == "sample.jpg"
+    assert payload["thumbnail_jpeg"] == "dGh1bWI="
+    assert _decode_base64_text(payload["thumbnail_jpeg"]) == b"thumb"
+    assert payload["detections"] == []
+    assert payload["warnings"] == ["reused existing content"]
 
 
 def test_upsert_photo_preserves_existing_thumbnail_when_new_record_lacks_one(tmp_path):

--- a/apps/api/tests/test_ingest_polling.py
+++ b/apps/api/tests/test_ingest_polling.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from sqlalchemy import create_engine, func, select
 
+from app.db.queue import IngestQueueStore
 from app.migrations import upgrade_database
 from app.services.source_registration import MARKER_FILENAME, write_source_marker
 from app.services.storage_sources import attach_storage_source_alias, create_storage_source
@@ -62,10 +63,22 @@ def test_poll_registered_storage_sources_processes_a_registered_source_end_to_en
     result = poll_registered_storage_sources(database_url=database_url, now=now)
 
     assert result.scanned == 1
-    assert result.inserted == 1
+    assert result.enqueued == 1
+    assert result.inserted == 0
     assert result.updated == 0
     assert result.errors == []
     expected_now = now.replace(tzinfo=None)
+
+    queue_rows = IngestQueueStore(database_url).list_pending()
+    assert len(queue_rows) == 1
+    assert queue_rows[0].payload_type == "ingest_candidate"
+    assert queue_rows[0].payload_json["runtime_path"] == str(
+        (watched / "birthday_park_001.jpg").resolve()
+    )
+    assert queue_rows[0].payload_json["watched_folder_id"] == watched_folder["watched_folder_id"]
+    assert queue_rows[0].payload_json["storage_source_id"] == source["storage_source_id"]
+    assert "sha256" not in queue_rows[0].payload_json
+    assert "thumbnail_jpeg" not in queue_rows[0].payload_json
 
     with engine.connect() as connection:
         source_row = connection.execute(
@@ -94,10 +107,10 @@ def test_poll_registered_storage_sources_processes_a_registered_source_end_to_en
     assert run_row["watched_folder_id"] == watched_folder["watched_folder_id"]
     assert run_row["status"] == "completed"
     assert run_row["files_seen"] == 1
-    assert run_row["files_created"] == 1
+    assert run_row["files_created"] == 0
     assert run_row["files_updated"] == 0
     assert run_row["error_count"] == 0
-    assert photo_count == 1
+    assert photo_count == 0
 
 
 def test_poll_registered_storage_sources_records_one_completed_run_per_chunk(tmp_path):
@@ -154,11 +167,121 @@ def test_poll_registered_storage_sources_records_one_completed_run_per_chunk(tmp
             ).mappings()
         )
 
-    assert [(row["status"], row["files_seen"]) for row in run_rows] == [
-        ("completed", 2),
-        ("completed", 2),
-        ("completed", 1),
+    assert result.enqueued == 5
+    assert result.inserted == 0
+    assert result.updated == 0
+    assert [(row["status"], row["files_seen"], row["files_created"], row["files_updated"]) for row in run_rows] == [
+        ("completed", 2, 0, 0),
+        ("completed", 2, 0, 0),
+        ("completed", 1, 0, 0),
     ]
+
+
+def test_poll_registered_storage_sources_does_not_increment_enqueued_for_idempotent_rescan(tmp_path):
+    from app.processing.ingest_polling import poll_registered_storage_sources
+
+    database_url = f"sqlite:///{tmp_path / 'poll-idempotent-rescan.db'}"
+    upgrade_database(database_url)
+    now = datetime(2026, 4, 4, 12, 2, tzinfo=UTC)
+
+    root = tmp_path / "source-root"
+    watched = root / "imports"
+    watched.mkdir(parents=True)
+    _write_test_image(watched / "photo_000.jpg")
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Source",
+            marker_filename=MARKER_FILENAME,
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            now=now,
+        )
+        create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            watched_path=watched.as_posix(),
+            display_name="Imports",
+            now=now,
+        )
+        write_source_marker(root, storage_source_id=source["storage_source_id"])
+
+    first = poll_registered_storage_sources(database_url=database_url, now=now)
+    second = poll_registered_storage_sources(database_url=database_url, now=now)
+
+    assert first.enqueued == 1
+    assert second.scanned == 1
+    assert second.enqueued == 0
+    assert len(IngestQueueStore(database_url).list_pending()) == 1
+
+
+def test_poll_registered_storage_sources_rolls_back_candidate_queue_rows_when_chunk_fails(
+    tmp_path, monkeypatch
+):
+    import app.processing.ingest_polling as ingest_polling
+
+    database_url = f"sqlite:///{tmp_path / 'poll-chunk-rollback.db'}"
+    upgrade_database(database_url)
+    now = datetime(2026, 4, 4, 12, 4, tzinfo=UTC)
+
+    root = tmp_path / "source-root"
+    watched = root / "imports"
+    watched.mkdir(parents=True)
+    _write_test_image(watched / "photo_000.jpg")
+    _write_test_image(watched / "photo_001.jpg")
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Source",
+            marker_filename=MARKER_FILENAME,
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            now=now,
+        )
+        watched_folder = create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            watched_path=watched.as_posix(),
+            display_name="Imports",
+            now=now,
+        )
+        write_source_marker(root, storage_source_id=source["storage_source_id"])
+
+    call_count = 0
+
+    def fail_during_chunk(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("forced chunk failure")
+
+    monkeypatch.setattr(ingest_polling, "_record_ingest_run", fail_during_chunk)
+
+    result = ingest_polling.poll_registered_storage_sources(
+        database_url=database_url,
+        now=now,
+        poll_chunk_size=2,
+    )
+
+    assert result.errors == [f"watched_folder:{watched_folder['watched_folder_id']}: forced chunk failure"]
+    assert result.enqueued == 0
+    assert IngestQueueStore(database_url).list_pending() == []
 
 
 def test_poll_registered_storage_sources_rejects_invalid_poll_chunk_size_without_marking_source_failed(

--- a/apps/api/tests/test_ingest_queue_processor.py
+++ b/apps/api/tests/test_ingest_queue_processor.py
@@ -530,6 +530,82 @@ def test_process_pending_rows_records_canonical_path_for_retryable_ingest_candid
     assert file_rows[0]["error_detail"] == "staged extraction exploded"
 
 
+def test_process_pending_rows_persists_candidate_warning_payloads_instead_of_retrying(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-candidate-warning.db'}"
+    upgrade_database(database_url)
+    queue_store = IngestQueueStore(database_url)
+
+    candidate_payload = {
+        "payload_version": 1,
+        "storage_source_id": "source-1",
+        "watched_folder_id": "wf-1",
+        "canonical_path": "/library/candidate-warning.jpg",
+        "runtime_path": str((tmp_path / "candidate-warning.jpg").resolve()),
+        "relative_path": "candidate-warning.jpg",
+        "filesize": 123,
+        "modified_ts": "2024-01-02T00:00:00+00:00",
+        "modified_mtime_ns": 123456789,
+        "idempotency_key": "wf-1:candidate-warning.jpg:123:123456789",
+    }
+    queue_store.enqueue(
+        payload_type="ingest_candidate",
+        payload=candidate_payload,
+        idempotency_key=candidate_payload["idempotency_key"],
+    )
+
+    extracted_payload = build_payload(
+        photo_id="candidate-warning-photo",
+        path="/library/candidate-warning.jpg",
+        thumbnail_jpeg=None,
+        thumbnail_mime_type=None,
+        thumbnail_width=None,
+        thumbnail_height=None,
+        detections=[],
+        warnings=["thumbnail generation failed: thumbnail exploded"],
+        payload_version=1,
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="candidate-warning.jpg",
+    )
+
+    def fake_process_candidate_payload(database_url_arg, *, payload, face_detector=None):
+        assert database_url_arg == database_url
+        assert payload == candidate_payload
+        return ExtractionResult(
+            extracted_payload=extracted_payload,
+            reused_existing_artifacts=False,
+            analysis_performed=True,
+        )
+
+    monkeypatch.setattr(
+        ingest_queue_processor,
+        "process_candidate_payload",
+        fake_process_candidate_payload,
+        raising=False,
+    )
+
+    result = process_pending_ingest_queue(database_url, limit=10)
+
+    completed_rows = queue_store.list_by_status("completed")
+    pending_rows = queue_store.list_by_status("pending")
+    file_rows = load_ingest_run_files(database_url)
+
+    assert result.processed == 1
+    assert result.failed == 0
+    assert result.retryable_errors == 0
+    assert len(completed_rows) == 1
+    assert completed_rows[0].payload_type == "ingest_candidate"
+    assert completed_rows[0].last_error == "thumbnail generation failed: thumbnail exploded"
+    assert len(pending_rows) == 1
+    assert pending_rows[0].payload_type == "extracted_photo"
+    assert pending_rows[0].payload_json == extracted_payload
+    assert len(file_rows) == 1
+    assert file_rows[0]["outcome"] == "completed"
+    assert file_rows[0]["error_detail"] == "thumbnail generation failed: thumbnail exploded"
+
+
 def test_process_pending_rows_revives_failed_extracted_photo_row_on_idempotency_collision(
     tmp_path, monkeypatch
 ):

--- a/apps/api/tests/test_ingest_queue_processor.py
+++ b/apps/api/tests/test_ingest_queue_processor.py
@@ -1016,6 +1016,81 @@ def test_process_pending_rows_persists_payload_faces_for_extracted_photo_without
     assert file_rows[0]["error_detail"] is None
 
 
+def test_process_pending_rows_does_not_mark_face_detection_complete_when_payload_has_warning(
+    tmp_path,
+):
+    database_url = f"sqlite:///{tmp_path / 'queue-processor-extracted-photo-face-warning.db'}"
+    upgrade_database(database_url)
+    queue_store = IngestQueueStore(database_url)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(watched_folders).values(
+                watched_folder_id="wf-1",
+                scan_path="/library/imports",
+                storage_source_id="source-1",
+                relative_path="imports",
+                display_name="Imports",
+                is_enabled=1,
+                availability_state="active",
+                created_ts=datetime(2024, 1, 1, tzinfo=UTC),
+                updated_ts=datetime(2024, 1, 1, tzinfo=UTC),
+            )
+        )
+
+    extracted_payload = serialize_extracted_content_submission(
+        record=ingest_queue_processor.PhotoRecord(
+            photo_id="photo-extracted-warning",
+            path="/library/extracted-warning.jpg",
+            sha256="e" * 64,
+            filesize=123,
+            ext="jpg",
+            created_ts=datetime(2024, 1, 1, tzinfo=UTC),
+            modified_ts=datetime(2024, 1, 2, tzinfo=UTC),
+            shot_ts=None,
+            shot_ts_source=None,
+            camera_make=None,
+            camera_model=None,
+            software=None,
+            orientation=None,
+            gps_latitude=None,
+            gps_longitude=None,
+            gps_altitude=None,
+            thumbnail_jpeg=b"thumb",
+            thumbnail_mime_type="image/jpeg",
+            thumbnail_width=128,
+            thumbnail_height=96,
+            faces_count=0,
+        ),
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="extracted-warning.jpg",
+        detections=[],
+        warnings=["face detection failed: detector exploded"],
+    )
+    queue_store.enqueue(
+        payload_type="extracted_photo",
+        payload=extracted_payload,
+        idempotency_key=f"extracted:{extracted_payload['photo_id']}",
+    )
+
+    result = process_pending_ingest_queue(
+        database_url,
+        limit=10,
+        face_detector=RaisingFaceDetector("should not run"),
+    )
+
+    assert result.processed == 1
+    assert result.failed == 0
+    assert result.retryable_errors == 0
+    assert load_face_rows(database_url, "photo-extracted-warning") == []
+    faces_count, faces_detected_ts = load_photo_detection_state(
+        database_url, "photo-extracted-warning"
+    )
+    assert faces_count == 0
+    assert faces_detected_ts is None
+
+
 def test_process_pending_rows_reuses_existing_photo_row_for_duplicate_sha_extracted_payload(
     tmp_path,
 ):
@@ -1156,6 +1231,46 @@ def test_process_pending_rows_marks_detection_complete_when_no_faces_found(tmp_p
     completed_rows = queue_store.list_by_status("completed")
     assert len(completed_rows) == 1
     assert completed_rows[0].last_error is None
+
+
+def test_process_pending_rows_marks_missing_candidate_files_failed(tmp_path):
+    database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-candidate-missing-file.db'}"
+    upgrade_database(database_url)
+    queue_store = IngestQueueStore(database_url)
+
+    missing_path = tmp_path / "missing.jpg"
+    candidate_payload = {
+        "payload_version": 1,
+        "storage_source_id": "source-1",
+        "watched_folder_id": "wf-1",
+        "canonical_path": "/library/missing.jpg",
+        "runtime_path": str(missing_path.resolve()),
+        "relative_path": "missing.jpg",
+        "filesize": 123,
+        "modified_ts": "2024-01-02T00:00:00+00:00",
+        "modified_mtime_ns": 123456789,
+        "idempotency_key": "wf-1:missing.jpg:123:123456789",
+    }
+    queue_id = queue_store.enqueue(
+        payload_type="ingest_candidate",
+        payload=candidate_payload,
+        idempotency_key=candidate_payload["idempotency_key"],
+    )
+
+    result = process_pending_ingest_queue(database_url, limit=10)
+
+    failed_rows = queue_store.list_by_status("failed")
+    file_rows = load_ingest_run_files(database_url)
+    assert result.processed == 0
+    assert result.failed == 1
+    assert result.retryable_errors == 0
+    assert len(failed_rows) == 1
+    assert failed_rows[0].ingest_queue_id == queue_id
+    assert "candidate file missing" in failed_rows[0].last_error.lower()
+    assert len(file_rows) == 1
+    assert file_rows[0]["path"] == candidate_payload["canonical_path"]
+    assert file_rows[0]["outcome"] == "failed"
+    assert "candidate file missing" in file_rows[0]["error_detail"].lower()
 
 
 def test_process_pending_rows_preserves_existing_thumbnail_when_queue_payload_has_no_thumbnail_data(

--- a/apps/api/tests/test_ingest_queue_processor.py
+++ b/apps/api/tests/test_ingest_queue_processor.py
@@ -702,6 +702,116 @@ def test_process_pending_rows_revives_failed_extracted_photo_row_on_idempotency_
     assert pending_rows[0].last_error is None
 
 
+def test_process_pending_rows_requeues_completed_extracted_photo_row_when_payload_refreshes(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-candidate-refresh-completed.db'}"
+    upgrade_database(database_url)
+    queue_store = IngestQueueStore(database_url)
+
+    candidate_payload = {
+        "payload_version": 1,
+        "storage_source_id": "source-1",
+        "watched_folder_id": "wf-1",
+        "canonical_path": "/library/candidate-refresh.jpg",
+        "runtime_path": str((tmp_path / "candidate-refresh.jpg").resolve()),
+        "relative_path": "candidate-refresh.jpg",
+        "filesize": 123,
+        "modified_ts": "2024-01-02T00:00:00+00:00",
+        "modified_mtime_ns": 123456789,
+        "idempotency_key": "wf-1:candidate-refresh.jpg:123:123456789",
+    }
+    queue_store.enqueue(
+        payload_type="ingest_candidate",
+        payload=candidate_payload,
+        idempotency_key=candidate_payload["idempotency_key"],
+    )
+
+    stale_extracted_payload = build_payload(
+        photo_id="shared-photo-id",
+        path="/library/stale.jpg",
+        detections=[],
+        warnings=["face detection failed: detector exploded"],
+        payload_version=1,
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="candidate-refresh.jpg",
+    )
+    extracted_queue_id = queue_store.enqueue(
+        payload_type="extracted_photo",
+        payload=stale_extracted_payload,
+        idempotency_key="extracted:shared-photo-id",
+    )
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            update(ingest_queue)
+            .where(ingest_queue.c.ingest_queue_id == extracted_queue_id)
+            .values(
+                status="completed",
+                last_error="face detection failed: detector exploded",
+                processed_ts=datetime.now(tz=UTC),
+            )
+        )
+
+    refreshed_payload = build_payload(
+        photo_id="shared-photo-id",
+        path="/library/candidate-refresh.jpg",
+        thumbnail_jpeg="dGh1bWI=",
+        thumbnail_mime_type="image/jpeg",
+        thumbnail_width=128,
+        thumbnail_height=128,
+        detections=[
+            {
+                "face_id": "face-1",
+                "bbox_x": 1,
+                "bbox_y": 2,
+                "bbox_w": 3,
+                "bbox_h": 4,
+                "bitmap": "ZmFjZS1iaXRtYXA=",
+                "embedding": None,
+                "provenance": {"detector": "fresh"},
+            }
+        ],
+        warnings=[],
+        payload_version=1,
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="candidate-refresh.jpg",
+    )
+
+    def fake_process_candidate_payload(database_url_arg, *, payload, face_detector=None):
+        assert database_url_arg == database_url
+        assert payload == candidate_payload
+        return ExtractionResult(
+            extracted_payload=refreshed_payload,
+            reused_existing_artifacts=False,
+            analysis_performed=True,
+        )
+
+    monkeypatch.setattr(
+        ingest_queue_processor,
+        "process_candidate_payload",
+        fake_process_candidate_payload,
+        raising=False,
+    )
+
+    result = process_pending_ingest_queue(database_url, limit=10)
+
+    completed_rows = queue_store.list_by_status("completed")
+    pending_rows = queue_store.list_by_status("pending")
+    assert result.processed == 1
+    assert result.failed == 0
+    assert result.retryable_errors == 0
+    assert len(completed_rows) == 1
+    assert completed_rows[0].payload_type == "ingest_candidate"
+    assert len(pending_rows) == 1
+    assert pending_rows[0].ingest_queue_id == extracted_queue_id
+    assert pending_rows[0].payload_type == "extracted_photo"
+    assert pending_rows[0].payload_json == refreshed_payload
+    assert pending_rows[0].last_error is None
+
+
 def test_process_pending_rows_records_failed_and_retryable_file_outcomes(tmp_path, monkeypatch):
     database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-run-errors.db'}"
     upgrade_database(database_url)

--- a/apps/api/tests/test_ingest_queue_processor.py
+++ b/apps/api/tests/test_ingest_queue_processor.py
@@ -625,7 +625,7 @@ def test_process_pending_rows_revives_failed_extracted_photo_row_on_idempotency_
         "modified_mtime_ns": 123456789,
         "idempotency_key": "wf-1:candidate-revive.jpg:123:123456789",
     }
-    queue_store.enqueue(
+    candidate_queue_id = queue_store.enqueue(
         payload_type="ingest_candidate",
         payload=candidate_payload,
         idempotency_key=candidate_payload["idempotency_key"],
@@ -639,6 +639,13 @@ def test_process_pending_rows_revives_failed_extracted_photo_row_on_idempotency_
         payload_type="extracted_photo",
         payload=stale_extracted_payload,
         idempotency_key="extracted:shared-photo-id",
+    )
+    base_time = datetime(2024, 1, 1, tzinfo=UTC)
+    set_queue_row_enqueued_ts(database_url, candidate_queue_id, enqueued_ts=base_time)
+    set_queue_row_enqueued_ts(
+        database_url,
+        extracted_queue_id,
+        enqueued_ts=base_time + timedelta(seconds=1),
     )
     engine = create_engine(database_url, future=True)
     with engine.begin() as connection:
@@ -721,7 +728,7 @@ def test_process_pending_rows_requeues_completed_extracted_photo_row_when_payloa
         "modified_mtime_ns": 123456789,
         "idempotency_key": "wf-1:candidate-refresh.jpg:123:123456789",
     }
-    queue_store.enqueue(
+    candidate_queue_id = queue_store.enqueue(
         payload_type="ingest_candidate",
         payload=candidate_payload,
         idempotency_key=candidate_payload["idempotency_key"],
@@ -741,6 +748,13 @@ def test_process_pending_rows_requeues_completed_extracted_photo_row_when_payloa
         payload_type="extracted_photo",
         payload=stale_extracted_payload,
         idempotency_key="extracted:shared-photo-id",
+    )
+    base_time = datetime(2024, 1, 1, tzinfo=UTC)
+    set_queue_row_enqueued_ts(database_url, candidate_queue_id, enqueued_ts=base_time)
+    set_queue_row_enqueued_ts(
+        database_url,
+        extracted_queue_id,
+        enqueued_ts=base_time + timedelta(seconds=1),
     )
     engine = create_engine(database_url, future=True)
     with engine.begin() as connection:
@@ -797,6 +811,112 @@ def test_process_pending_rows_requeues_completed_extracted_photo_row_when_payloa
     )
 
     result = process_pending_ingest_queue(database_url, limit=10)
+
+    completed_rows = queue_store.list_by_status("completed")
+    pending_rows = queue_store.list_by_status("pending")
+    assert result.processed == 1
+    assert result.failed == 0
+    assert result.retryable_errors == 0
+    assert len(completed_rows) == 1
+    assert completed_rows[0].payload_type == "ingest_candidate"
+    assert len(pending_rows) == 1
+    assert pending_rows[0].ingest_queue_id == extracted_queue_id
+    assert pending_rows[0].payload_type == "extracted_photo"
+    assert pending_rows[0].payload_json == refreshed_payload
+    assert pending_rows[0].last_error is None
+
+
+def test_process_pending_rows_refreshes_pending_extracted_photo_row_when_payload_refreshes(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-candidate-refresh-pending.db'}"
+    upgrade_database(database_url)
+    queue_store = IngestQueueStore(database_url)
+
+    candidate_payload = {
+        "payload_version": 1,
+        "storage_source_id": "source-1",
+        "watched_folder_id": "wf-1",
+        "canonical_path": "/library/candidate-refresh-pending.jpg",
+        "runtime_path": str((tmp_path / "candidate-refresh-pending.jpg").resolve()),
+        "relative_path": "candidate-refresh-pending.jpg",
+        "filesize": 123,
+        "modified_ts": "2024-01-02T00:00:00+00:00",
+        "modified_mtime_ns": 123456789,
+        "idempotency_key": "wf-1:candidate-refresh-pending.jpg:123:123456789",
+    }
+    candidate_queue_id = queue_store.enqueue(
+        payload_type="ingest_candidate",
+        payload=candidate_payload,
+        idempotency_key=candidate_payload["idempotency_key"],
+    )
+
+    stale_extracted_payload = build_payload(
+        photo_id="shared-photo-id",
+        path="/library/stale-pending.jpg",
+        detections=[],
+        warnings=["face detection failed: detector exploded"],
+        payload_version=1,
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="candidate-refresh-pending.jpg",
+    )
+    extracted_queue_id = queue_store.enqueue(
+        payload_type="extracted_photo",
+        payload=stale_extracted_payload,
+        idempotency_key="extracted:shared-photo-id",
+    )
+    base_time = datetime(2024, 1, 1, tzinfo=UTC)
+    set_queue_row_enqueued_ts(database_url, candidate_queue_id, enqueued_ts=base_time)
+    set_queue_row_enqueued_ts(
+        database_url,
+        extracted_queue_id,
+        enqueued_ts=base_time + timedelta(seconds=1),
+    )
+
+    refreshed_payload = build_payload(
+        photo_id="shared-photo-id",
+        path="/library/candidate-refresh-pending.jpg",
+        thumbnail_jpeg="dGh1bWI=",
+        thumbnail_mime_type="image/jpeg",
+        thumbnail_width=128,
+        thumbnail_height=128,
+        detections=[
+            {
+                "face_id": "face-1",
+                "bbox_x": 1,
+                "bbox_y": 2,
+                "bbox_w": 3,
+                "bbox_h": 4,
+                "bitmap": "ZmFjZS1iaXRtYXA=",
+                "embedding": None,
+                "provenance": {"detector": "fresh"},
+            }
+        ],
+        warnings=[],
+        payload_version=1,
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="candidate-refresh-pending.jpg",
+    )
+
+    def fake_process_candidate_payload(database_url_arg, *, payload, face_detector=None):
+        assert database_url_arg == database_url
+        assert payload == candidate_payload
+        return ExtractionResult(
+            extracted_payload=refreshed_payload,
+            reused_existing_artifacts=False,
+            analysis_performed=True,
+        )
+
+    monkeypatch.setattr(
+        ingest_queue_processor,
+        "process_candidate_payload",
+        fake_process_candidate_payload,
+        raising=False,
+    )
+
+    result = process_pending_ingest_queue(database_url, limit=1)
 
     completed_rows = queue_store.list_by_status("completed")
     pending_rows = queue_store.list_by_status("pending")

--- a/apps/api/tests/test_ingest_queue_processor.py
+++ b/apps/api/tests/test_ingest_queue_processor.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from sqlalchemy import create_engine, select, update
+from sqlalchemy import create_engine, insert, select, update
 from sqlalchemy.engine import Connection
 
 from app.db.queue import IngestQueueStore
@@ -13,7 +13,7 @@ from app.services.ingest_queue_processor import (
     PROCESSING_LEASE_SECONDS,
     process_pending_ingest_queue,
 )
-from app.storage import faces, photos
+from app.storage import faces, photo_files, photos, watched_folders
 from photoorg_db_schema import ingest_queue, ingest_run_files, ingest_runs
 
 
@@ -84,6 +84,17 @@ def load_face_rows(database_url: str, photo_id: str) -> list[dict]:
             )
             .where(faces.c.photo_id == photo_id)
             .order_by(faces.c.face_id)
+        ).mappings()
+    return [dict(row) for row in rows]
+
+
+def load_photo_file_rows(database_url: str, photo_id: str) -> list[dict]:
+    engine = create_engine(database_url, future=True)
+    with engine.connect() as connection:
+        rows = connection.execute(
+            select(photo_files)
+            .where(photo_files.c.photo_id == photo_id)
+            .order_by(photo_files.c.relative_path)
         ).mappings()
     return [dict(row) for row in rows]
 
@@ -810,6 +821,21 @@ def test_process_pending_rows_persists_payload_faces_for_extracted_photo_without
     database_url = f"sqlite:///{tmp_path / 'queue-processor-extracted-photo.db'}"
     upgrade_database(database_url)
     queue_store = IngestQueueStore(database_url)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(watched_folders).values(
+                watched_folder_id="wf-1",
+                scan_path="/library/imports",
+                storage_source_id="source-1",
+                relative_path="imports",
+                display_name="Imports",
+                is_enabled=1,
+                availability_state="active",
+                created_ts=datetime(2024, 1, 1, tzinfo=UTC),
+                updated_ts=datetime(2024, 1, 1, tzinfo=UTC),
+            )
+        )
 
     extracted_payload = serialize_extracted_content_submission(
         record=ingest_queue_processor.PhotoRecord(
@@ -891,6 +917,17 @@ def test_process_pending_rows_persists_payload_faces_for_extracted_photo_without
     assert len(completed_rows) == 1
     assert completed_rows[0].payload_type == "extracted_photo"
     assert completed_rows[0].last_error is None
+    photo_file_rows = load_photo_file_rows(database_url, "photo-extracted-1")
+    assert len(photo_file_rows) == 1
+    assert photo_file_rows[0]["photo_id"] == "photo-extracted-1"
+    assert photo_file_rows[0]["watched_folder_id"] == "wf-1"
+    assert photo_file_rows[0]["relative_path"] == "extracted.jpg"
+    assert photo_file_rows[0]["filename"] == "extracted.jpg"
+    assert photo_file_rows[0]["extension"] == "jpg"
+    assert photo_file_rows[0]["filesize"] == 123
+    assert photo_file_rows[0]["lifecycle_state"] == "active"
+    assert photo_file_rows[0]["missing_ts"] is None
+    assert photo_file_rows[0]["deleted_ts"] is None
     assert len(run_rows) == 1
     assert run_rows[0]["status"] == "completed"
     assert run_rows[0]["files_seen"] == 1
@@ -901,6 +938,119 @@ def test_process_pending_rows_persists_payload_faces_for_extracted_photo_without
     assert file_rows[0]["path"] == "/library/extracted.jpg"
     assert file_rows[0]["outcome"] == "completed"
     assert file_rows[0]["error_detail"] is None
+
+
+def test_process_pending_rows_reuses_existing_photo_row_for_duplicate_sha_extracted_payload(
+    tmp_path,
+):
+    database_url = f"sqlite:///{tmp_path / 'queue-processor-extracted-photo-duplicate-sha.db'}"
+    upgrade_database(database_url)
+    queue_store = IngestQueueStore(database_url)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(watched_folders).values(
+                watched_folder_id="wf-1",
+                scan_path="/library/imports",
+                storage_source_id="source-1",
+                relative_path="imports",
+                display_name="Imports",
+                is_enabled=1,
+                availability_state="active",
+                created_ts=datetime(2024, 1, 1, tzinfo=UTC),
+                updated_ts=datetime(2024, 1, 1, tzinfo=UTC),
+            )
+        )
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-existing",
+                path="/library/original.jpg",
+                sha256="d" * 64,
+                phash=None,
+                filesize=100,
+                ext="jpg",
+                created_ts=datetime(2024, 1, 1, tzinfo=UTC),
+                modified_ts=datetime(2024, 1, 1, tzinfo=UTC),
+                shot_ts=None,
+                shot_ts_source=None,
+                camera_make=None,
+                camera_model=None,
+                software=None,
+                orientation=None,
+                gps_latitude=None,
+                gps_longitude=None,
+                gps_altitude=None,
+                thumbnail_jpeg=b"old-thumb",
+                thumbnail_mime_type="image/jpeg",
+                thumbnail_width=64,
+                thumbnail_height=64,
+                updated_ts=datetime(2024, 1, 1, tzinfo=UTC),
+                deleted_ts=None,
+                faces_count=1,
+                faces_detected_ts=datetime(2024, 1, 1, tzinfo=UTC),
+            )
+        )
+    extracted_payload = serialize_extracted_content_submission(
+        record=ingest_queue_processor.PhotoRecord(
+            photo_id="photo-new-path",
+            path="/library/duplicate.jpg",
+            sha256="d" * 64,
+            filesize=123,
+            ext="jpg",
+            created_ts=datetime(2024, 1, 2, tzinfo=UTC),
+            modified_ts=datetime(2024, 1, 3, tzinfo=UTC),
+            shot_ts=None,
+            shot_ts_source=None,
+            camera_make=None,
+            camera_model=None,
+            software=None,
+            orientation=None,
+            gps_latitude=None,
+            gps_longitude=None,
+            gps_altitude=None,
+            thumbnail_jpeg=b"thumb",
+            thumbnail_mime_type="image/jpeg",
+            thumbnail_width=128,
+            thumbnail_height=96,
+            faces_count=1,
+        ),
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="duplicate.jpg",
+        detections=[
+            {
+                "face_id": "face-from-payload",
+                "bbox_x": 11,
+                "bbox_y": 22,
+                "bbox_w": 33,
+                "bbox_h": 44,
+                "bitmap": b"face-bitmap",
+                "embedding": None,
+                "provenance": {"detector": "staged"},
+            }
+        ],
+        warnings=[],
+    )
+    queue_store.enqueue(
+        payload_type="extracted_photo",
+        payload=extracted_payload,
+        idempotency_key="extracted:photo-new-path",
+    )
+
+    result = process_pending_ingest_queue(
+        database_url,
+        limit=10,
+        face_detector=RaisingFaceDetector("should not run"),
+    )
+
+    assert result.processed == 1
+    assert result.failed == 0
+    assert result.retryable_errors == 0
+    photo = load_photo_row(database_url, "photo-existing")
+    assert photo["photo_id"] == "photo-existing"
+    assert photo["path"] == "/library/duplicate.jpg"
+    file_rows = load_photo_file_rows(database_url, "photo-existing")
+    assert [row["relative_path"] for row in file_rows] == ["duplicate.jpg"]
 
 
 def test_process_pending_rows_marks_detection_complete_when_no_faces_found(tmp_path):

--- a/apps/api/tests/test_ingest_queue_processor.py
+++ b/apps/api/tests/test_ingest_queue_processor.py
@@ -6,6 +6,8 @@ from sqlalchemy.engine import Connection
 
 from app.db.queue import IngestQueueStore
 from app.migrations import upgrade_database
+from app.processing.ingest_persistence import serialize_extracted_content_submission
+from app.services.ingest_extraction_worker import ExtractionResult
 from app.services import ingest_queue_processor
 from app.services.ingest_queue_processor import (
     PROCESSING_LEASE_SECONDS,
@@ -290,6 +292,329 @@ def test_process_pending_rows_marks_unsupported_payload_failed_without_stranding
     assert file_rows[0]["error_detail"] == "Unsupported payload_type: unknown_payload"
 
 
+def test_process_pending_rows_routes_ingest_candidate_to_extracted_payload_queue(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-candidate.db'}"
+    upgrade_database(database_url)
+    queue_store = IngestQueueStore(database_url)
+
+    candidate_payload = {
+        "payload_version": 1,
+        "storage_source_id": "source-1",
+        "watched_folder_id": "wf-1",
+        "canonical_path": "/library/candidate.jpg",
+        "runtime_path": str((tmp_path / "candidate.jpg").resolve()),
+        "relative_path": "candidate.jpg",
+        "filesize": 123,
+        "modified_ts": "2024-01-02T00:00:00+00:00",
+        "modified_mtime_ns": 123456789,
+        "idempotency_key": "wf-1:candidate.jpg:123:123456789",
+    }
+    queue_store.enqueue(
+        payload_type="ingest_candidate",
+        payload=candidate_payload,
+        idempotency_key=candidate_payload["idempotency_key"],
+    )
+
+    extracted_payload = build_payload(
+        photo_id="extracted-photo-1",
+        path="/library/candidate.jpg",
+        thumbnail_jpeg="dGh1bWI=",
+        thumbnail_mime_type="image/jpeg",
+        thumbnail_width=128,
+        thumbnail_height=128,
+        detections=[],
+        warnings=[],
+        payload_version=1,
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="candidate.jpg",
+    )
+
+    def fake_process_candidate_payload(database_url_arg, *, payload, face_detector=None):
+        assert database_url_arg == database_url
+        assert payload == candidate_payload
+        return ExtractionResult(
+            extracted_payload=extracted_payload,
+            reused_existing_artifacts=False,
+            analysis_performed=True,
+        )
+
+    monkeypatch.setattr(
+        ingest_queue_processor,
+        "process_candidate_payload",
+        fake_process_candidate_payload,
+        raising=False,
+    )
+
+    result = process_pending_ingest_queue(database_url, limit=10)
+
+    completed_rows = queue_store.list_by_status("completed")
+    pending_rows = queue_store.list_by_status("pending")
+    run_rows = load_ingest_runs(database_url)
+    file_rows = load_ingest_run_files(database_url)
+
+    assert result.processed == 1
+    assert result.failed == 0
+    assert result.retryable_errors == 0
+    assert len(completed_rows) == 1
+    assert completed_rows[0].payload_type == "ingest_candidate"
+    assert completed_rows[0].payload_json == candidate_payload
+    assert completed_rows[0].last_error is None
+    assert len(pending_rows) == 1
+    assert pending_rows[0].payload_type == "extracted_photo"
+    assert pending_rows[0].payload_json == extracted_payload
+    assert pending_rows[0].idempotency_key == f"extracted:{extracted_payload['photo_id']}"
+    assert load_photo_paths(database_url) == []
+    assert len(run_rows) == 1
+    assert run_rows[0]["status"] == "completed"
+    assert run_rows[0]["files_seen"] == 1
+    assert run_rows[0]["files_created"] == 0
+    assert run_rows[0]["files_updated"] == 0
+    assert run_rows[0]["error_count"] == 0
+    assert len(file_rows) == 1
+    assert file_rows[0]["path"] == candidate_payload["canonical_path"]
+    assert file_rows[0]["outcome"] == "completed"
+    assert file_rows[0]["error_detail"] is None
+
+
+def test_process_pending_rows_scopes_extracted_photo_idempotency_key_away_from_legacy_rows(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-candidate-idempotency.db'}"
+    upgrade_database(database_url)
+    queue_store = IngestQueueStore(database_url)
+
+    legacy_payload = build_payload(photo_id="shared-photo-id", path="queued/legacy.heic")
+    legacy_queue_id = queue_store.enqueue(
+        payload_type="photo_metadata",
+        payload=legacy_payload,
+        idempotency_key="shared-photo-id",
+    )
+    mark_queue_row_processing(
+        database_url,
+        legacy_queue_id,
+        last_attempt_ts=datetime.now(tz=UTC),
+    )
+
+    candidate_payload = {
+        "payload_version": 1,
+        "storage_source_id": "source-1",
+        "watched_folder_id": "wf-1",
+        "canonical_path": "/library/candidate-collision.jpg",
+        "runtime_path": str((tmp_path / "candidate-collision.jpg").resolve()),
+        "relative_path": "candidate-collision.jpg",
+        "filesize": 123,
+        "modified_ts": "2024-01-02T00:00:00+00:00",
+        "modified_mtime_ns": 123456789,
+        "idempotency_key": "wf-1:candidate-collision.jpg:123:123456789",
+    }
+    queue_store.enqueue(
+        payload_type="ingest_candidate",
+        payload=candidate_payload,
+        idempotency_key=candidate_payload["idempotency_key"],
+    )
+
+    extracted_payload = build_payload(
+        photo_id="shared-photo-id",
+        path="/library/candidate-collision.jpg",
+        thumbnail_jpeg="dGh1bWI=",
+        thumbnail_mime_type="image/jpeg",
+        thumbnail_width=128,
+        thumbnail_height=128,
+        detections=[],
+        warnings=[],
+        payload_version=1,
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="candidate-collision.jpg",
+    )
+
+    def fake_process_candidate_payload(database_url_arg, *, payload, face_detector=None):
+        assert database_url_arg == database_url
+        assert payload == candidate_payload
+        return ExtractionResult(
+            extracted_payload=extracted_payload,
+            reused_existing_artifacts=False,
+            analysis_performed=True,
+        )
+
+    monkeypatch.setattr(
+        ingest_queue_processor,
+        "process_candidate_payload",
+        fake_process_candidate_payload,
+        raising=False,
+    )
+
+    result = process_pending_ingest_queue(database_url, limit=10)
+
+    pending_rows = queue_store.list_by_status("pending")
+    processing_rows = queue_store.list_by_status("processing")
+    assert result.processed == 1
+    assert result.failed == 0
+    assert result.retryable_errors == 0
+    assert len(processing_rows) == 1
+    assert processing_rows[0].ingest_queue_id == legacy_queue_id
+    assert len(pending_rows) == 1
+    extracted_row = next(row for row in pending_rows if row.payload_type == "extracted_photo")
+    assert extracted_row.payload_json == extracted_payload
+    assert extracted_row.idempotency_key == "extracted:shared-photo-id"
+
+
+def test_process_pending_rows_records_canonical_path_for_retryable_ingest_candidate_failure(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-candidate-failure.db'}"
+    upgrade_database(database_url)
+    queue_store = IngestQueueStore(database_url)
+
+    candidate_payload = {
+        "payload_version": 1,
+        "storage_source_id": "source-1",
+        "watched_folder_id": "wf-1",
+        "canonical_path": "/library/candidate-failure.jpg",
+        "runtime_path": str((tmp_path / "candidate-failure.jpg").resolve()),
+        "relative_path": "candidate-failure.jpg",
+        "filesize": 123,
+        "modified_ts": "2024-01-02T00:00:00+00:00",
+        "modified_mtime_ns": 123456789,
+        "idempotency_key": "wf-1:candidate-failure.jpg:123:123456789",
+    }
+    queue_id = queue_store.enqueue(
+        payload_type="ingest_candidate",
+        payload=candidate_payload,
+        idempotency_key=candidate_payload["idempotency_key"],
+    )
+
+    def failing_process_candidate_payload(database_url_arg, *, payload, face_detector=None):
+        assert database_url_arg == database_url
+        assert payload == candidate_payload
+        raise RuntimeError("staged extraction exploded")
+
+    monkeypatch.setattr(
+        ingest_queue_processor,
+        "process_candidate_payload",
+        failing_process_candidate_payload,
+        raising=False,
+    )
+
+    result = process_pending_ingest_queue(database_url, limit=10)
+
+    run_rows = load_ingest_runs(database_url)
+    file_rows = load_ingest_run_files(database_url)
+
+    assert result.processed == 0
+    assert result.failed == 0
+    assert result.retryable_errors == 1
+    assert len(run_rows) == 1
+    assert run_rows[0]["status"] == "partial"
+    assert run_rows[0]["files_seen"] == 1
+    assert run_rows[0]["error_count"] == 1
+    assert run_rows[0]["error_summary"] == "staged extraction exploded"
+    assert len(file_rows) == 1
+    assert file_rows[0]["ingest_queue_id"] == queue_id
+    assert file_rows[0]["path"] == candidate_payload["canonical_path"]
+    assert file_rows[0]["outcome"] == "retryable_error"
+    assert file_rows[0]["error_detail"] == "staged extraction exploded"
+
+
+def test_process_pending_rows_revives_failed_extracted_photo_row_on_idempotency_collision(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-candidate-revive.db'}"
+    upgrade_database(database_url)
+    queue_store = IngestQueueStore(database_url)
+
+    candidate_payload = {
+        "payload_version": 1,
+        "storage_source_id": "source-1",
+        "watched_folder_id": "wf-1",
+        "canonical_path": "/library/candidate-revive.jpg",
+        "runtime_path": str((tmp_path / "candidate-revive.jpg").resolve()),
+        "relative_path": "candidate-revive.jpg",
+        "filesize": 123,
+        "modified_ts": "2024-01-02T00:00:00+00:00",
+        "modified_mtime_ns": 123456789,
+        "idempotency_key": "wf-1:candidate-revive.jpg:123:123456789",
+    }
+    queue_store.enqueue(
+        payload_type="ingest_candidate",
+        payload=candidate_payload,
+        idempotency_key=candidate_payload["idempotency_key"],
+    )
+
+    stale_extracted_payload = build_payload(
+        photo_id="shared-photo-id",
+        path="/library/stale.jpg",
+    )
+    extracted_queue_id = queue_store.enqueue(
+        payload_type="extracted_photo",
+        payload=stale_extracted_payload,
+        idempotency_key="extracted:shared-photo-id",
+    )
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            update(ingest_queue)
+            .where(ingest_queue.c.ingest_queue_id == extracted_queue_id)
+            .values(
+                status="failed",
+                last_error="old failure",
+                processed_ts=datetime.now(tz=UTC),
+            )
+        )
+
+    refreshed_payload = build_payload(
+        photo_id="shared-photo-id",
+        path="/library/candidate-revive.jpg",
+        thumbnail_jpeg="dGh1bWI=",
+        thumbnail_mime_type="image/jpeg",
+        thumbnail_width=128,
+        thumbnail_height=128,
+        detections=[],
+        warnings=[],
+        payload_version=1,
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="candidate-revive.jpg",
+    )
+
+    def fake_process_candidate_payload(database_url_arg, *, payload, face_detector=None):
+        assert database_url_arg == database_url
+        assert payload == candidate_payload
+        return ExtractionResult(
+            extracted_payload=refreshed_payload,
+            reused_existing_artifacts=False,
+            analysis_performed=True,
+        )
+
+    monkeypatch.setattr(
+        ingest_queue_processor,
+        "process_candidate_payload",
+        fake_process_candidate_payload,
+        raising=False,
+    )
+
+    result = process_pending_ingest_queue(database_url, limit=10)
+
+    completed_rows = queue_store.list_by_status("completed")
+    pending_rows = queue_store.list_by_status("pending")
+    failed_rows = queue_store.list_by_status("failed")
+
+    assert result.processed == 1
+    assert result.failed == 0
+    assert result.retryable_errors == 0
+    assert len(completed_rows) == 1
+    assert completed_rows[0].payload_type == "ingest_candidate"
+    assert failed_rows == []
+    assert len(pending_rows) == 1
+    assert pending_rows[0].ingest_queue_id == extracted_queue_id
+    assert pending_rows[0].payload_type == "extracted_photo"
+    assert pending_rows[0].payload_json == refreshed_payload
+    assert pending_rows[0].last_error is None
+
+
 def test_process_pending_rows_records_failed_and_retryable_file_outcomes(tmp_path, monkeypatch):
     database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-run-errors.db'}"
     upgrade_database(database_url)
@@ -477,6 +802,105 @@ def test_process_pending_rows_persists_detected_faces_for_photo_metadata(tmp_pat
     completed_rows = queue_store.list_by_status("completed")
     assert len(completed_rows) == 1
     assert completed_rows[0].last_error is None
+
+
+def test_process_pending_rows_persists_payload_faces_for_extracted_photo_without_detection(
+    tmp_path,
+):
+    database_url = f"sqlite:///{tmp_path / 'queue-processor-extracted-photo.db'}"
+    upgrade_database(database_url)
+    queue_store = IngestQueueStore(database_url)
+
+    extracted_payload = serialize_extracted_content_submission(
+        record=ingest_queue_processor.PhotoRecord(
+            photo_id="photo-extracted-1",
+            path="/library/extracted.jpg",
+            sha256="c" * 64,
+            filesize=123,
+            ext="jpg",
+            created_ts=datetime(2024, 1, 1, tzinfo=UTC),
+            modified_ts=datetime(2024, 1, 2, tzinfo=UTC),
+            shot_ts=None,
+            shot_ts_source=None,
+            camera_make=None,
+            camera_model=None,
+            software=None,
+            orientation=None,
+            gps_latitude=None,
+            gps_longitude=None,
+            gps_altitude=None,
+            thumbnail_jpeg=b"thumb",
+            thumbnail_mime_type="image/jpeg",
+            thumbnail_width=128,
+            thumbnail_height=96,
+            faces_count=1,
+        ),
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="extracted.jpg",
+        detections=[
+            {
+                "face_id": "face-from-payload",
+                "bbox_x": 11,
+                "bbox_y": 22,
+                "bbox_w": 33,
+                "bbox_h": 44,
+                "bitmap": b"face-bitmap",
+                "embedding": None,
+                "provenance": {"detector": "staged"},
+            }
+        ],
+        warnings=[],
+    )
+    queue_store.enqueue(
+        payload_type="extracted_photo",
+        payload=extracted_payload,
+        idempotency_key=f"extracted:{extracted_payload['photo_id']}",
+    )
+
+    result = process_pending_ingest_queue(
+        database_url,
+        limit=10,
+        face_detector=RaisingFaceDetector("should not run"),
+    )
+
+    run_rows = load_ingest_runs(database_url)
+    file_rows = load_ingest_run_files(database_url)
+
+    assert result.processed == 1
+    assert result.failed == 0
+    assert result.retryable_errors == 0
+    assert load_photo_paths(database_url) == ["/library/extracted.jpg"]
+    assert load_face_rows(database_url, "photo-extracted-1") == [
+        {
+            "face_id": "face-from-payload",
+            "photo_id": "photo-extracted-1",
+            "bbox_x": 11,
+            "bbox_y": 22,
+            "bbox_w": 33,
+            "bbox_h": 44,
+            "provenance": {"detector": "staged"},
+        }
+    ]
+    faces_count, faces_detected_ts = load_photo_detection_state(
+        database_url, "photo-extracted-1"
+    )
+    assert faces_count == 1
+    assert faces_detected_ts is not None
+    completed_rows = queue_store.list_by_status("completed")
+    assert len(completed_rows) == 1
+    assert completed_rows[0].payload_type == "extracted_photo"
+    assert completed_rows[0].last_error is None
+    assert len(run_rows) == 1
+    assert run_rows[0]["status"] == "completed"
+    assert run_rows[0]["files_seen"] == 1
+    assert run_rows[0]["files_created"] == 1
+    assert run_rows[0]["files_updated"] == 0
+    assert run_rows[0]["error_count"] == 0
+    assert len(file_rows) == 1
+    assert file_rows[0]["path"] == "/library/extracted.jpg"
+    assert file_rows[0]["outcome"] == "completed"
+    assert file_rows[0]["error_detail"] is None
 
 
 def test_process_pending_rows_marks_detection_complete_when_no_faces_found(tmp_path):

--- a/apps/api/tests/test_ingest_queue_processor.py
+++ b/apps/api/tests/test_ingest_queue_processor.py
@@ -932,6 +932,109 @@ def test_process_pending_rows_refreshes_pending_extracted_photo_row_when_payload
     assert pending_rows[0].last_error is None
 
 
+def test_process_pending_rows_retries_candidate_when_collided_extracted_row_is_processing(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-candidate-refresh-processing.db'}"
+    upgrade_database(database_url)
+    queue_store = IngestQueueStore(database_url)
+
+    candidate_payload = {
+        "payload_version": 1,
+        "storage_source_id": "source-1",
+        "watched_folder_id": "wf-1",
+        "canonical_path": "/library/candidate-refresh-processing.jpg",
+        "runtime_path": str((tmp_path / "candidate-refresh-processing.jpg").resolve()),
+        "relative_path": "candidate-refresh-processing.jpg",
+        "filesize": 123,
+        "modified_ts": "2024-01-02T00:00:00+00:00",
+        "modified_mtime_ns": 123456789,
+        "idempotency_key": "wf-1:candidate-refresh-processing.jpg:123:123456789",
+    }
+    candidate_queue_id = queue_store.enqueue(
+        payload_type="ingest_candidate",
+        payload=candidate_payload,
+        idempotency_key=candidate_payload["idempotency_key"],
+    )
+
+    stale_extracted_payload = build_payload(
+        photo_id="shared-photo-id",
+        path="/library/stale-processing.jpg",
+        payload_version=1,
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="candidate-refresh-processing.jpg",
+    )
+    extracted_queue_id = queue_store.enqueue(
+        payload_type="extracted_photo",
+        payload=stale_extracted_payload,
+        idempotency_key="extracted:shared-photo-id",
+    )
+    base_time = datetime(2024, 1, 1, tzinfo=UTC)
+    set_queue_row_enqueued_ts(database_url, candidate_queue_id, enqueued_ts=base_time)
+    set_queue_row_enqueued_ts(
+        database_url,
+        extracted_queue_id,
+        enqueued_ts=base_time + timedelta(seconds=1),
+    )
+    mark_queue_row_processing(
+        database_url,
+        extracted_queue_id,
+        last_attempt_ts=datetime.now(tz=UTC),
+    )
+
+    refreshed_payload = build_payload(
+        photo_id="shared-photo-id",
+        path="/library/candidate-refresh-processing.jpg",
+        thumbnail_jpeg="dGh1bWI=",
+        thumbnail_mime_type="image/jpeg",
+        thumbnail_width=128,
+        thumbnail_height=128,
+        detections=[],
+        warnings=[],
+        payload_version=1,
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="candidate-refresh-processing.jpg",
+    )
+
+    def fake_process_candidate_payload(database_url_arg, *, payload, face_detector=None):
+        assert database_url_arg == database_url
+        assert payload == candidate_payload
+        return ExtractionResult(
+            extracted_payload=refreshed_payload,
+            reused_existing_artifacts=False,
+            analysis_performed=True,
+        )
+
+    monkeypatch.setattr(
+        ingest_queue_processor,
+        "process_candidate_payload",
+        fake_process_candidate_payload,
+        raising=False,
+    )
+
+    result = process_pending_ingest_queue(database_url, limit=1)
+
+    processing_rows = queue_store.list_by_status("processing")
+    completed_rows = queue_store.list_by_status("completed")
+    pending_rows = queue_store.list_by_status("pending")
+
+    assert result.processed == 0
+    assert result.failed == 0
+    assert result.retryable_errors == 1
+    assert completed_rows == []
+    assert pending_rows == []
+    assert {row.ingest_queue_id for row in processing_rows} == {
+        candidate_queue_id,
+        extracted_queue_id,
+    }
+    candidate_row = next(row for row in processing_rows if row.ingest_queue_id == candidate_queue_id)
+    extracted_row = next(row for row in processing_rows if row.ingest_queue_id == extracted_queue_id)
+    assert candidate_row.last_error == "extracted payload row is currently processing; retry candidate later"
+    assert extracted_row.payload_json == stale_extracted_payload
+
+
 def test_process_pending_rows_records_failed_and_retryable_file_outcomes(tmp_path, monkeypatch):
     database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-run-errors.db'}"
     upgrade_database(database_url)

--- a/docs/superpowers/plans/2026-04-05-issue-126-staged-ingest-analysis.md
+++ b/docs/superpowers/plans/2026-04-05-issue-126-staged-ingest-analysis.md
@@ -1,0 +1,761 @@
+# Issue 126 Staged Ingest Analysis Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor watched-folder ingest so polling only discovers candidate files, downstream workers hash and analyze content in parallelizable stages, and persistence reuses extracted artifacts for duplicate SHA content without reopening originals for face detection.
+
+**Architecture:** Keep source validation, watched-folder reconciliation, and ingest-run bookkeeping in the polling layer, but move file reading and media-derived work behind queued worker stages. Introduce an explicit candidate payload for discovery, a content-analysis payload keyed by SHA, and persistence logic that can reuse metadata, thumbnails, and face detections when the same content appears at multiple paths.
+
+**Tech Stack:** Python, SQLAlchemy Core, pytest, existing ingest queue store and ingest-run bookkeeping, OpenCV face detection, Pillow thumbnail/metadata extraction
+
+---
+
+## File Map
+
+**Create:**
+
+- `apps/api/app/services/ingest_extraction_worker.py`
+  Own the staged worker flow that reads a candidate file, computes SHA, short-circuits known-content analysis, runs metadata/thumbnail/face extraction when needed, and hands a complete payload to persistence.
+- `apps/api/tests/test_ingest_extraction_worker.py`
+  Cover hashing short-circuit behavior, new-content analysis, duplicate-content reuse, and stage-specific failure handling.
+
+**Modify:**
+
+- `apps/api/app/processing/ingest_polling.py`
+  Replace inline `build_photo_record()` and thumbnail work in the polling loop with candidate enqueueing and preserve watched-folder bookkeeping.
+- `apps/api/app/services/ingest_queue_processor.py`
+  Split persistence from analysis, consume new payload types, and remove direct original-file face detection from persistence.
+- `apps/api/app/processing/ingest_persistence.py`
+  Add candidate payload builders, extracted payload serializers/parsers, and persistence helpers that can reuse derived artifacts by SHA.
+- `apps/api/app/db/queue.py`
+  Keep the queue API generic enough for multiple payload types and update tests only if payload routing needs a small helper.
+- `apps/api/app/processing/ingest.py`
+  Keep facade entrypoints stable while delegating polling to the new discovery behavior.
+
+**Test:**
+
+- `apps/api/tests/test_ingest_polling.py`
+- `apps/api/tests/test_ingest_queue_processor.py`
+- `apps/api/tests/test_ingest_persistence.py`
+- `apps/api/tests/test_ingest.py`
+
+### Task 1: Define The New Queue Payload Contracts
+
+**Files:**
+- Modify: `apps/api/app/processing/ingest_persistence.py`
+- Test: `apps/api/tests/test_ingest_persistence.py`
+
+- [ ] **Step 1: Write the failing contract tests for candidate and extracted payload shapes**
+
+```python
+def test_build_ingest_candidate_submission_serializes_discovery_fields(tmp_path):
+    from app.processing.ingest_persistence import build_ingest_candidate_submission
+
+    source_root = tmp_path / "library"
+    source_root.mkdir()
+    photo_path = source_root / "sample.jpg"
+    photo_path.write_bytes(b"candidate-bytes")
+
+    payload = build_ingest_candidate_submission(
+        photo_path,
+        scan_root=source_root,
+        canonical_path="/library/sample.jpg",
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+    )
+
+    assert payload["payload_version"] == 1
+    assert payload["storage_source_id"] == "source-1"
+    assert payload["watched_folder_id"] == "wf-1"
+    assert payload["canonical_path"] == "/library/sample.jpg"
+    assert payload["runtime_path"] == str(photo_path.resolve())
+    assert payload["relative_path"] == "sample.jpg"
+    assert payload["idempotency_key"] == "wf-1:sample.jpg"
+    assert "sha256" not in payload
+    assert "faces" not in payload
+
+
+def test_serialize_extracted_content_submission_includes_face_and_thumbnail_fields():
+    from datetime import UTC, datetime
+
+    from app.processing.ingest_persistence import PhotoRecord, serialize_extracted_content_submission
+
+    record = PhotoRecord(
+        photo_id="photo-1",
+        path="/library/sample.jpg",
+        sha256="abc123",
+        filesize=123,
+        ext="jpg",
+        created_ts=datetime(2026, 4, 5, 12, 0, tzinfo=UTC),
+        modified_ts=datetime(2026, 4, 5, 12, 1, tzinfo=UTC),
+        shot_ts=None,
+        shot_ts_source=None,
+        camera_make="Canon",
+        camera_model="EOS",
+        software=None,
+        orientation="1",
+        gps_latitude=None,
+        gps_longitude=None,
+        gps_altitude=None,
+        thumbnail_jpeg=b"thumb",
+        thumbnail_mime_type="image/jpeg",
+        thumbnail_width=128,
+        thumbnail_height=128,
+        faces_count=1,
+    )
+
+    payload = serialize_extracted_content_submission(
+        record=record,
+        storage_source_id="source-1",
+        watched_folder_id="wf-1",
+        relative_path="sample.jpg",
+        detections=[
+            {
+                "face_id": "face-1",
+                "bbox_x": 1,
+                "bbox_y": 2,
+                "bbox_w": 3,
+                "bbox_h": 4,
+                "bitmap": None,
+                "embedding": None,
+                "provenance": {"detector": "opencv"},
+            }
+        ],
+        warnings=["face detection failed for sidecar"],
+    )
+
+    assert payload["payload_version"] == 1
+    assert payload["sha256"] == "abc123"
+    assert payload["faces_count"] == 1
+    assert payload["detections"][0]["face_id"] == "face-1"
+    assert payload["warnings"] == ["face detection failed for sidecar"]
+```
+
+- [ ] **Step 2: Run the payload contract tests to verify they fail**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_persistence.py -k "candidate_submission or extracted_content_submission" -q`
+
+Expected: `FAIL` because `build_ingest_candidate_submission` and `serialize_extracted_content_submission` do not exist yet.
+
+- [ ] **Step 3: Add minimal payload builders and serializers in `ingest_persistence.py`**
+
+```python
+def build_ingest_candidate_submission(
+    path: Path,
+    *,
+    scan_root: Path,
+    canonical_path: str,
+    storage_source_id: str,
+    watched_folder_id: str,
+) -> dict:
+    stat = path.stat()
+    relative_path = relative_photo_path(scan_root, path)
+    return {
+        "payload_version": 1,
+        "storage_source_id": storage_source_id,
+        "watched_folder_id": watched_folder_id,
+        "canonical_path": canonical_path,
+        "runtime_path": str(path.resolve()),
+        "relative_path": relative_path,
+        "filesize": stat.st_size,
+        "modified_ts": _normalize_timestamp(_parse_timestamp(stat_timestamp_to_iso(stat.st_mtime))).isoformat(),
+        "idempotency_key": f"{watched_folder_id}:{relative_path}",
+    }
+
+
+def serialize_extracted_content_submission(
+    *,
+    record: PhotoRecord,
+    storage_source_id: str,
+    watched_folder_id: str,
+    relative_path: str,
+    detections: list[dict],
+    warnings: list[str],
+) -> dict:
+    payload = _serialize_record(record)
+    payload.update(
+        {
+            "payload_version": 1,
+            "storage_source_id": storage_source_id,
+            "watched_folder_id": watched_folder_id,
+            "relative_path": relative_path,
+            "detections": detections,
+            "warnings": warnings,
+        }
+    )
+    return payload
+
+
+def serialize_reused_content_submission(
+    *,
+    record: PhotoRecord,
+    candidate_payload: dict,
+    warnings: list[str],
+) -> dict:
+    payload = _serialize_record(record)
+    payload.update(
+        {
+            "payload_version": 1,
+            "storage_source_id": candidate_payload["storage_source_id"],
+            "watched_folder_id": candidate_payload["watched_folder_id"],
+            "relative_path": candidate_payload["relative_path"],
+            "detections": [],
+            "warnings": warnings,
+        }
+    )
+    return payload
+```
+
+- [ ] **Step 4: Run the payload contract tests to verify they pass**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_persistence.py -k "candidate_submission or extracted_content_submission" -q`
+
+Expected: `2 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/processing/ingest_persistence.py apps/api/tests/test_ingest_persistence.py
+git commit -m "feat: define staged ingest payload contracts"
+```
+
+### Task 2: Add The Extraction Worker With SHA Short-Circuiting
+
+**Files:**
+- Create: `apps/api/app/services/ingest_extraction_worker.py`
+- Modify: `apps/api/app/processing/ingest_persistence.py`
+- Test: `apps/api/tests/test_ingest_extraction_worker.py`
+
+- [ ] **Step 1: Write the failing extraction-worker tests for known and new content**
+
+```python
+def test_process_candidate_reuses_existing_sha_without_running_face_detection(tmp_path, monkeypatch):
+    from app.services.ingest_extraction_worker import process_candidate_payload
+
+    candidate = {
+        "payload_version": 1,
+        "storage_source_id": "source-1",
+        "watched_folder_id": "wf-1",
+        "canonical_path": "/library/dup.jpg",
+        "runtime_path": str((tmp_path / "dup.jpg").resolve()),
+        "relative_path": "dup.jpg",
+        "idempotency_key": "wf-1:dup.jpg",
+    }
+
+    calls = {"detect": 0}
+
+    class Detector:
+        def detect(self, path):
+            calls["detect"] += 1
+            return []
+
+    monkeypatch.setattr(
+        "app.services.ingest_extraction_worker.lookup_existing_artifacts_by_sha",
+        lambda connection, sha256: {"metadata_complete": True, "thumbnail_complete": True, "faces_complete": True},
+    )
+
+    result = process_candidate_payload(
+        database_url=f"sqlite:///{tmp_path / 'worker.db'}",
+        payload=candidate,
+        face_detector=Detector(),
+    )
+
+    assert result.reused_existing_artifacts is True
+    assert result.analysis_performed is False
+    assert calls["detect"] == 0
+
+
+def test_process_candidate_runs_analysis_for_new_sha(tmp_path):
+    from app.services.ingest_extraction_worker import process_candidate_payload
+
+    photo_path = tmp_path / "new.jpg"
+    photo_path.write_bytes(b"new-bytes")
+
+    result = process_candidate_payload(
+        database_url=f"sqlite:///{tmp_path / 'worker-new.db'}",
+        payload={
+            "payload_version": 1,
+            "storage_source_id": "source-1",
+            "watched_folder_id": "wf-1",
+            "canonical_path": "/library/new.jpg",
+            "runtime_path": str(photo_path.resolve()),
+            "relative_path": "new.jpg",
+            "idempotency_key": "wf-1:new.jpg",
+        },
+    )
+
+    assert result.reused_existing_artifacts is False
+    assert result.analysis_performed is True
+    assert result.extracted_payload["sha256"]
+    assert "detections" in result.extracted_payload
+```
+
+- [ ] **Step 2: Run the extraction-worker tests to verify they fail**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_extraction_worker.py -q`
+
+Expected: `FAIL` because the worker module and SHA reuse helpers do not exist yet.
+
+- [ ] **Step 3: Add a focused extraction worker module and artifact lookup helper**
+
+```python
+@dataclass(frozen=True)
+class ExtractionResult:
+    extracted_payload: dict
+    reused_existing_artifacts: bool
+    analysis_performed: bool
+
+
+def process_candidate_payload(
+    database_url: str | Path | None,
+    *,
+    payload: dict,
+    face_detector=None,
+) -> ExtractionResult:
+    runtime_path = Path(payload["runtime_path"])
+    record = build_photo_record(runtime_path, canonical_path=payload["canonical_path"])
+    engine = create_db_engine(database_url)
+
+    with engine.begin() as connection:
+        existing = lookup_existing_artifacts_by_sha(connection, record.sha256)
+        if existing is not None and all(existing.values()):
+            extracted_payload = serialize_reused_content_submission(
+                record=record,
+                candidate_payload=payload,
+                warnings=[],
+            )
+            return ExtractionResult(
+                extracted_payload=extracted_payload,
+                reused_existing_artifacts=True,
+                analysis_performed=False,
+            )
+
+    thumbnail = generate_thumbnail(runtime_path)
+    detections = _detect_faces(runtime_path, detector=face_detector)
+    enriched = PhotoRecord(
+        **{
+            **record.__dict__,
+            "thumbnail_jpeg": thumbnail.jpeg_bytes,
+            "thumbnail_mime_type": thumbnail.mime_type,
+            "thumbnail_width": thumbnail.width,
+            "thumbnail_height": thumbnail.height,
+            "faces_count": len(detections),
+        }
+    )
+    return ExtractionResult(
+        extracted_payload=serialize_extracted_content_submission(
+            record=enriched,
+            storage_source_id=payload["storage_source_id"],
+            watched_folder_id=payload["watched_folder_id"],
+            relative_path=payload["relative_path"],
+            detections=detections,
+            warnings=[],
+        ),
+        reused_existing_artifacts=False,
+        analysis_performed=True,
+    )
+```
+
+- [ ] **Step 4: Run the extraction-worker tests to verify they pass**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_extraction_worker.py -q`
+
+Expected: `2 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/services/ingest_extraction_worker.py apps/api/app/processing/ingest_persistence.py apps/api/tests/test_ingest_extraction_worker.py
+git commit -m "feat: add staged extraction worker"
+```
+
+### Task 3: Refactor Polling Into Discovery And Candidate Enqueueing
+
+**Files:**
+- Modify: `apps/api/app/processing/ingest_polling.py`
+- Modify: `apps/api/app/db/queue.py`
+- Test: `apps/api/tests/test_ingest_polling.py`
+- Test: `apps/api/tests/test_ingest.py`
+
+- [ ] **Step 1: Write the failing polling tests for candidate enqueueing**
+
+```python
+def test_poll_registered_storage_sources_enqueues_candidate_payloads_without_inline_thumbnail_work(
+    tmp_path,
+    monkeypatch,
+):
+    import app.processing.ingest_polling as ingest_polling
+    from app.db.queue import IngestQueueStore
+
+    database_url = f"sqlite:///{tmp_path / 'poll-discovery.db'}"
+    enqueued_payloads = []
+
+    def record_enqueue(self, *, payload_type, payload, idempotency_key):
+        enqueued_payloads.append((payload_type, payload, idempotency_key))
+        return "queue-1"
+
+    monkeypatch.setattr(IngestQueueStore, "enqueue", record_enqueue)
+
+    def fail_thumbnail(path):
+        raise AssertionError("thumbnail generation should not run during polling")
+
+    monkeypatch.setattr(ingest_polling, "generate_thumbnail", fail_thumbnail)
+
+    result = ingest_polling.poll_registered_storage_sources(database_url=database_url)
+
+    assert result.scanned == 1
+    assert result.enqueued == 1
+    assert enqueued_payloads[0][0] == "ingest_candidate"
+    assert "runtime_path" in enqueued_payloads[0][1]
+    assert "sha256" not in enqueued_payloads[0][1]
+```
+
+- [ ] **Step 2: Run the polling enqueue test to verify it fails**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_polling.py -k "candidate_payloads_without_inline_thumbnail_work" -q`
+
+Expected: `FAIL` because polling still builds records and thumbnails inline and does not enqueue candidate payloads.
+
+- [ ] **Step 3: Change the polling chunk processor to enqueue candidate payloads and keep bookkeeping**
+
+```python
+queue_store = IngestQueueStore(database_url)
+
+
+def _enqueue_watched_folder_candidate(
+    *,
+    queue_store: IngestQueueStore,
+    photo_path: Path,
+    source_root: Path,
+    watched_folder_id: str,
+    storage_source_id: str,
+    canonical_path_for_relative_path: Callable[[str], str],
+) -> tuple[str, str]:
+    relative_path = relative_photo_path(source_root, photo_path)
+    payload = build_ingest_candidate_submission(
+        photo_path,
+        scan_root=source_root,
+        canonical_path=canonical_path_for_relative_path(relative_path),
+        storage_source_id=storage_source_id,
+        watched_folder_id=watched_folder_id,
+    )
+    queue_id = queue_store.enqueue(
+        payload_type="ingest_candidate",
+        payload=payload,
+        idempotency_key=payload["idempotency_key"],
+    )
+    return relative_path, queue_id
+```
+
+```python
+for photo_path in photo_paths:
+    scanned += 1
+    relative_path, _queue_id = _enqueue_watched_folder_candidate(
+        queue_store=queue_store,
+        photo_path=photo_path,
+        source_root=source_root,
+        watched_folder_id=watched_folder_id,
+        storage_source_id=storage_source_id,
+        canonical_path_for_relative_path=canonical_path_for_relative_path,
+    )
+    observed_relative_paths.add(relative_path)
+```
+
+- [ ] **Step 4: Run the focused polling tests and the facade regression tests**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_polling.py -k "candidate_payloads_without_inline_thumbnail_work or completed_run_per_chunk" -q`
+
+Expected: `PASS`
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest.py -k "poll_registered_storage_sources" -q`
+
+Expected: `PASS`, with assertions updated for enqueue-oriented poll behavior where needed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/processing/ingest_polling.py apps/api/app/db/queue.py apps/api/tests/test_ingest_polling.py apps/api/tests/test_ingest.py
+git commit -m "refactor: make polling discovery-only"
+```
+
+### Task 4: Make Queue Processing Persist Extracted Payloads Instead Of Running Face Detection
+
+**Files:**
+- Modify: `apps/api/app/services/ingest_queue_processor.py`
+- Modify: `apps/api/app/processing/ingest_persistence.py`
+- Test: `apps/api/tests/test_ingest_queue_processor.py`
+
+- [ ] **Step 1: Write the failing queue-processor tests for extracted payload persistence**
+
+```python
+def test_process_pending_ingest_queue_persists_face_detections_from_extracted_payload(tmp_path, monkeypatch):
+    from app.db.queue import IngestQueueStore
+    from app.services.ingest_queue_processor import process_pending_ingest_queue
+
+    database_url = f"sqlite:///{tmp_path / 'queue-persist.db'}"
+    queue_store = IngestQueueStore(database_url)
+
+    queue_store.enqueue(
+        payload_type="extracted_photo",
+        payload={
+            "payload_version": 1,
+            "photo_id": "photo-1",
+            "path": "/library/sample.jpg",
+            "sha256": "abc123",
+            "filesize": 123,
+            "ext": "jpg",
+            "created_ts": "2026-04-05T12:00:00+00:00",
+            "modified_ts": "2026-04-05T12:00:00+00:00",
+            "shot_ts": None,
+            "shot_ts_source": None,
+            "camera_make": None,
+            "camera_model": None,
+            "software": None,
+            "orientation": None,
+            "gps_latitude": None,
+            "gps_longitude": None,
+            "gps_altitude": None,
+            "faces_count": 1,
+            "detections": [
+                {
+                    "face_id": "face-1",
+                    "bbox_x": 1,
+                    "bbox_y": 2,
+                    "bbox_w": 3,
+                    "bbox_h": 4,
+                    "bitmap": None,
+                    "embedding": None,
+                    "provenance": {"detector": "opencv"},
+                }
+            ],
+            "warnings": [],
+        },
+        idempotency_key="photo-1",
+    )
+
+    def fail_detect(path):
+        raise AssertionError("queue persistence should not run face detection")
+
+    result = process_pending_ingest_queue(
+        database_url,
+        limit=10,
+        face_detector=type("Detector", (), {"detect": fail_detect})(),
+    )
+
+    assert result.processed == 1
+```
+
+- [ ] **Step 2: Run the extracted-payload queue test to verify it fails**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_queue_processor.py -k "persists_face_detections_from_extracted_payload" -q`
+
+Expected: `FAIL` because the processor only accepts `photo_metadata` payloads and still calls `_apply_face_detection()`.
+
+- [ ] **Step 3: Route payload types explicitly and keep persistence free of media analysis**
+
+```python
+if claimed_row.payload_type == "ingest_candidate":
+    extraction_result = process_candidate_payload(
+        database_url,
+        payload=claimed_row.payload_json,
+        face_detector=detector,
+    )
+    queue_store.mark_completed(
+        claimed_row.ingest_queue_id,
+        last_error=_warning_summary(extraction_result.extracted_payload.get("warnings", [])),
+        connection=connection,
+    )
+    queue_store.enqueue(
+        payload_type="extracted_photo",
+        payload=extraction_result.extracted_payload,
+        idempotency_key=extraction_result.extracted_payload["photo_id"],
+    )
+    continue
+
+if claimed_row.payload_type == "extracted_photo":
+    record = payload_to_photo_record(claimed_row.payload_json)
+    created = upsert_photo(connection, record)
+    store_face_detections(
+        connection,
+        record.photo_id,
+        claimed_row.payload_json.get("detections", []),
+    )
+    queue_store.mark_completed(
+        claimed_row.ingest_queue_id,
+        last_error=_warning_summary(claimed_row.payload_json.get("warnings", [])),
+        connection=connection,
+    )
+    continue
+```
+
+- [ ] **Step 4: Run the queue-processor suite to verify the new routing works**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_queue_processor.py -q`
+
+Expected: `PASS`, with older tests updated to reflect `ingest_candidate` and `extracted_photo` routing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/services/ingest_queue_processor.py apps/api/app/processing/ingest_persistence.py apps/api/tests/test_ingest_queue_processor.py
+git commit -m "refactor: persist extracted ingest payloads"
+```
+
+### Task 5: Reuse Artifacts By SHA Across Duplicate-Content Paths
+
+**Files:**
+- Modify: `apps/api/app/processing/ingest_persistence.py`
+- Modify: `apps/api/app/services/ingest_extraction_worker.py`
+- Test: `apps/api/tests/test_ingest_persistence.py`
+- Test: `apps/api/tests/test_ingest.py`
+
+- [ ] **Step 1: Write the failing reuse tests for duplicate-content files**
+
+```python
+def test_lookup_existing_artifacts_by_sha_reports_complete_face_thumbnail_and_metadata_state(tmp_path):
+    from app.processing.ingest_persistence import lookup_existing_artifacts_by_sha
+
+    database_url = f"sqlite:///{tmp_path / 'reuse.db'}"
+    state = lookup_existing_artifacts_by_sha(database_url, "known-sha")
+
+    assert state == {
+        "metadata_complete": True,
+        "thumbnail_complete": True,
+        "faces_complete": True,
+    }
+
+
+def test_poll_and_process_duplicate_content_reuses_existing_artifacts(tmp_path):
+    from sqlalchemy import create_engine, select
+
+    from app.processing.ingest import poll_registered_storage_sources
+    from app.services.ingest_queue_processor import process_pending_ingest_queue
+    from photoorg_db_schema import photos
+
+    database_url = f"sqlite:///{tmp_path / 'duplicate.db'}"
+
+    first_result = poll_registered_storage_sources(database_url=database_url)
+    second_result = poll_registered_storage_sources(database_url=database_url)
+    process_pending_ingest_queue(database_url, limit=20)
+
+    engine = create_engine(database_url)
+    with engine.begin() as connection:
+        row = connection.execute(
+            select(photos.c.faces_count).where(photos.c.path == "/library/dup.jpg")
+        ).mappings().one()
+
+    assert first_result.scanned == 1
+    assert second_result.scanned == 1
+    assert row["faces_count"] == 1
+```
+
+- [ ] **Step 2: Run the duplicate-content reuse tests to verify they fail**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_persistence.py -k "lookup_existing_artifacts_by_sha" -q`
+
+Expected: `FAIL` because the lookup helper is not implemented.
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest.py -k "duplicate_content_reuses_existing_artifacts" -q`
+
+Expected: `FAIL` because the end-to-end flow does not yet short-circuit analysis by SHA.
+
+- [ ] **Step 3: Implement the SHA completeness lookup and reuse path**
+
+```python
+def lookup_existing_artifacts_by_sha(connection: Connection, sha256: str) -> dict[str, bool] | None:
+    row = connection.execute(
+        select(
+            photos.c.photo_id,
+            photos.c.camera_make,
+            photos.c.thumbnail_jpeg,
+            photos.c.faces_detected_ts,
+            photos.c.faces_count,
+        ).where(photos.c.sha256 == sha256)
+    ).mappings().first()
+    if row is None:
+        return None
+    return {
+        "metadata_complete": row["camera_make"] is not None,
+        "thumbnail_complete": row["thumbnail_jpeg"] is not None,
+        "faces_complete": row["faces_detected_ts"] is not None or row["faces_count"] == 0,
+    }
+```
+
+```python
+if existing is not None and all(existing.values()):
+    return ExtractionResult(
+        extracted_payload=serialize_reused_content_submission(
+            record=record,
+            candidate_payload=payload,
+            warnings=[],
+        ),
+        reused_existing_artifacts=True,
+        analysis_performed=False,
+    )
+```
+
+- [ ] **Step 4: Run the reuse tests and targeted end-to-end regressions**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_persistence.py -k "lookup_existing_artifacts_by_sha" -q`
+
+Expected: `PASS`
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest.py -k "same_hash or duplicate_content_reuses_existing_artifacts or preserves_existing_face_detection_timestamp" -q`
+
+Expected: `PASS`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/processing/ingest_persistence.py apps/api/app/services/ingest_extraction_worker.py apps/api/tests/test_ingest_persistence.py apps/api/tests/test_ingest.py
+git commit -m "feat: reuse extracted artifacts by sha"
+```
+
+### Task 6: Final Verification And Docs Alignment
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CONTRIBUTING.md`
+- Test: `apps/api/tests/test_ingest_polling.py`
+- Test: `apps/api/tests/test_ingest_queue_processor.py`
+- Test: `apps/api/tests/test_ingest_extraction_worker.py`
+- Test: `apps/api/tests/test_ingest.py`
+
+- [ ] **Step 1: Add or update docs for the staged ingest flow**
+
+```markdown
+`poll-storage-sources` now performs discovery and candidate scheduling only.
+Queued workers perform content hashing and, when needed, metadata extraction,
+thumbnail generation, and face detection before persistence.
+Duplicate-content files reuse existing extracted artifacts by SHA.
+```
+
+- [ ] **Step 2: Run the focused ingest verification suite**
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_persistence.py -q`
+Expected: `PASS`
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_extraction_worker.py -q`
+Expected: `PASS`
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_polling.py -q`
+Expected: `PASS`
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest_queue_processor.py -q`
+Expected: `PASS`
+
+Run: `uv run python -m pytest apps/api/tests/test_ingest.py -k "poll_registered_storage_sources or same_hash or face_detection" -q`
+Expected: `PASS`
+
+- [ ] **Step 3: Run one representative end-to-end local workflow**
+
+Run: `uv run python -m pytest apps/e2e/tests/test_seed_corpus_workflow.py -q`
+
+Expected: `PASS`, demonstrating staged polling plus downstream processing still produces searchable photos with persisted face regions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CONTRIBUTING.md apps/api/app apps/api/tests
+git commit -m "docs: describe staged ingest analysis pipeline"
+```

--- a/docs/superpowers/specs/2026-04-05-issue-126-staged-ingest-analysis-design.md
+++ b/docs/superpowers/specs/2026-04-05-issue-126-staged-ingest-analysis-design.md
@@ -1,0 +1,251 @@
+# Issue 126 Staged Ingest Analysis Design
+
+Date: 2026-04-05
+Issue: #126
+
+## Summary
+
+Refactor ingest so watched-folder polling stops performing full media extraction inline. Instead, polling should discover candidate file instances and schedule downstream work, with content hashing and expensive media analysis split into separate stages.
+
+The key design decision is that EXIF extraction, thumbnail generation, and face detection are content-level work, not file-path work. If two file instances have different paths or stat metadata but the same SHA, the system should reuse existing extracted artifacts instead of recomputing them.
+
+## Goals
+
+- keep the sequential polling loop lightweight and operationally responsive
+- separate discovery, content identity, expensive analysis, and persistence into distinct responsibilities
+- avoid rerunning EXIF extraction, thumbnail generation, and face detection for duplicate-content files
+- preserve the existing source-aware watched-folder reconciliation model
+- let downstream persistence consume extracted payloads without reopening original files for media analysis
+- keep ingest resilient when hashing or extraction fails for individual files
+
+## Non-Goals
+
+- no person recognition or face labeling beyond raw face detection
+- no attempt to make one polling process itself highly concurrent while keeping the same mixed responsibilities
+- no unrelated schema cleanup beyond what is needed for the staged ingest boundary
+- no redesign of watched-folder registration or storage-source validation semantics
+
+## Current Problem
+
+The current ingest path mixes too many responsibilities inside the watched-folder polling flow:
+
+- polling enumerates files
+- polling opens original files to derive metadata and thumbnails
+- queue processing may reopen original files again to run face detection
+- duplicate-content files at different paths may trigger repeated expensive analysis
+
+This has two architectural costs:
+
+- the operator-facing `poll-storage-sources` command remains the throughput bottleneck because it performs expensive work sequentially
+- the responsibility boundary between extraction and persistence is unclear, especially for face detection
+
+Recent chunked polling work improved durability and visibility of progress, but it intentionally kept execution serial. Adding more expensive analysis into that same serial loop would make the system slower in practice even if it moved face detection "upstream."
+
+## Recommended Approach
+
+Adopt a staged ingest pipeline with separate boundaries for discovery, content identity, analysis, and persistence.
+
+### Stage 1: Polling And Discovery
+
+Polling should:
+
+- enumerate enabled watched folders under validated storage sources
+- identify candidate file instances that may need ingest work
+- decide whether a file should advance to hashing based on path and file-state evidence already available at scan time
+- record watched-folder progress and reconciliation bookkeeping
+
+Polling should not perform:
+
+- EXIF extraction
+- thumbnail generation
+- face detection
+- other expensive media-derived work that requires the sequential poll loop to read and analyze the whole file
+
+### Stage 2: Hashing And Content Identity
+
+A downstream hashing stage should:
+
+- read candidate files and compute SHA in parallelizable worker execution
+- determine whether the content is already known
+- decide whether expensive analysis can be skipped because all required derived artifacts already exist for that SHA
+
+This makes SHA the cache boundary for expensive derived artifacts.
+
+### Stage 3: Content Analysis
+
+If the SHA is new, or if required derived artifacts are missing or stale, the system should run content analysis once for that content:
+
+- EXIF extraction
+- thumbnail generation
+- face detection
+
+This stage should emit a complete extracted payload keyed by content identity rather than path identity.
+
+### Stage 4: Persistence
+
+Persistence should:
+
+- upsert logical photo state using the extracted payload
+- persist face detections and derived metadata from the payload
+- link or update file instances for the current watched-folder observation
+- avoid reopening the original file just to recompute media-derived artifacts
+
+## Why SHA Belongs After Discovery
+
+It is tempting to require the poller to compute SHA before deciding what to do, but that would pull a large fraction of the expensive I/O back into the sequential polling path.
+
+The better split is:
+
+- polling decides which file instances are candidates for further work using path and stat evidence
+- hashing computes SHA in a parallelizable stage
+- analysis only runs if the SHA is new or artifact-completeness checks fail
+
+This keeps the expensive file-read boundary outside the poller while still using SHA as the reuse key for extracted artifacts.
+
+## Artifact Reuse Rule
+
+The system should treat expensive derived artifacts as content-level assets.
+
+If two observed file instances differ in path or stat metadata but produce the same SHA:
+
+- EXIF extraction should not rerun if the required metadata already exists for that SHA
+- thumbnail generation should not rerun if the required thumbnail asset already exists for that SHA
+- face detection should not rerun if the required face artifacts already exist for that SHA
+
+Only file-instance linkage and watched-folder reconciliation should update for the new path observation.
+
+This rule is the core reason to split hashing from analysis rather than treating every discovered file as a fresh extraction job.
+
+## Queue And Payload Contracts
+
+The queue contracts should reflect the staged model.
+
+### Discovery-To-Hashing Payload
+
+The discovery stage should enqueue a file-instance candidate payload that contains only the information needed to locate and track the candidate work item. It should not claim that expensive media analysis has already happened.
+
+Expected contents:
+
+- storage source identity and watched-folder identity
+- the runtime path needed for a worker to read the file
+- the canonical logical path or file-instance path context
+- enough stat evidence to support idempotency or stale-work rejection
+
+### Hashing-To-Analysis Decision
+
+After hashing, the system should choose one of two outcomes:
+
+- known content with complete artifacts: skip content analysis and continue to persistence/linkage
+- new or incomplete content: enqueue or perform content analysis for that SHA
+
+### Analysis-To-Persistence Payload
+
+The extracted payload should be content-oriented and complete enough that persistence does not need to reopen the original file for media analysis.
+
+Expected contents:
+
+- SHA and content identity
+- metadata fields currently derived from extraction
+- thumbnail-derived fields and bytes or asset references
+- face detections and related warning details
+- enough source/file-instance context to link the current observation to the logical photo
+
+## Responsibility Boundaries
+
+The target separation is:
+
+- polling: discovery and watched-folder bookkeeping
+- hashing: content identity establishment
+- analysis: expensive media-derived artifact generation
+- persistence: database mutation from extracted payloads
+
+This is a better single-responsibility split than placing more work into the sequential poller or leaving queue persistence responsible for reopening files.
+
+## Failure Handling
+
+Failure handling should be stage-specific.
+
+### Polling Failures
+
+Source validation and watched-folder reachability failures keep their existing meaning. A folder that cannot be safely scanned should not advance file lifecycle transitions for that scan.
+
+### Hashing Failures
+
+If hashing fails for one candidate file:
+
+- the file should record a retryable or failed work outcome based on the error class
+- the watched-folder scan as a whole should not be forced to fail if the broader scan remains valid
+- no downstream expensive analysis should run for that candidate
+
+### Analysis Failures
+
+If EXIF extraction, thumbnail generation, or face detection fails:
+
+- the system should preserve the successful hashing and identity result
+- the failure should be attached to the work outcome and surfaced in ingest-run visibility
+- the design should allow partial success where appropriate, especially if face detection fails but metadata persistence can still proceed
+
+The exact artifact-completeness semantics should be explicit in implementation, but the architecture should support "persist what succeeded, warn about what failed" rather than all-or-nothing media analysis for every file.
+
+## Data Model Direction
+
+The current logical-photo and file-instance split already points in the right direction.
+
+This design strengthens that split:
+
+- file-instance observations belong to watched-folder reconciliation
+- expensive derived artifacts belong to content identity keyed by SHA
+- persistence should reuse derived artifacts across multiple file instances sharing the same content
+
+Implementation may use existing tables where possible, but the architecture should treat derived artifacts as reusable by content, not owned by a single observed path.
+
+## Testing Strategy
+
+Follow TDD.
+
+Add focused coverage for:
+
+- a polling-driven scan that enqueues candidate work without performing full inline media analysis
+- a hashing path that detects known SHA content and skips EXIF and face work
+- a new-content path that runs analysis and persists payload-carried face detections
+- duplicate-content files at different paths reusing prior extracted artifacts
+- queue or worker persistence not reopening original files purely to run face detection
+- partial-failure behavior where face detection fails but other ingest data remains persistable
+
+Existing tests that assume polling directly performs the full extraction stack should be updated only where the staged boundary intentionally changes that contract.
+
+## Verification
+
+Minimum verification for implementation:
+
+- `uv run python -m pytest apps/api/tests/test_ingest_polling.py -q`
+- `uv run python -m pytest apps/api/tests/test_ingest_queue_processor.py -q`
+- `uv run python -m pytest apps/api/tests/test_ingest.py -k "poll_registered_storage_sources or ingest_directory" -q`
+
+Representative local validation should demonstrate:
+
+- a watched folder scan schedules candidate work quickly
+- hashing identifies known versus new content
+- duplicate-content files skip repeated expensive analysis
+- resulting photo detail data includes persisted face regions after the staged pipeline completes
+
+## Alternatives Considered
+
+### Move Face Detection Directly Into The Sequential Poller
+
+Rejected because it technically moves face detection earlier but worsens the operator bottleneck. The poller would remain responsible for too many concerns and would become slower.
+
+### Keep Queue Processing Responsible For Reopening Originals
+
+Rejected because it preserves the current ambiguity in which persistence code also performs media analysis. It also repeats expensive work when extracted payloads should have been reusable.
+
+### Compute SHA Inside The Poller Before Enqueueing
+
+Rejected because SHA computation still requires reading the file. That would move a large part of the expensive work boundary back into the sequential poll path and undercut the point of the split.
+
+## Open Questions Resolved
+
+- The poller should be lightweight and should not become the home of all upstream extraction work.
+- SHA is the reuse boundary for expensive derived artifacts.
+- Content analysis may be split from hashing so known content can short-circuit downstream work.
+- Face detection belongs in the extracted-artifact stage, not in final queue persistence.


### PR DESCRIPTION
Closes #126

## Summary
- refactor source-backed polling into discovery-only candidate scheduling and route queue processing through staged extraction and extracted-photo persistence
- add SHA-first extraction reuse so duplicate-content paths reuse thumbnails, metadata, and face detections instead of re-running analysis
- update repository docs to describe the staged ingest pipeline and queue boundary

## Plan
- committed implementation plan: `docs/superpowers/plans/2026-04-05-issue-126-staged-ingest-analysis.md`

## Validation
- `uv run python -m pytest apps/api/tests/test_ingest_persistence.py -q`
- `uv run python -m pytest apps/api/tests/test_ingest_extraction_worker.py -q`
- `uv run python -m pytest apps/api/tests/test_ingest_polling.py -q`
- `uv run python -m pytest apps/api/tests/test_ingest_queue_processor.py -q`
- `uv run python -m pytest apps/api/tests/test_ingest.py -k "poll_registered_storage_sources or same_hash or face_detection" -q`
- `uv run python -m pytest apps/e2e/tests/test_seed_corpus_workflow.py -q`