### PR TITLE
[codex] Redesign operational activity into live snapshot and history

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,12 @@ Typical usage is expected to be:
 - authorized users confirm or correct face associations
 - users monitor ingestion status and recent issues from the UI
 
-For operator troubleshooting during long imports or background processing, the API also exposes `GET /api/v1/operations/activity`.
-That endpoint is read-only and intended for repeated polling by a UI or CLI.
-It summarizes whether the system is currently idle, actively polling watched folders, actively processing queued ingest work, or surfacing attention signals such as recent failures or stalled queue work.
+For operator troubleshooting during long imports or background processing, the API exposes two operational endpoints:
+
+- `GET /api/v1/operations/activity` for a live snapshot of active polling and ingest work
+- `GET /api/v1/operations/activity/history` for completed and failed operational history
+
+The live endpoint is read-only and intended for repeated polling by a UI or CLI. It shows only work that is currently underway. The history endpoint is separate so completed and failed activity can be reviewed without being conflated with current live state.
 
 ## Current Documentation
 

--- a/apps/api/app/routers/operations.py
+++ b/apps/api/app/routers/operations.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
 from app.services.operational_activity import (
+    InvalidOperationalActivityCursor,
     get_operational_activity,
     get_operational_activity_history,
 )
@@ -164,11 +165,14 @@ def get_operational_activity_history_endpoint(
     queue_cursor: str | None = None,
     db: Session = Depends(get_db),
 ) -> OperationalActivityHistoryResponse:
-    payload = get_operational_activity_history(
-        db.connection(),
-        polling_limit=polling_limit,
-        polling_cursor=polling_cursor,
-        queue_limit=queue_limit,
-        queue_cursor=queue_cursor,
-    )
+    try:
+        payload = get_operational_activity_history(
+            db.connection(),
+            polling_limit=polling_limit,
+            polling_cursor=polling_cursor,
+            queue_limit=queue_limit,
+            queue_cursor=queue_cursor,
+        )
+    except InvalidOperationalActivityCursor as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid {exc}") from exc
     return OperationalActivityHistoryResponse.model_validate(payload)

--- a/apps/api/app/routers/operations.py
+++ b/apps/api/app/routers/operations.py
@@ -7,7 +7,10 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
-from app.services.operational_activity import get_operational_activity
+from app.services.operational_activity import (
+    get_operational_activity,
+    get_operational_activity_history,
+)
 
 
 router = APIRouter(prefix="/operations", tags=["operations"])
@@ -96,6 +99,43 @@ class OperationalActivityLiveResponse(BaseModel):
     ingest_queue: QueueLiveSectionResponse
 
 
+class PollingHistoryItemResponse(BaseModel):
+    ingest_run_id: str
+    watched_folder_id: str
+    display_name: str | None = None
+    event_type: str
+    event_ts: datetime
+    status: str
+    error_summary: str | None = None
+
+
+class QueueHistoryItemResponse(BaseModel):
+    ingest_queue_id: str
+    payload_type: str
+    path: str | None = None
+    event_type: str
+    event_ts: datetime
+    status: str
+    last_error: str | None = None
+
+
+class PagedPollingHistorySectionResponse(BaseModel):
+    items: list[PollingHistoryItemResponse]
+    next_cursor: str | None = None
+    has_more: bool
+
+
+class PagedQueueHistorySectionResponse(BaseModel):
+    items: list[QueueHistoryItemResponse]
+    next_cursor: str | None = None
+    has_more: bool
+
+
+class OperationalActivityHistoryResponse(BaseModel):
+    polling: PagedPollingHistorySectionResponse
+    ingest_queue: PagedQueueHistorySectionResponse
+
+
 @router.get(
     "/activity",
     summary="Get live operational activity",
@@ -110,3 +150,25 @@ def get_operational_activity_endpoint(
 ) -> OperationalActivityLiveResponse:
     payload = get_operational_activity(db.connection())
     return OperationalActivityLiveResponse.model_validate(payload)
+
+
+@router.get(
+    "/activity/history",
+    summary="Get operational activity history",
+    response_model=OperationalActivityHistoryResponse,
+)
+def get_operational_activity_history_endpoint(
+    polling_limit: int = 20,
+    polling_cursor: str | None = None,
+    queue_limit: int = 20,
+    queue_cursor: str | None = None,
+    db: Session = Depends(get_db),
+) -> OperationalActivityHistoryResponse:
+    payload = get_operational_activity_history(
+        db.connection(),
+        polling_limit=polling_limit,
+        polling_cursor=polling_cursor,
+        queue_limit=queue_limit,
+        queue_cursor=queue_cursor,
+    )
+    return OperationalActivityHistoryResponse.model_validate(payload)

--- a/apps/api/app/routers/operations.py
+++ b/apps/api/app/routers/operations.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
@@ -13,90 +13,100 @@ from app.services.operational_activity import get_operational_activity
 router = APIRouter(prefix="/operations", tags=["operations"])
 
 
-class ActiveWatchedFolderResponse(BaseModel):
+class PollingLiveItemResponse(BaseModel):
     model_config = ConfigDict(
-        json_schema_extra={
-            "description": "Watched folder currently associated with an in-progress polling run."
-        }
+        json_schema_extra={"description": "A currently active watched-folder polling run."}
     )
 
+    ingest_run_id: str
     watched_folder_id: str
     storage_source_id: str
     display_name: str | None = None
     scan_path: str
-    started_ts: datetime | None = None
+    started_ts: datetime
+    files_seen: int | None = None
+    estimated_files_total: int | None = None
+    percent_complete: float | None = None
 
 
-class PollingActivityResponse(BaseModel):
+class PollingLiveSummaryResponse(BaseModel):
     model_config = ConfigDict(
-        json_schema_extra={"description": "Current watched-folder polling activity."}
+        json_schema_extra={"description": "Summary of active polling work."}
     )
 
-    active_count: int = Field(description="Number of watched folders with an active polling run.")
-    active_watched_folders: list[ActiveWatchedFolderResponse]
+    active_count: int
+    files_seen: int | None = None
+    estimated_files_total: int | None = None
+    percent_complete: float | None = None
 
 
-class IngestQueueActivityResponse(BaseModel):
+class PollingLiveSectionResponse(BaseModel):
     model_config = ConfigDict(
-        json_schema_extra={"description": "Current queue backlog and processing summary."}
+        json_schema_extra={"description": "Currently active polling work."}
+    )
+
+    items: list[PollingLiveItemResponse]
+    summary: PollingLiveSummaryResponse
+
+
+class QueueLiveItemResponse(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={"description": "A currently active ingest queue item."}
+    )
+
+    ingest_queue_id: str
+    payload_type: str
+    path: str | None = None
+    last_attempt_ts: datetime | None = None
+    is_stalled: bool
+    processed_count: int | None = None
+    estimated_total: int | None = None
+    percent_complete: float | None = None
+
+
+class QueueLiveSummaryResponse(BaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={"description": "Summary of active ingest queue work."}
     )
 
     pending_count: int
     processing_count: int
-    failed_count: int
     stalled_count: int
-    lease_timeout_seconds: int
-    oldest_pending_ts: datetime | None = None
+    processed_count: int | None = None
+    estimated_total: int | None = None
+    percent_complete: float | None = None
 
 
-class ActivitySignalsResponse(BaseModel):
+class QueueLiveSectionResponse(BaseModel):
     model_config = ConfigDict(
-        json_schema_extra={"description": "Operator-facing warning signals derived from current state."}
+        json_schema_extra={"description": "Currently active ingest queue work."}
     )
 
-    recent_failure_count: int
-    stalled_count: int
+    items: list[QueueLiveItemResponse]
+    summary: QueueLiveSummaryResponse
 
 
-class RecentFailureResponse(BaseModel):
+class OperationalActivityLiveResponse(BaseModel):
     model_config = ConfigDict(
-        json_schema_extra={"description": "Recent ingest failure surfaced for operator troubleshooting."}
+        json_schema_extra={"description": "Live operational activity snapshot for active work."}
     )
 
-    kind: str
-    watched_folder_id: str
-    display_name: str | None = None
-    status: str
-    error_summary: str | None = None
-    completed_ts: datetime | None = None
-
-
-class OperationalActivityResponse(BaseModel):
-    model_config = ConfigDict(
-        json_schema_extra={
-            "description": "Read-only operational summary for polling and ingest queue activity."
-        }
-    )
-
-    state: str = Field(description="High-level operator state: idle, polling, processing_queue, or attention_required.")
     observed_at: datetime
-    polling: PollingActivityResponse
-    ingest_queue: IngestQueueActivityResponse
-    signals: ActivitySignalsResponse
-    recent_failures: list[RecentFailureResponse]
+    polling: PollingLiveSectionResponse
+    ingest_queue: QueueLiveSectionResponse
 
 
 @router.get(
     "/activity",
-    summary="Get operational activity",
+    summary="Get live operational activity",
     description=(
-        "Return a read-only summary of current polling activity, queue backlog, and recent failure signals "
-        "so operators can tell whether the system is idle, busy, or needs attention."
+        "Return a read-only snapshot of currently active polling and ingest queue work "
+        "for repeated operator polling."
     ),
-    response_model=OperationalActivityResponse,
+    response_model=OperationalActivityLiveResponse,
 )
 def get_operational_activity_endpoint(
     db: Session = Depends(get_db),
-) -> OperationalActivityResponse:
+) -> OperationalActivityLiveResponse:
     payload = get_operational_activity(db.connection())
-    return OperationalActivityResponse.model_validate(payload)
+    return OperationalActivityLiveResponse.model_validate(payload)

--- a/apps/api/app/services/operational_activity.py
+++ b/apps/api/app/services/operational_activity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import json
 from datetime import UTC, datetime
 from typing import Any
@@ -10,6 +11,10 @@ from sqlalchemy.engine import Connection
 
 from app.db.queue import _processing_lease_cutoff
 from app.storage import ingest_queue, ingest_runs, watched_folders
+
+
+class InvalidOperationalActivityCursor(ValueError):
+    pass
 
 
 def get_operational_activity(
@@ -188,7 +193,7 @@ def _load_polling_history(
         .where(ingest_runs.c.watched_folder_id.is_not(None))
     )
 
-    cursor_values = _decode_cursor(cursor)
+    cursor_values = _decode_cursor(cursor, parameter_name="polling_cursor")
     if cursor_values is not None:
         query = query.where(_polling_history_after_cursor(cursor_values))
 
@@ -238,7 +243,7 @@ def _load_queue_history(
     cursor: str | None,
 ) -> dict[str, Any]:
     normalized_limit = max(1, limit)
-    cursor_values = _decode_cursor(cursor)
+    cursor_values = _decode_cursor(cursor, parameter_name="queue_cursor")
     event_ts = func.coalesce(
         ingest_queue.c.processed_ts,
         ingest_queue.c.last_attempt_ts,
@@ -331,15 +336,22 @@ def _encode_cursor(
     return base64.urlsafe_b64encode(raw).decode("ascii")
 
 
-def _decode_cursor(cursor: str | None) -> dict[str, Any] | None:
+def _decode_cursor(
+    cursor: str | None,
+    *,
+    parameter_name: str,
+) -> dict[str, Any] | None:
     if not cursor:
         return None
-    payload = json.loads(base64.urlsafe_b64decode(cursor.encode("ascii")))
-    return {
-        "completed_ts": _parse_cursor_timestamp(payload.get("completed_ts")),
-        "started_ts": _parse_cursor_timestamp(payload.get("started_ts")),
-        "row_id": str(payload["row_id"]),
-    }
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(cursor.encode("ascii")))
+        return {
+            "completed_ts": _parse_cursor_timestamp(payload.get("completed_ts")),
+            "started_ts": _parse_cursor_timestamp(payload.get("started_ts")),
+            "row_id": str(payload["row_id"]),
+        }
+    except (KeyError, ValueError, TypeError, binascii.Error, json.JSONDecodeError) as exc:
+        raise InvalidOperationalActivityCursor(parameter_name) from exc
 
 
 def _parse_cursor_timestamp(value: str | None) -> datetime | None:

--- a/apps/api/app/services/operational_activity.py
+++ b/apps/api/app/services/operational_activity.py
@@ -67,10 +67,12 @@ def _list_active_polling(connection: Connection) -> list[dict[str, Any]]:
 
 
 def _build_polling_live_summary(items: list[dict[str, Any]]) -> dict[str, Any]:
-    files_seen_values = [item["files_seen"] for item in items if item["files_seen"] is not None]
+    files_seen = None
+    if all(item["files_seen"] is not None for item in items):
+        files_seen = sum(int(item["files_seen"]) for item in items)
     return {
         "active_count": len(items),
-        "files_seen": sum(files_seen_values) if files_seen_values else 0,
+        "files_seen": files_seen,
         "estimated_files_total": None,
         "percent_complete": None,
     }
@@ -114,7 +116,7 @@ def _load_live_ingest_queue(
                 "path": _extract_queue_path(row["payload_json"]),
                 "last_attempt_ts": _iso_utc(last_attempt_ts),
                 "is_stalled": is_stalled,
-                "processed_count": 0,
+                "processed_count": None,
                 "estimated_total": None,
                 "percent_complete": None,
             }
@@ -126,7 +128,7 @@ def _load_live_ingest_queue(
             "pending_count": pending_count,
             "processing_count": processing_count,
             "stalled_count": stalled_count,
-            "processed_count": 0,
+            "processed_count": None,
             "estimated_total": None,
             "percent_complete": None,
         },

--- a/apps/api/app/services/operational_activity.py
+++ b/apps/api/app/services/operational_activity.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import base64
+import json
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.engine import Connection
 
 from app.db.queue import _processing_lease_cutoff
@@ -25,6 +27,30 @@ def get_operational_activity(
             "items": polling_items,
             "summary": _build_polling_live_summary(polling_items),
         },
+        "ingest_queue": queue_section,
+    }
+
+
+def get_operational_activity_history(
+    connection: Connection,
+    *,
+    polling_limit: int,
+    polling_cursor: str | None,
+    queue_limit: int,
+    queue_cursor: str | None,
+) -> dict[str, Any]:
+    polling_section = _load_polling_history(
+        connection,
+        limit=polling_limit,
+        cursor=polling_cursor,
+    )
+    queue_section = _load_queue_history(
+        connection,
+        limit=queue_limit,
+        cursor=queue_cursor,
+    )
+    return {
+        "polling": polling_section,
         "ingest_queue": queue_section,
     }
 
@@ -135,6 +161,144 @@ def _load_live_ingest_queue(
     }
 
 
+def _load_polling_history(
+    connection: Connection,
+    *,
+    limit: int,
+    cursor: str | None,
+) -> dict[str, Any]:
+    normalized_limit = max(1, limit)
+    query = (
+        select(
+            ingest_runs.c.ingest_run_id,
+            ingest_runs.c.watched_folder_id,
+            watched_folders.c.display_name,
+            ingest_runs.c.status,
+            ingest_runs.c.completed_ts,
+            ingest_runs.c.started_ts,
+            ingest_runs.c.error_summary,
+        )
+        .select_from(
+            ingest_runs.join(
+                watched_folders,
+                ingest_runs.c.watched_folder_id == watched_folders.c.watched_folder_id,
+            )
+        )
+        .where(ingest_runs.c.status != "processing")
+        .where(ingest_runs.c.watched_folder_id.is_not(None))
+    )
+
+    cursor_values = _decode_cursor(cursor)
+    if cursor_values is not None:
+        query = query.where(_polling_history_after_cursor(cursor_values))
+
+    rows = list(
+        connection.execute(
+            query.order_by(
+                ingest_runs.c.completed_ts.desc().nullslast(),
+                ingest_runs.c.started_ts.desc(),
+                ingest_runs.c.ingest_run_id.desc(),
+            ).limit(normalized_limit + 1)
+        ).mappings()
+    )
+
+    items = [
+        {
+            "ingest_run_id": str(row["ingest_run_id"]),
+            "watched_folder_id": str(row["watched_folder_id"]),
+            "display_name": row["display_name"],
+            "event_type": _polling_event_type(row["status"]),
+            "event_ts": _iso_utc(row["completed_ts"] or row["started_ts"]),
+            "status": row["status"],
+            "error_summary": row["error_summary"],
+        }
+        for row in rows[:normalized_limit]
+    ]
+    has_more = len(rows) > normalized_limit
+    next_cursor = None
+    if has_more and items:
+        last_row = rows[normalized_limit - 1]
+        next_cursor = _encode_cursor(
+            completed_ts=_normalize_timestamp(last_row["completed_ts"]),
+            started_ts=_normalize_timestamp(last_row["started_ts"]),
+            row_id=str(last_row["ingest_run_id"]),
+        )
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor,
+        "has_more": has_more,
+    }
+
+
+def _load_queue_history(
+    connection: Connection,
+    *,
+    limit: int,
+    cursor: str | None,
+) -> dict[str, Any]:
+    normalized_limit = max(1, limit)
+    cursor_values = _decode_cursor(cursor)
+    event_ts = func.coalesce(
+        ingest_queue.c.processed_ts,
+        ingest_queue.c.last_attempt_ts,
+        ingest_queue.c.enqueued_ts,
+    )
+
+    query = (
+        select(
+            ingest_queue.c.ingest_queue_id,
+            ingest_queue.c.payload_type,
+            ingest_queue.c.payload_json,
+            ingest_queue.c.status,
+            ingest_queue.c.processed_ts,
+            ingest_queue.c.last_attempt_ts,
+            ingest_queue.c.enqueued_ts,
+            ingest_queue.c.last_error,
+            event_ts.label("event_ts"),
+        )
+        .where(ingest_queue.c.status.in_(("completed", "failed")))
+    )
+    if cursor_values is not None:
+        query = query.where(_queue_history_after_cursor(cursor_values, event_ts))
+
+    rows = list(
+        connection.execute(
+            query.order_by(event_ts.desc(), ingest_queue.c.ingest_queue_id.desc()).limit(
+                normalized_limit + 1
+            )
+        ).mappings()
+    )
+
+    items = [
+        {
+            "ingest_queue_id": str(row["ingest_queue_id"]),
+            "payload_type": row["payload_type"],
+            "path": _extract_queue_path(row["payload_json"]),
+            "event_type": _queue_event_type(row["status"]),
+            "event_ts": _iso_utc(row["event_ts"]),
+            "status": row["status"],
+            "last_error": row["last_error"],
+        }
+        for row in rows[:normalized_limit]
+    ]
+    has_more = len(rows) > normalized_limit
+    next_cursor = None
+    if has_more and items:
+        last_row = rows[normalized_limit - 1]
+        next_cursor = _encode_cursor(
+            completed_ts=None,
+            started_ts=_normalize_timestamp(last_row["event_ts"]),
+            row_id=str(last_row["ingest_queue_id"]),
+        )
+
+    return {
+        "items": items,
+        "next_cursor": next_cursor,
+        "has_more": has_more,
+    }
+
+
 def _extract_queue_path(payload_json: Any) -> str | None:
     if not isinstance(payload_json, dict):
         return None
@@ -142,6 +306,92 @@ def _extract_queue_path(payload_json: Any) -> str | None:
     if path is None:
         return None
     return str(path)
+
+
+def _polling_event_type(status: str) -> str:
+    return "poll_completed" if status == "completed" else "poll_failed"
+
+
+def _queue_event_type(status: str) -> str:
+    return "queue_processing_completed" if status == "completed" else "queue_processing_failed"
+
+
+def _encode_cursor(
+    *,
+    completed_ts: datetime | None,
+    started_ts: datetime | None,
+    row_id: str,
+) -> str:
+    payload = {
+        "completed_ts": _iso_utc(completed_ts),
+        "started_ts": _iso_utc(started_ts),
+        "row_id": row_id,
+    }
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def _decode_cursor(cursor: str | None) -> dict[str, Any] | None:
+    if not cursor:
+        return None
+    payload = json.loads(base64.urlsafe_b64decode(cursor.encode("ascii")))
+    return {
+        "completed_ts": _parse_cursor_timestamp(payload.get("completed_ts")),
+        "started_ts": _parse_cursor_timestamp(payload.get("started_ts")),
+        "row_id": str(payload["row_id"]),
+    }
+
+
+def _parse_cursor_timestamp(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return _normalize_timestamp(datetime.fromisoformat(value.replace("Z", "+00:00")))
+
+
+def _polling_history_after_cursor(cursor: dict[str, Any]):
+    cursor_completed_ts = cursor["completed_ts"]
+    cursor_started_ts = cursor["started_ts"]
+    cursor_row_id = cursor["row_id"]
+
+    if cursor_completed_ts is None:
+        return and_(
+            ingest_runs.c.completed_ts.is_(None),
+            or_(
+                ingest_runs.c.started_ts < cursor_started_ts,
+                and_(
+                    ingest_runs.c.started_ts == cursor_started_ts,
+                    ingest_runs.c.ingest_run_id < cursor_row_id,
+                ),
+            ),
+        )
+
+    return or_(
+        ingest_runs.c.completed_ts.is_(None),
+        ingest_runs.c.completed_ts < cursor_completed_ts,
+        and_(
+            ingest_runs.c.completed_ts == cursor_completed_ts,
+            or_(
+                ingest_runs.c.started_ts < cursor_started_ts,
+                and_(
+                    ingest_runs.c.started_ts == cursor_started_ts,
+                    ingest_runs.c.ingest_run_id < cursor_row_id,
+                ),
+            ),
+        ),
+    )
+
+
+def _queue_history_after_cursor(cursor: dict[str, Any], event_ts):
+    cursor_event_ts = cursor["started_ts"]
+    cursor_row_id = cursor["row_id"]
+
+    return or_(
+        event_ts < cursor_event_ts,
+        and_(
+            event_ts == cursor_event_ts,
+            ingest_queue.c.ingest_queue_id < cursor_row_id,
+        ),
+    )
 
 
 def _count_rows(connection: Connection, criterion) -> int:

--- a/apps/api/app/services/operational_activity.py
+++ b/apps/api/app/services/operational_activity.py
@@ -6,7 +6,7 @@ from typing import Any
 from sqlalchemy import func, select
 from sqlalchemy.engine import Connection
 
-from app.db.queue import PROCESSING_LEASE_SECONDS, _processing_lease_cutoff
+from app.db.queue import _processing_lease_cutoff
 from app.storage import ingest_queue, ingest_runs, watched_folders
 
 
@@ -17,39 +17,28 @@ def get_operational_activity(
 ) -> dict[str, Any]:
     observed_at = _normalize_timestamp(now or datetime.now(tz=UTC))
     lease_cutoff = _processing_lease_cutoff(observed_at)
-    active_polling = _list_active_polling(connection)
-    queue_status = _load_ingest_queue_status(connection, lease_cutoff=lease_cutoff)
-    recent_failures = _list_recent_failures(connection)
-    signals = {
-        "recent_failure_count": len(recent_failures),
-        "stalled_count": queue_status["stalled_count"],
-    }
-
+    polling_items = _list_active_polling(connection)
+    queue_section = _load_live_ingest_queue(connection, lease_cutoff=lease_cutoff)
     return {
-        "state": _derive_activity_state(
-            active_polling_count=len(active_polling),
-            processing_queue_count=queue_status["processing_count"],
-            signal_counts=signals,
-        ),
         "observed_at": _iso_utc(observed_at),
         "polling": {
-            "active_count": len(active_polling),
-            "active_watched_folders": active_polling,
+            "items": polling_items,
+            "summary": _build_polling_live_summary(polling_items),
         },
-        "ingest_queue": queue_status,
-        "signals": signals,
-        "recent_failures": recent_failures,
+        "ingest_queue": queue_section,
     }
 
 
 def _list_active_polling(connection: Connection) -> list[dict[str, Any]]:
     rows = connection.execute(
         select(
+            ingest_runs.c.ingest_run_id,
             ingest_runs.c.watched_folder_id,
             watched_folders.c.storage_source_id,
             watched_folders.c.display_name,
             watched_folders.c.scan_path,
             ingest_runs.c.started_ts,
+            ingest_runs.c.files_seen,
         )
         .select_from(
             ingest_runs.join(
@@ -63,103 +52,100 @@ def _list_active_polling(connection: Connection) -> list[dict[str, Any]]:
     ).mappings()
     return [
         {
+            "ingest_run_id": str(row["ingest_run_id"]),
             "watched_folder_id": str(row["watched_folder_id"]),
             "storage_source_id": str(row["storage_source_id"]),
             "display_name": row["display_name"],
             "scan_path": str(row["scan_path"]),
             "started_ts": _iso_utc(row["started_ts"]),
+            "files_seen": row["files_seen"],
+            "estimated_files_total": None,
+            "percent_complete": None,
         }
         for row in rows
     ]
 
 
-def _load_ingest_queue_status(
+def _build_polling_live_summary(items: list[dict[str, Any]]) -> dict[str, Any]:
+    files_seen_values = [item["files_seen"] for item in items if item["files_seen"] is not None]
+    return {
+        "active_count": len(items),
+        "files_seen": sum(files_seen_values) if files_seen_values else 0,
+        "estimated_files_total": None,
+        "percent_complete": None,
+    }
+
+
+def _load_live_ingest_queue(
     connection: Connection,
     *,
     lease_cutoff: datetime,
 ) -> dict[str, Any]:
     pending_count = _count_rows(connection, ingest_queue.c.status == "pending")
-    processing_count = _count_rows(
-        connection,
-        (ingest_queue.c.status == "processing")
-        & ingest_queue.c.last_attempt_ts.is_not(None)
-        & (ingest_queue.c.last_attempt_ts > lease_cutoff),
-    )
-    stalled_count = _count_rows(
-        connection,
-        (ingest_queue.c.status == "processing")
-        & (
-            ingest_queue.c.last_attempt_ts.is_(None)
-            | (ingest_queue.c.last_attempt_ts <= lease_cutoff)
-        ),
-    )
-    failed_count = _count_rows(connection, ingest_queue.c.status == "failed")
-    oldest_pending_ts = connection.execute(
-        select(func.min(ingest_queue.c.enqueued_ts)).where(ingest_queue.c.status == "pending")
-    ).scalar_one()
+    rows = connection.execute(
+        select(
+            ingest_queue.c.ingest_queue_id,
+            ingest_queue.c.payload_type,
+            ingest_queue.c.payload_json,
+            ingest_queue.c.last_attempt_ts,
+        )
+        .where(ingest_queue.c.status == "processing")
+        .order_by(
+            ingest_queue.c.last_attempt_ts.desc().nullslast(),
+            ingest_queue.c.enqueued_ts,
+            ingest_queue.c.ingest_queue_id,
+        )
+    ).mappings()
+
+    items = []
+    processing_count = 0
+    stalled_count = 0
+    for row in rows:
+        last_attempt_ts = _normalize_timestamp(row["last_attempt_ts"])
+        is_stalled = last_attempt_ts is None or last_attempt_ts <= lease_cutoff
+        if is_stalled:
+            stalled_count += 1
+        else:
+            processing_count += 1
+        items.append(
+            {
+                "ingest_queue_id": str(row["ingest_queue_id"]),
+                "payload_type": row["payload_type"],
+                "path": _extract_queue_path(row["payload_json"]),
+                "last_attempt_ts": _iso_utc(last_attempt_ts),
+                "is_stalled": is_stalled,
+                "processed_count": 0,
+                "estimated_total": None,
+                "percent_complete": None,
+            }
+        )
+
     return {
-        "pending_count": pending_count,
-        "processing_count": processing_count,
-        "failed_count": failed_count,
-        "stalled_count": stalled_count,
-        "lease_timeout_seconds": PROCESSING_LEASE_SECONDS,
-        "oldest_pending_ts": _iso_utc(oldest_pending_ts),
+        "items": items,
+        "summary": {
+            "pending_count": pending_count,
+            "processing_count": processing_count,
+            "stalled_count": stalled_count,
+            "processed_count": 0,
+            "estimated_total": None,
+            "percent_complete": None,
+        },
     }
 
 
+def _extract_queue_path(payload_json: Any) -> str | None:
+    if not isinstance(payload_json, dict):
+        return None
+    path = payload_json.get("path")
+    if path is None:
+        return None
+    return str(path)
+
+
 def _count_rows(connection: Connection, criterion) -> int:
-    return int(connection.execute(select(func.count()).select_from(ingest_queue).where(criterion)).scalar_one())
-
-
-def _list_recent_failures(connection: Connection) -> list[dict[str, Any]]:
-    rows = connection.execute(
-        select(
-            ingest_runs.c.watched_folder_id,
-            watched_folders.c.display_name,
-            ingest_runs.c.status,
-            ingest_runs.c.error_summary,
-            ingest_runs.c.completed_ts,
-        )
-        .select_from(
-            ingest_runs.join(
-                watched_folders,
-                ingest_runs.c.watched_folder_id == watched_folders.c.watched_folder_id,
-            )
-        )
-        .where(ingest_runs.c.error_count > 0)
-        .order_by(
-            ingest_runs.c.completed_ts.desc().nullslast(),
-            ingest_runs.c.started_ts.desc(),
-            ingest_runs.c.ingest_run_id.desc(),
-        )
-        .limit(5)
-    ).mappings()
-    return [
-        {
-            "kind": "watched_folder_ingest",
-            "watched_folder_id": str(row["watched_folder_id"]),
-            "display_name": row["display_name"],
-            "status": str(row["status"]),
-            "error_summary": row["error_summary"],
-            "completed_ts": _iso_utc(row["completed_ts"]),
-        }
-        for row in rows
-    ]
-
-
-def _derive_activity_state(
-    *,
-    active_polling_count: int,
-    processing_queue_count: int,
-    signal_counts: dict[str, int],
-) -> str:
-    if active_polling_count > 0:
-        return "polling"
-    if processing_queue_count > 0:
-        return "processing_queue"
-    if signal_counts["recent_failure_count"] > 0 or signal_counts["stalled_count"] > 0:
-        return "attention_required"
-    return "idle"
+    return int(
+        connection.execute(select(func.count()).select_from(ingest_queue).where(criterion)).scalar_one()
+    )
 
 
 def _normalize_timestamp(value: datetime | None) -> datetime | None:

--- a/apps/api/tests/test_main.py
+++ b/apps/api/tests/test_main.py
@@ -77,6 +77,7 @@ class TestHealthEndpoint:
             "responses"
         ]["400"]["description"] == "Watched folder validation failed"
         assert "/api/v1/operations/activity" in schema["paths"]
+        assert "/api/v1/operations/activity/history" in schema["paths"]
         assert any(tag["name"] == "operations" for tag in schema["tags"])
         watched_folder_mutation_responses = schema["paths"][
             "/api/v1/storage-sources/{storage_source_id}/watched-folders/{watched_folder_id}"
@@ -90,7 +91,14 @@ class TestHealthEndpoint:
         assert schema["paths"]["/api/v1/internal/ingest-queue/process"]["post"]["responses"]["403"][
             "description"
         ] == "Worker role required"
-        assert schema["paths"]["/api/v1/operations/activity"]["get"]["summary"] == "Get operational activity"
+        assert (
+            schema["paths"]["/api/v1/operations/activity"]["get"]["summary"]
+            == "Get live operational activity"
+        )
+        assert (
+            schema["paths"]["/api/v1/operations/activity/history"]["get"]["summary"]
+            == "Get operational activity history"
+        )
         assert (
             schema["components"]["schemas"]["RegisterStorageSourceRequest"]["properties"]["root_path"][
                 "description"

--- a/apps/api/tests/test_operational_activity_api.py
+++ b/apps/api/tests/test_operational_activity_api.py
@@ -212,6 +212,43 @@ def test_operational_activity_api_reports_active_queue_processing(tmp_path, monk
     assert payload["ingest_queue"]["items"][0]["is_stalled"] is False
 
 
+def test_operational_activity_api_keeps_unresolved_stalled_queue_work_visible(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'operational-activity-stalled.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    now = datetime.now(tz=UTC)
+    stale_attempt_ts = now - timedelta(seconds=PROCESSING_LEASE_SECONDS + 60)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(ingest_queue).values(
+                ingest_queue_id="queue-stalled",
+                payload_type="photo_metadata",
+                payload_json={"path": "queued/stalled.jpg"},
+                idempotency_key="stalled.jpg",
+                status="processing",
+                attempt_count=2,
+                enqueued_ts=now - timedelta(minutes=8),
+                last_attempt_ts=stale_attempt_ts,
+                processed_ts=None,
+                last_error="temporary timeout",
+            )
+        )
+
+    client = TestClient(app)
+
+    response = client.get("/api/v1/operations/activity")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["polling"]["items"] == []
+    assert payload["ingest_queue"]["summary"]["stalled_count"] == 1
+    assert payload["ingest_queue"]["items"][0]["ingest_queue_id"] == "queue-stalled"
+    assert payload["ingest_queue"]["items"][0]["is_stalled"] is True
+
+
 def _seed_source_with_watched_folder(*, tmp_path, monkeypatch, database_name: str, database_url: str):
     from app.services.storage_sources import attach_storage_source_alias, create_storage_source
     from app.services.watched_folders import create_watched_folder

--- a/apps/api/tests/test_operational_activity_api.py
+++ b/apps/api/tests/test_operational_activity_api.py
@@ -12,7 +12,7 @@ from app.migrations import upgrade_database
 from app.storage import ingest_queue, ingest_runs
 
 
-def test_operational_activity_api_reports_idle_when_no_current_work(tmp_path, monkeypatch):
+def test_operational_activity_api_returns_empty_sections_when_no_current_work(tmp_path, monkeypatch):
     database_url = f"sqlite:///{tmp_path / 'operational-activity-idle.db'}"
     upgrade_database(database_url)
     monkeypatch.setenv("DATABASE_URL", database_url)
@@ -24,16 +24,17 @@ def test_operational_activity_api_reports_idle_when_no_current_work(tmp_path, mo
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["state"] == "idle"
-    assert payload["polling"]["active_count"] == 0
-    assert payload["ingest_queue"]["pending_count"] == 0
-    assert payload["ingest_queue"]["processing_count"] == 0
-    assert payload["signals"]["recent_failure_count"] == 0
-    assert payload["signals"]["stalled_count"] == 0
-    assert payload["recent_failures"] == []
+    assert set(payload.keys()) == {"observed_at", "polling", "ingest_queue"}
+    assert payload["polling"]["items"] == []
+    assert payload["polling"]["summary"]["active_count"] == 0
+    assert payload["ingest_queue"]["items"] == []
+    assert payload["ingest_queue"]["summary"]["processing_count"] == 0
+    assert "state" not in payload
+    assert "signals" not in payload
+    assert "recent_failures" not in payload
 
 
-def test_operational_activity_api_reports_active_polling(tmp_path, monkeypatch):
+def test_operational_activity_api_returns_only_active_polling_work(tmp_path, monkeypatch):
     database_url = f"sqlite:///{tmp_path / 'operational-activity-polling.db'}"
     source, watched_folder = _seed_source_with_watched_folder(
         tmp_path=tmp_path,
@@ -67,10 +68,12 @@ def test_operational_activity_api_reports_active_polling(tmp_path, monkeypatch):
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["state"] == "polling"
-    assert payload["polling"]["active_count"] == 1
-    assert payload["polling"]["active_watched_folders"] == [
+    assert payload["polling"]["summary"]["active_count"] == 1
+    assert payload["polling"]["items"][0]["ingest_run_id"] == "run-polling"
+    assert payload["ingest_queue"]["items"] == []
+    assert payload["polling"]["items"] == [
         {
+            "ingest_run_id": "run-polling",
             "watched_folder_id": watched_folder["watched_folder_id"],
             "storage_source_id": source["storage_source_id"],
             "display_name": "Trips",
@@ -78,7 +81,89 @@ def test_operational_activity_api_reports_active_polling(tmp_path, monkeypatch):
             "started_ts": "2026-04-04T15:30:00Z",
         }
     ]
-    assert payload["ingest_queue"]["processing_count"] == 0
+
+
+def test_operational_activity_api_excludes_completed_and_failed_work_from_live_snapshot(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'operational-activity-history-only.db'}"
+    _, watched_folder = _seed_source_with_watched_folder(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        database_name="operational-activity-history-only.db",
+        database_url=database_url,
+    )
+    now = datetime.now(tz=UTC)
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(ingest_runs).values(
+                ingest_run_id="run-completed",
+                watched_folder_id=watched_folder["watched_folder_id"],
+                status="completed",
+                started_ts=now - timedelta(minutes=3),
+                completed_ts=now - timedelta(minutes=2),
+                files_seen=12,
+                files_created=4,
+                files_updated=1,
+                files_missing=0,
+                error_count=0,
+                error_summary=None,
+            )
+        )
+        connection.execute(
+            insert(ingest_runs).values(
+                ingest_run_id="run-failed",
+                watched_folder_id=watched_folder["watched_folder_id"],
+                status="failed",
+                started_ts=now - timedelta(minutes=2),
+                completed_ts=now - timedelta(minutes=1),
+                files_seen=8,
+                files_created=2,
+                files_updated=0,
+                files_missing=1,
+                error_count=1,
+                error_summary="marker mismatch on alias //nas/family-share",
+            )
+        )
+        connection.execute(
+            insert(ingest_queue).values(
+                ingest_queue_id="queue-completed",
+                payload_type="photo_metadata",
+                payload_json={"path": "queued/completed.jpg"},
+                idempotency_key="completed.jpg",
+                status="completed",
+                attempt_count=1,
+                enqueued_ts=now - timedelta(minutes=10),
+                last_attempt_ts=now - timedelta(minutes=5),
+                processed_ts=now - timedelta(minutes=4),
+                last_error=None,
+            )
+        )
+        connection.execute(
+            insert(ingest_queue).values(
+                ingest_queue_id="queue-failed",
+                payload_type="photo_metadata",
+                payload_json={"path": "queued/failed.jpg"},
+                idempotency_key="failed.jpg",
+                status="failed",
+                attempt_count=2,
+                enqueued_ts=now - timedelta(minutes=9),
+                last_attempt_ts=now - timedelta(minutes=3),
+                processed_ts=None,
+                last_error="temporary timeout",
+            )
+        )
+
+    client = TestClient(app)
+
+    response = client.get("/api/v1/operations/activity")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["polling"]["items"] == []
+    assert payload["ingest_queue"]["items"] == []
 
 
 def test_operational_activity_api_reports_active_queue_processing(tmp_path, monkeypatch):

--- a/apps/api/tests/test_operational_activity_api.py
+++ b/apps/api/tests/test_operational_activity_api.py
@@ -71,16 +71,6 @@ def test_operational_activity_api_returns_only_active_polling_work(tmp_path, mon
     assert payload["polling"]["summary"]["active_count"] == 1
     assert payload["polling"]["items"][0]["ingest_run_id"] == "run-polling"
     assert payload["ingest_queue"]["items"] == []
-    assert payload["polling"]["items"] == [
-        {
-            "ingest_run_id": "run-polling",
-            "watched_folder_id": watched_folder["watched_folder_id"],
-            "storage_source_id": source["storage_source_id"],
-            "display_name": "Trips",
-            "scan_path": str(tmp_path / "family-share" / "2024" / "trips"),
-            "started_ts": "2026-04-04T15:30:00Z",
-        }
-    ]
 
 
 def test_operational_activity_api_excludes_completed_and_failed_work_from_live_snapshot(

--- a/apps/api/tests/test_operational_activity_api.py
+++ b/apps/api/tests/test_operational_activity_api.py
@@ -261,6 +261,153 @@ def test_operational_activity_api_keeps_unresolved_stalled_queue_work_visible(tm
     assert payload["ingest_queue"]["items"][0]["is_stalled"] is True
 
 
+def test_operational_activity_history_returns_completed_and_failed_polling_entries_newest_first(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'operational-activity-history-ordering.db'}"
+    _, watched_folder = _seed_source_with_watched_folder(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        database_name="operational-activity-history-ordering.db",
+        database_url=database_url,
+    )
+    now = datetime(2026, 4, 4, 17, 0, tzinfo=UTC)
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(ingest_runs).values(
+                ingest_run_id="run-history-failed",
+                watched_folder_id=watched_folder["watched_folder_id"],
+                status="failed",
+                started_ts=now - timedelta(minutes=10),
+                completed_ts=now - timedelta(minutes=9),
+                files_seen=12,
+                files_created=4,
+                files_updated=0,
+                files_missing=1,
+                error_count=1,
+                error_summary="marker mismatch on alias //nas/family-share",
+            )
+        )
+        connection.execute(
+            insert(ingest_runs).values(
+                ingest_run_id="run-history-completed",
+                watched_folder_id=watched_folder["watched_folder_id"],
+                status="completed",
+                started_ts=now - timedelta(minutes=5),
+                completed_ts=now - timedelta(minutes=4),
+                files_seen=14,
+                files_created=5,
+                files_updated=1,
+                files_missing=0,
+                error_count=0,
+                error_summary=None,
+            )
+        )
+
+    client = TestClient(app)
+
+    response = client.get("/api/v1/operations/activity/history")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["polling"]["items"][0]["event_type"] == "poll_completed"
+    assert payload["polling"]["items"][1]["event_type"] == "poll_failed"
+    assert payload["polling"]["items"][0]["watched_folder_id"] == watched_folder["watched_folder_id"]
+    assert payload["polling"]["has_more"] is False
+
+
+def test_operational_activity_history_keeps_polling_and_queue_pagination_separate(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'operational-activity-history-pagination.db'}"
+    _, watched_folder = _seed_source_with_watched_folder(
+        tmp_path=tmp_path,
+        monkeypatch=monkeypatch,
+        database_name="operational-activity-history-pagination.db",
+        database_url=database_url,
+    )
+    now = datetime(2026, 4, 4, 18, 0, tzinfo=UTC)
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(ingest_runs),
+            [
+                {
+                    "ingest_run_id": "run-history-1",
+                    "watched_folder_id": watched_folder["watched_folder_id"],
+                    "status": "completed",
+                    "started_ts": now - timedelta(minutes=6),
+                    "completed_ts": now - timedelta(minutes=5),
+                    "files_seen": 10,
+                    "files_created": 4,
+                    "files_updated": 0,
+                    "files_missing": 0,
+                    "error_count": 0,
+                    "error_summary": None,
+                },
+                {
+                    "ingest_run_id": "run-history-2",
+                    "watched_folder_id": watched_folder["watched_folder_id"],
+                    "status": "failed",
+                    "started_ts": now - timedelta(minutes=4),
+                    "completed_ts": now - timedelta(minutes=3),
+                    "files_seen": 9,
+                    "files_created": 3,
+                    "files_updated": 1,
+                    "files_missing": 1,
+                    "error_count": 1,
+                    "error_summary": "transient marker read failure",
+                },
+            ],
+        )
+        connection.execute(
+            insert(ingest_queue),
+            [
+                {
+                    "ingest_queue_id": "queue-history-1",
+                    "payload_type": "photo_metadata",
+                    "payload_json": {"path": "queued/history-1.jpg"},
+                    "idempotency_key": "history-1.jpg",
+                    "status": "completed",
+                    "attempt_count": 1,
+                    "enqueued_ts": now - timedelta(minutes=9),
+                    "last_attempt_ts": now - timedelta(minutes=8),
+                    "processed_ts": now - timedelta(minutes=7),
+                    "last_error": None,
+                },
+                {
+                    "ingest_queue_id": "queue-history-2",
+                    "payload_type": "photo_metadata",
+                    "payload_json": {"path": "queued/history-2.jpg"},
+                    "idempotency_key": "history-2.jpg",
+                    "status": "failed",
+                    "attempt_count": 2,
+                    "enqueued_ts": now - timedelta(minutes=5),
+                    "last_attempt_ts": now - timedelta(minutes=4),
+                    "processed_ts": None,
+                    "last_error": "temporary timeout",
+                },
+            ],
+        )
+
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/operations/activity/history",
+        params={"polling_limit": 1, "queue_limit": 1},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["polling"]["items"]) == 1
+    assert len(payload["ingest_queue"]["items"]) == 1
+    assert payload["polling"]["next_cursor"] is not None
+    assert payload["ingest_queue"]["next_cursor"] is not None
+
+
 def _seed_source_with_watched_folder(*, tmp_path, monkeypatch, database_name: str, database_url: str):
     from app.services.storage_sources import attach_storage_source_alias, create_storage_source
     from app.services.watched_folders import create_watched_folder

--- a/apps/api/tests/test_operational_activity_api.py
+++ b/apps/api/tests/test_operational_activity_api.py
@@ -156,7 +156,7 @@ def test_operational_activity_api_excludes_completed_and_failed_work_from_live_s
     assert payload["ingest_queue"]["items"] == []
 
 
-def test_operational_activity_api_reports_active_queue_processing(tmp_path, monkeypatch):
+def test_operational_activity_api_returns_active_queue_work_with_summary(tmp_path, monkeypatch):
     database_url = f"sqlite:///{tmp_path / 'operational-activity-queue.db'}"
     upgrade_database(database_url)
     monkeypatch.setenv("DATABASE_URL", database_url)
@@ -206,10 +206,17 @@ def test_operational_activity_api_reports_active_queue_processing(tmp_path, monk
     assert payload["ingest_queue"]["summary"]["pending_count"] == 1
     assert payload["ingest_queue"]["summary"]["processing_count"] == 1
     assert payload["ingest_queue"]["summary"]["stalled_count"] == 0
+    assert payload["ingest_queue"]["summary"]["processed_count"] == 0
+    assert payload["ingest_queue"]["summary"]["estimated_total"] is None
+    assert payload["ingest_queue"]["summary"]["percent_complete"] is None
     assert payload["ingest_queue"]["items"][0]["ingest_queue_id"] == "queue-processing"
     assert payload["ingest_queue"]["items"][0]["payload_type"] == "photo_metadata"
     assert payload["ingest_queue"]["items"][0]["path"] == "queued/active.jpg"
+    assert payload["ingest_queue"]["items"][0]["last_attempt_ts"] is not None
     assert payload["ingest_queue"]["items"][0]["is_stalled"] is False
+    assert payload["ingest_queue"]["items"][0]["processed_count"] == 0
+    assert payload["ingest_queue"]["items"][0]["estimated_total"] is None
+    assert payload["ingest_queue"]["items"][0]["percent_complete"] is None
 
 
 def test_operational_activity_api_keeps_unresolved_stalled_queue_work_visible(tmp_path, monkeypatch):
@@ -244,7 +251,12 @@ def test_operational_activity_api_keeps_unresolved_stalled_queue_work_visible(tm
     assert response.status_code == 200
     payload = response.json()
     assert payload["polling"]["items"] == []
+    assert payload["ingest_queue"]["summary"]["pending_count"] == 0
+    assert payload["ingest_queue"]["summary"]["processing_count"] == 0
     assert payload["ingest_queue"]["summary"]["stalled_count"] == 1
+    assert payload["ingest_queue"]["summary"]["processed_count"] == 0
+    assert payload["ingest_queue"]["summary"]["estimated_total"] is None
+    assert payload["ingest_queue"]["summary"]["percent_complete"] is None
     assert payload["ingest_queue"]["items"][0]["ingest_queue_id"] == "queue-stalled"
     assert payload["ingest_queue"]["items"][0]["is_stalled"] is True
 

--- a/apps/api/tests/test_operational_activity_api.py
+++ b/apps/api/tests/test_operational_activity_api.py
@@ -206,7 +206,7 @@ def test_operational_activity_api_returns_active_queue_work_with_summary(tmp_pat
     assert payload["ingest_queue"]["summary"]["pending_count"] == 1
     assert payload["ingest_queue"]["summary"]["processing_count"] == 1
     assert payload["ingest_queue"]["summary"]["stalled_count"] == 0
-    assert payload["ingest_queue"]["summary"]["processed_count"] == 0
+    assert payload["ingest_queue"]["summary"]["processed_count"] is None
     assert payload["ingest_queue"]["summary"]["estimated_total"] is None
     assert payload["ingest_queue"]["summary"]["percent_complete"] is None
     assert payload["ingest_queue"]["items"][0]["ingest_queue_id"] == "queue-processing"
@@ -214,7 +214,7 @@ def test_operational_activity_api_returns_active_queue_work_with_summary(tmp_pat
     assert payload["ingest_queue"]["items"][0]["path"] == "queued/active.jpg"
     assert payload["ingest_queue"]["items"][0]["last_attempt_ts"] is not None
     assert payload["ingest_queue"]["items"][0]["is_stalled"] is False
-    assert payload["ingest_queue"]["items"][0]["processed_count"] == 0
+    assert payload["ingest_queue"]["items"][0]["processed_count"] is None
     assert payload["ingest_queue"]["items"][0]["estimated_total"] is None
     assert payload["ingest_queue"]["items"][0]["percent_complete"] is None
 
@@ -254,7 +254,7 @@ def test_operational_activity_api_keeps_unresolved_stalled_queue_work_visible(tm
     assert payload["ingest_queue"]["summary"]["pending_count"] == 0
     assert payload["ingest_queue"]["summary"]["processing_count"] == 0
     assert payload["ingest_queue"]["summary"]["stalled_count"] == 1
-    assert payload["ingest_queue"]["summary"]["processed_count"] == 0
+    assert payload["ingest_queue"]["summary"]["processed_count"] is None
     assert payload["ingest_queue"]["summary"]["estimated_total"] is None
     assert payload["ingest_queue"]["summary"]["percent_complete"] is None
     assert payload["ingest_queue"]["items"][0]["ingest_queue_id"] == "queue-stalled"

--- a/apps/api/tests/test_operational_activity_api.py
+++ b/apps/api/tests/test_operational_activity_api.py
@@ -210,75 +210,16 @@ def test_operational_activity_api_reports_active_queue_processing(tmp_path, monk
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["state"] == "processing_queue"
-    assert payload["polling"]["active_count"] == 0
-    assert payload["ingest_queue"]["pending_count"] == 1
-    assert payload["ingest_queue"]["processing_count"] == 1
-    assert payload["ingest_queue"]["failed_count"] == 0
-    assert payload["ingest_queue"]["stalled_count"] == 0
-    assert payload["ingest_queue"]["oldest_pending_ts"] == (
-        now - timedelta(minutes=5)
-    ).isoformat().replace("+00:00", "Z")
-
-
-def test_operational_activity_api_reports_attention_required_for_failed_or_stalled_work(
-    tmp_path, monkeypatch
-):
-    database_url = f"sqlite:///{tmp_path / 'operational-activity-attention.db'}"
-    _, watched_folder = _seed_source_with_watched_folder(
-        tmp_path=tmp_path,
-        monkeypatch=monkeypatch,
-        database_name="operational-activity-attention.db",
-        database_url=database_url,
-    )
-    now = datetime.now(tz=UTC)
-    stale_attempt_ts = now - timedelta(seconds=PROCESSING_LEASE_SECONDS + 60)
-
-    engine = create_engine(database_url, future=True)
-    with engine.begin() as connection:
-        connection.execute(
-            insert(ingest_runs).values(
-                ingest_run_id="run-failed",
-                watched_folder_id=watched_folder["watched_folder_id"],
-                status="failed",
-                started_ts=now - timedelta(minutes=2),
-                completed_ts=now - timedelta(minutes=1),
-                files_seen=12,
-                files_created=2,
-                files_updated=1,
-                files_missing=0,
-                error_count=1,
-                error_summary="marker mismatch on alias //nas/family-share",
-            )
-        )
-        connection.execute(
-            insert(ingest_queue).values(
-                ingest_queue_id="queue-stalled",
-                payload_type="photo_metadata",
-                payload_json={"path": "queued/stalled.jpg"},
-                idempotency_key="stalled.jpg",
-                status="processing",
-                attempt_count=2,
-                enqueued_ts=now - timedelta(minutes=8),
-                last_attempt_ts=stale_attempt_ts,
-                processed_ts=None,
-                last_error="temporary timeout",
-            )
-        )
-
-    client = TestClient(app)
-
-    response = client.get("/api/v1/operations/activity")
-
-    assert response.status_code == 200
-    payload = response.json()
-    assert payload["state"] == "attention_required"
-    assert payload["signals"]["recent_failure_count"] == 1
-    assert payload["signals"]["stalled_count"] == 1
-    assert payload["ingest_queue"]["stalled_count"] == 1
-    assert payload["recent_failures"][0]["kind"] == "watched_folder_ingest"
-    assert payload["recent_failures"][0]["watched_folder_id"] == watched_folder["watched_folder_id"]
-    assert payload["recent_failures"][0]["error_summary"] == "marker mismatch on alias //nas/family-share"
+    assert set(payload.keys()) == {"observed_at", "polling", "ingest_queue"}
+    assert payload["polling"]["items"] == []
+    assert payload["polling"]["summary"]["active_count"] == 0
+    assert payload["ingest_queue"]["summary"]["pending_count"] == 1
+    assert payload["ingest_queue"]["summary"]["processing_count"] == 1
+    assert payload["ingest_queue"]["summary"]["stalled_count"] == 0
+    assert payload["ingest_queue"]["items"][0]["ingest_queue_id"] == "queue-processing"
+    assert payload["ingest_queue"]["items"][0]["payload_type"] == "photo_metadata"
+    assert payload["ingest_queue"]["items"][0]["path"] == "queued/active.jpg"
+    assert payload["ingest_queue"]["items"][0]["is_stalled"] is False
 
 
 def _seed_source_with_watched_folder(*, tmp_path, monkeypatch, database_name: str, database_url: str):

--- a/apps/api/tests/test_operational_activity_api.py
+++ b/apps/api/tests/test_operational_activity_api.py
@@ -408,6 +408,25 @@ def test_operational_activity_history_keeps_polling_and_queue_pagination_separat
     assert payload["ingest_queue"]["next_cursor"] is not None
 
 
+def test_operational_activity_history_rejects_malformed_cursor_with_client_error(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'operational-activity-history-bad-cursor.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    client = TestClient(app)
+
+    response = client.get(
+        "/api/v1/operations/activity/history",
+        params={"polling_cursor": "not-a-valid-cursor"},
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Invalid polling_cursor"}
+
+
 def _seed_source_with_watched_folder(*, tmp_path, monkeypatch, database_name: str, database_url: str):
     from app.services.storage_sources import attach_storage_source_alias, create_storage_source
     from app.services.watched_folders import create_watched_folder

--- a/docs/superpowers/specs/2026-04-05-issue-127-operational-activity-live-snapshot-design.md
+++ b/docs/superpowers/specs/2026-04-05-issue-127-operational-activity-live-snapshot-design.md
@@ -1,0 +1,268 @@
+# Issue 127 Operational Activity Live Snapshot Design
+
+Date: 2026-04-05
+Issue: #127
+
+## Summary
+
+Redesign operational activity around two distinct operator needs:
+
+- `GET /api/v1/operations/activity` shows only activity that is currently underway
+- `GET /api/v1/operations/activity/history` shows completed and failed activity for troubleshooting
+
+The live endpoint should answer "what is happening right now?" without mixing in old failures or recovered work. The history endpoint should answer "what happened earlier?" without pretending to be current health.
+
+## Goals
+
+- make the primary activity endpoint a live, poll-friendly snapshot of current work
+- separate active work from historical completed and failed work
+- split both live and history views into distinct `polling` and `ingest_queue` sections
+- expose progress estimates for active work when the backend can support them honestly
+- remove the sticky derived global state model from the live endpoint
+- preserve enough structured history for operators to understand failure-then-recovery sequences
+
+## Non-Goals
+
+- no per-file event stream in this issue
+- no global top-level health state such as `idle` or `attention_required`
+- no analytics-oriented aggregation beyond simple live progress summaries
+- no UI implementation in this issue
+
+## Current Problem
+
+`GET /api/v1/operations/activity` currently returns a derived summary with top-level states such as `idle`, `polling`, `processing_queue`, and `attention_required`.
+
+That model conflates live work and recent history. A watched-folder poll can fail and later recover, but the endpoint may remain in `attention_required` because an older failure is still present in recent history. This makes the endpoint less trustworthy for operators who are trying to determine whether work is currently active and how far along it is.
+
+The current shape also focuses on coarse state labels rather than the underlying active work. It does not give operators a clear view of which poll or ingest work is underway or what progress has been made so far.
+
+## Recommended Approach
+
+Replace the current summary-only model with two complementary endpoints:
+
+- `GET /api/v1/operations/activity`
+  - live snapshot of only active work
+  - no historical failures or completed work
+- `GET /api/v1/operations/activity/history`
+  - paged history of completed and failed work
+  - intended for troubleshooting, review, and recovery interpretation
+
+Both endpoints remain split into two top-level sections:
+
+- `polling`
+- `ingest_queue`
+
+This keeps operator concerns separate:
+
+- live endpoint: current activity and progress
+- history endpoint: completed and failed outcomes over time
+
+## Alternatives Considered
+
+### Single Paged Mixed Journal
+
+Return one newest-first journal interleaving polling and queue events in a single stream.
+
+Rejected because the user wants separate sections, and because a journal-first surface does not directly satisfy the primary operator need of seeing current work and progress at a glance.
+
+### Keep One Endpoint But Mix Live and History
+
+Keep `/operations/activity` as a combined response with active items plus recent completed and failed entries.
+
+Rejected because it recreates the ambiguity that caused the current derived summary to become misleading. Active state and history serve different operator questions and should not share one overloaded payload.
+
+### Per-File Activity Entries
+
+Surface one journal item per file-level ingest action.
+
+Rejected because it would create high-volume noise, obscure the operator view of current progress, and turn the endpoint into an audit feed rather than an operational surface.
+
+## Live Endpoint Design
+
+### Intent
+
+The live endpoint exists to show only currently undergoing work. If nothing is active, nothing should be shown beyond an empty response structure.
+
+It should not describe recovered failures, recent successes, or historical troubleshooting context.
+
+### Response Shape
+
+`GET /api/v1/operations/activity` returns a snapshot with these top-level sections:
+
+- `polling`
+- `ingest_queue`
+
+Each section contains:
+
+- `items`: active work entries
+- `summary`: aggregate counts and optional progress estimates
+
+No top-level `state`, `signals`, or `recent_failures` fields remain.
+
+### Polling Section
+
+The `polling` section contains active watched-folder polling runs only.
+
+Each item should identify:
+
+- `ingest_run_id`
+- `watched_folder_id`
+- `storage_source_id`
+- `display_name`
+- `scan_path`
+- `started_ts`
+- optional progress fields when available
+
+The section `summary` should include the active run count and aggregate progress fields when those values can be calculated honestly.
+
+### Ingest Queue Section
+
+The `ingest_queue` section contains active ingest queue work only.
+
+Each item should identify:
+
+- `ingest_queue_id`
+- `payload_type`
+- lightweight object context such as path when already present on the queue row
+- `last_attempt_ts`
+- optional progress fields when available
+
+The section `summary` should include:
+
+- `pending_count`
+- `processing_count`
+- optional progress estimate fields
+
+Stalled queue work is still active operator-relevant work and should appear in the live endpoint while it remains unresolved.
+
+### Progress Semantics
+
+Progress must be treated as an estimate, not a promise.
+
+The endpoint should expose progress only where the backend has a defensible basis for it. Otherwise the relevant progress fields should be `null` or absent.
+
+Examples of progress fields that may be supported:
+
+- `files_seen`
+- `estimated_files_total`
+- `processed_count`
+- `estimated_total`
+- `percent_complete`
+
+The first implementation does not need to invent new persistence solely to support precise percentages. It may start with partial estimates if they are clearly grounded in existing runtime or persisted data.
+
+## History Endpoint Design
+
+### Intent
+
+The history endpoint exists to show completed and failed operational activity after the fact. It is for troubleshooting and review, not live status polling.
+
+### Response Shape
+
+`GET /api/v1/operations/activity/history` returns separate `polling` and `ingest_queue` sections.
+
+Each section is independently paged and ordered from most recent to oldest.
+
+Each section contains:
+
+- `items`
+- `next_cursor`
+- `has_more`
+
+### Polling History Entries
+
+Polling history entries should represent watched-folder ingest run outcomes at the run level, not the file level.
+
+Representative entry types:
+
+- `poll_completed`
+- `poll_failed`
+
+If active runs are excluded from history, there is no need for a `poll_started` history entry in the initial version.
+
+### Queue History Entries
+
+Queue history entries should represent queue-item outcomes at the queue-row level.
+
+Representative entry types:
+
+- `queue_processing_completed`
+- `queue_processing_failed`
+
+If stalled rows are surfaced in history after resolution or timeout classification, they may also use:
+
+- `queue_processing_stalled`
+
+### Recovery Semantics
+
+The history endpoint must make recovery sequences explicit without deriving a global health label.
+
+If a watched-folder poll fails and a later run succeeds, history should simply show:
+
+- the failed polling entry
+- the later completed polling entry
+
+Clients can interpret that as recovery without the backend inventing a sticky summary state.
+
+## Data Model and Assembly Strategy
+
+Split the current `operational_activity.py` responsibility into two read models:
+
+- live snapshot assembly
+- history journal assembly
+
+The live snapshot should query only rows that correspond to active polling or active queue work. The history journal should query only completed and failed rows.
+
+Existing sources of truth are sufficient for the first version:
+
+- `ingest_runs` for watched-folder polling activity
+- `ingest_queue` for queue activity
+
+This design intentionally avoids introducing a new event log table in the first implementation.
+
+## Documentation Changes
+
+Update documentation to reflect the new split:
+
+- `README.md` should describe `/api/v1/operations/activity` as a live snapshot endpoint
+- API schema descriptions should distinguish the live endpoint from the history endpoint
+- operator guidance should explain that recovery interpretation belongs to history, not the live snapshot
+
+## Testing Strategy
+
+Follow TDD.
+
+Add and update tests for:
+
+- live endpoint returns no active activity when no polling or queue work is underway
+- live endpoint returns only active polling items and progress summary fields
+- live endpoint returns only active queue items and progress summary fields
+- live endpoint does not surface completed or recovered work
+- stalled queue work remains visible in the live endpoint while unresolved
+- history endpoint returns completed and failed polling entries newest-first
+- history endpoint returns completed and failed queue entries newest-first
+- history endpoint keeps polling and queue pagination independent
+- history endpoint represents failure followed by recovery as separate ordered entries without deriving `attention_required`
+
+Existing tests that assert top-level `state`, `signals`, or `recent_failures` on `/api/v1/operations/activity` should be replaced with tests aligned to the live snapshot contract.
+
+## Verification
+
+Minimum verification for implementation:
+
+- `uv run python -m pytest apps/api/tests/test_operational_activity_api.py -q`
+- `uv run python -m pytest apps/api/tests/test_main.py -q`
+
+Representative local validation should also confirm:
+
+- active work appears while polling or queue processing is underway
+- no activity is shown once work completes
+- history shows failure and later recovery in descending timestamp order
+
+## Open Questions Resolved
+
+- The primary activity endpoint should focus on current live work, not a mixed history journal.
+- Polling and ingest queue activity should be shown in separate sections.
+- Historical completed and failed activity should move to a separate endpoint.
+- File-level events are out of scope for this issue.
+- Progress estimates are desirable, but only when the backend can support them honestly.


### PR DESCRIPTION
## Summary

Refactor the operational activity API into two distinct operator-facing surfaces:

- `GET /api/v1/operations/activity` now returns a live snapshot of active polling and ingest queue work
- `GET /api/v1/operations/activity/history` now returns paged completed/failed history with separate polling and queue sections

This removes the old sticky derived state model and keeps current activity separate from historical troubleshooting context.

Closes #127.

## What Changed

- replaced the old live `state`/`signals`/`recent_failures` summary contract with live `polling` and `ingest_queue` sections
- added a separate history endpoint with independent pagination for polling and queue history
- kept progress fields nullable when the backend does not have an honest estimate
- hardened history cursor handling so malformed cursors return `400` instead of surfacing as server errors
- updated OpenAPI assertions and README documentation to reflect the live/history split

## Validation

- `uv run python -m pytest apps/api/tests/test_operational_activity_api.py apps/api/tests/test_main.py -q`

## Notes

- the untracked implementation plan file was intentionally left out of the branch