### PR TITLE
feat(api): implement people management API for issue #41

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 
 from app.routers.ingest_queue import router as ingest_queue_router
 from app.routers.operations import router as operations_router
+from app.routers.people import router as people_router
 from app.routers.photos import router as photos_router
 from app.routers.storage_sources import router as storage_sources_router
 from app.openapi_docs import openapi_yaml_response
@@ -18,6 +19,10 @@ app = FastAPI(
         {
             "name": "photos",
             "description": "Browse and inspect photo records and metadata.",
+        },
+        {
+            "name": "people",
+            "description": "Create and manage people identities used by face-labeling workflows.",
         },
         {
             "name": "search",
@@ -41,6 +46,7 @@ app = FastAPI(
 
 app.include_router(ingest_queue_router, prefix="/api/v1")
 app.include_router(operations_router, prefix="/api/v1")
+app.include_router(people_router, prefix="/api/v1")
 app.include_router(photos_router, prefix="/api/v1")
 app.include_router(storage_sources_router, prefix="/api/v1")
 

--- a/apps/api/app/routers/people.py
+++ b/apps/api/app/routers/people.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, StringConstraints
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_db
+from app.services.people import create_person, get_person, list_people
+
+
+router = APIRouter(prefix="/people", tags=["people"])
+
+DisplayName = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1),
+    Field(...),
+]
+
+
+class CreatePersonRequest(BaseModel):
+    display_name: DisplayName
+
+
+class PersonResponse(BaseModel):
+    person_id: str
+    display_name: str
+    created_ts: datetime
+    updated_ts: datetime
+
+
+@router.post(
+    "",
+    summary="Create person",
+    description="Create a person identity used by face-labeling workflows.",
+    response_model=PersonResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_person_endpoint(
+    body: CreatePersonRequest,
+    db: Session = Depends(get_db),
+) -> PersonResponse:
+    person = create_person(
+        db.connection(),
+        display_name=body.display_name,
+        now=datetime.now(tz=UTC),
+    )
+    db.commit()
+    return PersonResponse.model_validate(person)
+
+
+@router.get(
+    "",
+    summary="List people",
+    description="Return all person identities ordered by display name.",
+    response_model=list[PersonResponse],
+)
+def list_people_endpoint(db: Session = Depends(get_db)) -> list[PersonResponse]:
+    rows = list_people(db.connection())
+    return [PersonResponse.model_validate(row) for row in rows]
+
+
+@router.get(
+    "/{person_id}",
+    summary="Get person",
+    description="Return one person identity by ID.",
+    response_model=PersonResponse,
+    responses={
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Person not found",
+        }
+    },
+)
+def get_person_endpoint(
+    person_id: str,
+    db: Session = Depends(get_db),
+) -> PersonResponse:
+    person = get_person(db.connection(), person_id)
+    if person is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Person not found")
+    return PersonResponse.model_validate(person)

--- a/apps/api/app/routers/people.py
+++ b/apps/api/app/routers/people.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
 from app.services.people import (
+    PersonInUseError,
     PersonNotFoundError,
     create_person,
+    delete_person,
     get_person,
     list_people,
     update_person,
@@ -140,3 +142,31 @@ def update_person_endpoint(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     db.commit()
     return PersonResponse.model_validate(person)
+
+
+@router.delete(
+    "/{person_id}",
+    summary="Delete person",
+    description="Delete one person identity by ID when it has no face references.",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Person not found",
+        },
+        status.HTTP_409_CONFLICT: {
+            "description": "Person is referenced by face or label data",
+        },
+    },
+)
+def delete_person_endpoint(
+    person_id: str,
+    db: Session = Depends(get_db),
+) -> Response:
+    try:
+        delete_person(db.connection(), person_id)
+    except PersonNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except PersonInUseError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/apps/api/app/routers/people.py
+++ b/apps/api/app/routers/people.py
@@ -4,11 +4,17 @@ from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field, StringConstraints
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 from sqlalchemy.orm import Session
 
 from app.dependencies import get_db
-from app.services.people import create_person, get_person, list_people
+from app.services.people import (
+    PersonNotFoundError,
+    create_person,
+    get_person,
+    list_people,
+    update_person,
+)
 
 
 router = APIRouter(prefix="/people", tags=["people"])
@@ -21,10 +27,34 @@ DisplayName = Annotated[
 
 
 class CreatePersonRequest(BaseModel):
+    """Request payload to create a person identity."""
+
+    model_config = ConfigDict(
+        json_schema_extra={"description": "Create a person by display name."}
+    )
+
+    display_name: DisplayName
+
+
+class UpdatePersonRequest(BaseModel):
+    """Request payload to rename an existing person identity."""
+
+    model_config = ConfigDict(
+        json_schema_extra={"description": "Rename a person by display name."}
+    )
+
     display_name: DisplayName
 
 
 class PersonResponse(BaseModel):
+    """Person identity returned by people API operations."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Canonical person record with audit timestamps."
+        }
+    )
+
     person_id: str
     display_name: str
     created_ts: datetime
@@ -80,4 +110,33 @@ def get_person_endpoint(
     person = get_person(db.connection(), person_id)
     if person is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Person not found")
+    return PersonResponse.model_validate(person)
+
+
+@router.patch(
+    "/{person_id}",
+    summary="Update person",
+    description="Rename one person identity by ID.",
+    response_model=PersonResponse,
+    responses={
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Person not found",
+        }
+    },
+)
+def update_person_endpoint(
+    person_id: str,
+    body: UpdatePersonRequest,
+    db: Session = Depends(get_db),
+) -> PersonResponse:
+    try:
+        person = update_person(
+            db.connection(),
+            person_id=person_id,
+            display_name=body.display_name,
+            now=datetime.now(tz=UTC),
+        )
+    except PersonNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    db.commit()
     return PersonResponse.model_validate(person)

--- a/apps/api/app/services/people.py
+++ b/apps/api/app/services/people.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+from sqlalchemy import insert, select
+from sqlalchemy.engine import Connection
+
+from app.storage import people
+
+
+class PersonNotFoundError(LookupError):
+    pass
+
+
+def _normalize_display_name(display_name: str) -> str:
+    return display_name.strip()
+
+
+def create_person(
+    connection: Connection,
+    *,
+    display_name: str,
+    now: datetime,
+) -> dict[str, object]:
+    person_id = str(uuid4())
+    normalized_display_name = _normalize_display_name(display_name)
+    row = {
+        "person_id": person_id,
+        "display_name": normalized_display_name,
+        "created_ts": now,
+        "updated_ts": now,
+    }
+    connection.execute(insert(people).values(row))
+    return row
+
+
+def list_people(connection: Connection) -> list[dict[str, object]]:
+    rows = connection.execute(
+        select(people).order_by(people.c.display_name, people.c.person_id)
+    ).mappings()
+    return [_person_from_row(row) for row in rows]
+
+
+def get_person(connection: Connection, person_id: str) -> dict[str, object] | None:
+    row = (
+        connection.execute(select(people).where(people.c.person_id == person_id))
+        .mappings()
+        .first()
+    )
+    if row is None:
+        return None
+    return _person_from_row(row)
+
+
+def _person_from_row(row: Any) -> dict[str, object]:
+    return {
+        "person_id": row["person_id"],
+        "display_name": row["display_name"],
+        "created_ts": row["created_ts"],
+        "updated_ts": row["updated_ts"],
+    }

--- a/apps/api/app/services/people.py
+++ b/apps/api/app/services/people.py
@@ -4,13 +4,17 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
-from sqlalchemy import insert, select, update
+from sqlalchemy import delete, insert, select, update
 from sqlalchemy.engine import Connection
 
-from app.storage import people
+from app.storage import face_labels, faces, people
 
 
 class PersonNotFoundError(LookupError):
+    pass
+
+
+class PersonInUseError(RuntimeError):
     pass
 
 
@@ -74,6 +78,30 @@ def update_person(
     if person is None:
         raise PersonNotFoundError("Person not found")
     return person
+
+
+def _person_has_references(connection: Connection, person_id: str) -> bool:
+    face_reference = connection.execute(
+        select(faces.c.face_id).where(faces.c.person_id == person_id).limit(1)
+    ).first()
+    if face_reference is not None:
+        return True
+
+    face_label_reference = connection.execute(
+        select(face_labels.c.face_label_id)
+        .where(face_labels.c.person_id == person_id)
+        .limit(1)
+    ).first()
+    return face_label_reference is not None
+
+
+def delete_person(connection: Connection, person_id: str) -> None:
+    person = get_person(connection, person_id)
+    if person is None:
+        raise PersonNotFoundError("Person not found")
+    if _person_has_references(connection, person_id):
+        raise PersonInUseError("Person is referenced by face or label data")
+    connection.execute(delete(people).where(people.c.person_id == person_id))
 
 
 def _normalize_utc_datetime(value: datetime) -> datetime:

--- a/apps/api/app/services/people.py
+++ b/apps/api/app/services/people.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
@@ -61,32 +61,31 @@ def update_person(
     display_name: str,
     now: datetime,
 ) -> dict[str, object]:
-    existing = (
-        connection.execute(select(people).where(people.c.person_id == person_id))
-        .mappings()
-        .first()
-    )
-    if existing is None:
-        raise PersonNotFoundError("Person not found")
-
     normalized_display_name = _normalize_display_name(display_name)
-    connection.execute(
+    result = connection.execute(
         update(people)
         .where(people.c.person_id == person_id)
         .values(display_name=normalized_display_name, updated_ts=now)
     )
-    return {
-        "person_id": existing["person_id"],
-        "display_name": normalized_display_name,
-        "created_ts": existing["created_ts"],
-        "updated_ts": now,
-    }
+    if result.rowcount == 0:
+        raise PersonNotFoundError("Person not found")
+
+    person = get_person(connection, person_id)
+    if person is None:
+        raise PersonNotFoundError("Person not found")
+    return person
+
+
+def _normalize_utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
 
 
 def _person_from_row(row: Any) -> dict[str, object]:
     return {
         "person_id": row["person_id"],
         "display_name": row["display_name"],
-        "created_ts": row["created_ts"],
-        "updated_ts": row["updated_ts"],
+        "created_ts": _normalize_utc_datetime(row["created_ts"]),
+        "updated_ts": _normalize_utc_datetime(row["updated_ts"]),
     }

--- a/apps/api/app/services/people.py
+++ b/apps/api/app/services/people.py
@@ -80,28 +80,23 @@ def update_person(
     return person
 
 
-def _person_has_references(connection: Connection, person_id: str) -> bool:
-    face_reference = connection.execute(
-        select(faces.c.face_id).where(faces.c.person_id == person_id).limit(1)
-    ).first()
-    if face_reference is not None:
-        return True
-
-    face_label_reference = connection.execute(
-        select(face_labels.c.face_label_id)
-        .where(face_labels.c.person_id == person_id)
-        .limit(1)
-    ).first()
-    return face_label_reference is not None
-
-
 def delete_person(connection: Connection, person_id: str) -> None:
+    delete_result = connection.execute(
+        delete(people).where(
+            people.c.person_id == person_id,
+            ~select(faces.c.face_id).where(faces.c.person_id == person_id).exists(),
+            ~select(face_labels.c.face_label_id)
+            .where(face_labels.c.person_id == person_id)
+            .exists(),
+        )
+    )
+    if delete_result.rowcount == 1:
+        return
+
     person = get_person(connection, person_id)
     if person is None:
         raise PersonNotFoundError("Person not found")
-    if _person_has_references(connection, person_id):
-        raise PersonInUseError("Person is referenced by face or label data")
-    connection.execute(delete(people).where(people.c.person_id == person_id))
+    raise PersonInUseError("Person is referenced by face or label data")
 
 
 def _normalize_utc_datetime(value: datetime) -> datetime:

--- a/apps/api/app/services/people.py
+++ b/apps/api/app/services/people.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any
 from uuid import uuid4
 
-from sqlalchemy import insert, select
+from sqlalchemy import insert, select, update
 from sqlalchemy.engine import Connection
 
 from app.storage import people
@@ -52,6 +52,35 @@ def get_person(connection: Connection, person_id: str) -> dict[str, object] | No
     if row is None:
         return None
     return _person_from_row(row)
+
+
+def update_person(
+    connection: Connection,
+    *,
+    person_id: str,
+    display_name: str,
+    now: datetime,
+) -> dict[str, object]:
+    existing = (
+        connection.execute(select(people).where(people.c.person_id == person_id))
+        .mappings()
+        .first()
+    )
+    if existing is None:
+        raise PersonNotFoundError("Person not found")
+
+    normalized_display_name = _normalize_display_name(display_name)
+    connection.execute(
+        update(people)
+        .where(people.c.person_id == person_id)
+        .values(display_name=normalized_display_name, updated_ts=now)
+    )
+    return {
+        "person_id": existing["person_id"],
+        "display_name": normalized_display_name,
+        "created_ts": existing["created_ts"],
+        "updated_ts": now,
+    }
 
 
 def _person_from_row(row: Any) -> dict[str, object]:

--- a/apps/api/tests/test_people_api.py
+++ b/apps/api/tests/test_people_api.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, insert, update
@@ -21,6 +21,13 @@ def _client(tmp_path, monkeypatch, filename: str) -> TestClient:
 
 def _database_url(tmp_path, filename: str) -> str:
     return f"sqlite:///{tmp_path / filename}"
+
+
+def _parse_api_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset() == timedelta(0)
+    return parsed
 
 
 def test_people_create_api_trims_display_name_and_returns_created_record(tmp_path, monkeypatch):
@@ -96,11 +103,15 @@ def test_people_list_api_orders_by_display_name_then_person_id(tmp_path, monkeyp
     response = client.get("/api/v1/people")
 
     assert response.status_code == 200
-    assert [item["person_id"] for item in response.json()] == [
+    payload = response.json()
+    assert [item["person_id"] for item in payload] == [
         "person-a",
         "person-b",
         "person-c",
     ]
+    for item in payload:
+        _parse_api_timestamp(item["created_ts"])
+        _parse_api_timestamp(item["updated_ts"])
 
 
 def test_people_get_api_returns_existing_person(tmp_path, monkeypatch):
@@ -125,8 +136,11 @@ def test_people_get_api_returns_existing_person(tmp_path, monkeypatch):
     response = client.get("/api/v1/people/person-1")
 
     assert response.status_code == 200
-    assert response.json()["person_id"] == "person-1"
-    assert response.json()["display_name"] == "Jane Doe"
+    payload = response.json()
+    assert payload["person_id"] == "person-1"
+    assert payload["display_name"] == "Jane Doe"
+    assert _parse_api_timestamp(payload["created_ts"]) == now
+    assert _parse_api_timestamp(payload["updated_ts"]) == now
 
 
 def test_people_get_api_returns_404_for_missing_person(tmp_path, monkeypatch):
@@ -171,10 +185,18 @@ def test_people_update_api_renames_person_and_refreshes_updated_timestamp(tmp_pa
     payload = response.json()
     assert payload["person_id"] == "person-1"
     assert payload["display_name"] == "Jane Smith"
-    created_ts = datetime.fromisoformat(payload["created_ts"]).replace(tzinfo=None)
-    updated_ts = datetime.fromisoformat(payload["updated_ts"]).replace(tzinfo=None)
-    assert created_ts == original_ts.replace(tzinfo=None)
-    assert updated_ts > original_ts.replace(tzinfo=None)
+    created_ts = _parse_api_timestamp(payload["created_ts"])
+    updated_ts = _parse_api_timestamp(payload["updated_ts"])
+    assert created_ts == original_ts
+    assert updated_ts > original_ts
+
+    get_response = client.get("/api/v1/people/person-1")
+    assert get_response.status_code == 200
+    persisted_payload = get_response.json()
+    assert persisted_payload["person_id"] == payload["person_id"]
+    assert persisted_payload["display_name"] == payload["display_name"]
+    assert _parse_api_timestamp(persisted_payload["created_ts"]) == created_ts
+    assert _parse_api_timestamp(persisted_payload["updated_ts"]) == updated_ts
 
 
 def test_people_update_api_rejects_blank_display_name(tmp_path, monkeypatch):

--- a/apps/api/tests/test_people_api.py
+++ b/apps/api/tests/test_people_api.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, insert, update
+from sqlalchemy import create_engine, insert, select, update
 
 from app.dependencies import _get_session_factory
 from app.main import app
 from app.migrations import upgrade_database
-from app.storage import people
+from app.storage import face_labels, faces, people, photos
 
 
 def _client(tmp_path, monkeypatch, filename: str) -> TestClient:
@@ -28,6 +28,18 @@ def _parse_api_timestamp(value: str) -> datetime:
     assert parsed.tzinfo is not None
     assert parsed.utcoffset() == timedelta(0)
     return parsed
+
+
+def _insert_photo(connection, *, photo_id: str) -> None:
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    connection.execute(
+        insert(photos).values(
+            photo_id=photo_id,
+            sha256=f"sha256-{photo_id}",
+            created_ts=now,
+            updated_ts=now,
+        )
+    )
 
 
 def test_people_create_api_trims_display_name_and_returns_created_record(tmp_path, monkeypatch):
@@ -215,6 +227,121 @@ def test_people_update_api_returns_404_for_missing_person(tmp_path, monkeypatch)
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Person not found"
+
+
+def test_people_delete_api_removes_unreferenced_person(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "people-delete.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(people).values(
+                person_id="person-1",
+                display_name="Jane Doe",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.delete("/api/v1/people/person-1")
+
+    assert response.status_code == 204
+    assert response.content == b""
+
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(people.c.person_id).where(people.c.person_id == "person-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id is None
+
+
+def test_people_delete_api_returns_404_for_missing_person(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-delete-missing.db")
+
+    response = client.delete("/api/v1/people/missing-person")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Person not found"
+
+
+def test_people_delete_api_returns_409_when_person_is_referenced_by_face(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "people-delete-face-reference.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(people).values(
+                person_id="person-1",
+                display_name="Jane Doe",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        _insert_photo(connection, photo_id="photo-1")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+            )
+        )
+
+    client = TestClient(app)
+    response = client.delete("/api/v1/people/person-1")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Person is referenced by face or label data"
+
+
+def test_people_delete_api_returns_409_when_person_is_referenced_by_face_label(
+    tmp_path, monkeypatch
+):
+    database_url = _database_url(tmp_path, "people-delete-face-label-reference.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(people).values(
+                person_id="person-1",
+                display_name="Jane Doe",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        _insert_photo(connection, photo_id="photo-1")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+            )
+        )
+        connection.execute(
+            insert(face_labels).values(
+                face_label_id="face-label-1",
+                face_id="face-1",
+                person_id="person-1",
+                label_source="manual",
+            )
+        )
+
+    client = TestClient(app)
+    response = client.delete("/api/v1/people/person-1")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Person is referenced by face or label data"
 
 
 def test_openapi_schema_includes_people_tag_and_paths(tmp_path, monkeypatch):

--- a/apps/api/tests/test_people_api.py
+++ b/apps/api/tests/test_people_api.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, insert
+
+from app.dependencies import _get_session_factory
+from app.main import app
+from app.migrations import upgrade_database
+from app.storage import people
+
+
+def _client(tmp_path, monkeypatch, filename: str) -> TestClient:
+    database_url = f"sqlite:///{tmp_path / filename}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+    return TestClient(app)
+
+
+def _database_url(tmp_path, filename: str) -> str:
+    return f"sqlite:///{tmp_path / filename}"
+
+
+def test_people_create_api_trims_display_name_and_returns_created_record(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-create.db")
+
+    response = client.post("/api/v1/people", json={"display_name": "  Jane Doe  "})
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["person_id"]
+    assert payload["display_name"] == "Jane Doe"
+    assert payload["created_ts"]
+    assert payload["updated_ts"] == payload["created_ts"]
+
+
+def test_people_create_api_rejects_blank_display_name(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-create-blank.db")
+
+    response = client.post("/api/v1/people", json={"display_name": "   "})
+
+    assert response.status_code == 422
+    assert any(error["loc"][-1] == "display_name" for error in response.json()["detail"])
+
+
+def test_people_list_api_orders_by_display_name_then_person_id(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "people-list.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(people),
+            [
+                {
+                    "person_id": "person-b",
+                    "display_name": "Alex",
+                    "created_ts": now,
+                    "updated_ts": now,
+                },
+                {
+                    "person_id": "person-c",
+                    "display_name": "Bea",
+                    "created_ts": now,
+                    "updated_ts": now,
+                },
+                {
+                    "person_id": "person-a",
+                    "display_name": "Alex",
+                    "created_ts": now,
+                    "updated_ts": now,
+                },
+            ],
+        )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/people")
+
+    assert response.status_code == 200
+    assert [item["person_id"] for item in response.json()] == [
+        "person-a",
+        "person-b",
+        "person-c",
+    ]
+
+
+def test_people_get_api_returns_existing_person(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "people-get.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(people).values(
+                person_id="person-1",
+                display_name="Jane Doe",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/people/person-1")
+
+    assert response.status_code == 200
+    assert response.json()["person_id"] == "person-1"
+    assert response.json()["display_name"] == "Jane Doe"
+
+
+def test_people_get_api_returns_404_for_missing_person(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-get-missing.db")
+
+    response = client.get("/api/v1/people/missing-person")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Person not found"
+
+
+def test_openapi_schema_includes_people_tag_and_paths(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-openapi.db")
+
+    schema = client.get("/openapi.json").json()
+
+    assert any(tag["name"] == "people" for tag in schema["tags"])
+    assert "/api/v1/people" in schema["paths"]
+    assert "/api/v1/people/{person_id}" in schema["paths"]

--- a/apps/api/tests/test_people_api.py
+++ b/apps/api/tests/test_people_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, insert
+from sqlalchemy import create_engine, insert, update
 
 from app.dependencies import _get_session_factory
 from app.main import app
@@ -34,6 +34,20 @@ def test_people_create_api_trims_display_name_and_returns_created_record(tmp_pat
     assert payload["display_name"] == "Jane Doe"
     assert payload["created_ts"]
     assert payload["updated_ts"] == payload["created_ts"]
+
+
+def test_people_create_api_persists_created_person_across_requests(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-create-persistence.db")
+
+    create_response = client.post("/api/v1/people", json={"display_name": "Jane Doe"})
+    person_id = create_response.json()["person_id"]
+
+    get_response = client.get(f"/api/v1/people/{person_id}")
+
+    assert create_response.status_code == 201
+    assert get_response.status_code == 200
+    assert get_response.json()["person_id"] == person_id
+    assert get_response.json()["display_name"] == "Jane Doe"
 
 
 def test_people_create_api_rejects_blank_display_name(tmp_path, monkeypatch):
@@ -119,6 +133,63 @@ def test_people_get_api_returns_404_for_missing_person(tmp_path, monkeypatch):
     client = _client(tmp_path, monkeypatch, "people-get-missing.db")
 
     response = client.get("/api/v1/people/missing-person")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Person not found"
+
+
+def test_people_update_api_renames_person_and_refreshes_updated_timestamp(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "people-update.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    original_ts = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(people).values(
+                person_id="person-1",
+                display_name="Jane Doe",
+                created_ts=original_ts,
+                updated_ts=original_ts,
+            )
+        )
+        connection.execute(
+            update(people)
+            .where(people.c.person_id == "person-1")
+            .values(updated_ts=original_ts)
+        )
+
+    client = TestClient(app)
+    response = client.patch(
+        "/api/v1/people/person-1",
+        json={"display_name": "  Jane Smith  "},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["person_id"] == "person-1"
+    assert payload["display_name"] == "Jane Smith"
+    created_ts = datetime.fromisoformat(payload["created_ts"]).replace(tzinfo=None)
+    updated_ts = datetime.fromisoformat(payload["updated_ts"]).replace(tzinfo=None)
+    assert created_ts == original_ts.replace(tzinfo=None)
+    assert updated_ts > original_ts.replace(tzinfo=None)
+
+
+def test_people_update_api_rejects_blank_display_name(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-update-blank.db")
+
+    response = client.patch("/api/v1/people/person-1", json={"display_name": "   "})
+
+    assert response.status_code == 422
+    assert any(error["loc"][-1] == "display_name" for error in response.json()["detail"])
+
+
+def test_people_update_api_returns_404_for_missing_person(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-update-missing.db")
+
+    response = client.patch("/api/v1/people/missing-person", json={"display_name": "Jane Doe"})
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Person not found"

--- a/apps/api/tests/test_people_api.py
+++ b/apps/api/tests/test_people_api.py
@@ -4,10 +4,13 @@ from datetime import UTC, datetime, timedelta
 
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, insert, select, update
+from sqlalchemy.sql.dml import Delete
 
 from app.dependencies import _get_session_factory
 from app.main import app
 from app.migrations import upgrade_database
+from app.routers import people as people_router
+from app.services import people as people_service
 from app.storage import face_labels, faces, people, photos
 
 
@@ -40,6 +43,31 @@ def _insert_photo(connection, *, photo_id: str) -> None:
             updated_ts=now,
         )
     )
+
+
+class _ResultWithRowcountZero:
+    rowcount = 0
+
+
+class _DeleteRowcountZeroConnection:
+    def __init__(self, connection) -> None:
+        self._connection = connection
+        self._did_inject = False
+
+    def execute(self, statement, *args, **kwargs):
+        if (
+            not self._did_inject
+            and isinstance(statement, Delete)
+            and statement.table.name == people.name
+        ):
+            # Simulate a concurrent delete that happens just before this DELETE executes.
+            self._did_inject = True
+            self._connection.execute(statement, *args, **kwargs)
+            return _ResultWithRowcountZero()
+        return self._connection.execute(statement, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._connection, name)
 
 
 def test_people_create_api_trims_display_name_and_returns_created_record(tmp_path, monkeypatch):
@@ -269,6 +297,41 @@ def test_people_delete_api_returns_404_for_missing_person(tmp_path, monkeypatch)
     assert response.json()["detail"] == "Person not found"
 
 
+def test_people_delete_api_returns_404_when_atomic_delete_loses_race(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "people-delete-race-not-found.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(people).values(
+                person_id="person-1",
+                display_name="Jane Doe",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+
+    def _delete_person_with_rowcount_zero(connection, person_id: str) -> None:
+        wrapped_connection = _DeleteRowcountZeroConnection(connection)
+        people_service.delete_person(wrapped_connection, person_id)
+
+    monkeypatch.setattr(
+        people_router,
+        "delete_person",
+        _delete_person_with_rowcount_zero,
+    )
+
+    client = TestClient(app)
+    response = client.delete("/api/v1/people/person-1")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Person not found"
+
+
 def test_people_delete_api_returns_409_when_person_is_referenced_by_face(tmp_path, monkeypatch):
     database_url = _database_url(tmp_path, "people-delete-face-reference.db")
     upgrade_database(database_url)
@@ -300,6 +363,11 @@ def test_people_delete_api_returns_409_when_person_is_referenced_by_face(tmp_pat
 
     assert response.status_code == 409
     assert response.json()["detail"] == "Person is referenced by face or label data"
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(people.c.person_id).where(people.c.person_id == "person-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id == "person-1"
 
 
 def test_people_delete_api_returns_409_when_person_is_referenced_by_face_label(
@@ -342,6 +410,11 @@ def test_people_delete_api_returns_409_when_person_is_referenced_by_face_label(
 
     assert response.status_code == 409
     assert response.json()["detail"] == "Person is referenced by face or label data"
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(people.c.person_id).where(people.c.person_id == "person-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id == "person-1"
 
 
 def test_openapi_schema_includes_people_tag_and_paths(tmp_path, monkeypatch):

--- a/docs/superpowers/plans/2026-04-24-issue-41-people-management-api.md
+++ b/docs/superpowers/plans/2026-04-24-issue-41-people-management-api.md
@@ -1,0 +1,908 @@
+# Issue 41 People Management API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add backend people-management model/service/API support for Phase 4 issue #41.
+
+**Architecture:** Use the existing `people` table as the persistence model and add a narrow `app.services.people` service boundary for people CRUD behavior. Expose that service through a new FastAPI router at `/api/v1/people`, with conservative delete checks against existing face and label references.
+
+**Tech Stack:** Python, FastAPI, Pydantic v2, SQLAlchemy Core, Alembic migrations already present, pytest, FastAPI TestClient
+
+---
+
+## File Map
+
+**Create:**
+
+- `apps/api/app/services/people.py`
+  Own people-record mutation, lookup, deterministic ordering, display-name normalization, and delete safety checks.
+- `apps/api/app/routers/people.py`
+  Expose `/api/v1/people` request/response models and HTTP routes.
+- `apps/api/tests/test_people_api.py`
+  Cover the API contract and SQLite-backed persistence behavior.
+
+**Modify:**
+
+- `apps/api/app/main.py`
+  Register the people router and add the OpenAPI `people` tag.
+
+**No schema changes expected:**
+
+- `packages/db-schema/photoorg_db_schema/schema.py`
+- `apps/api/alembic/versions/20260321_000001_initial_schema.py`
+
+The current `people` table already has `person_id`, `display_name`, `created_ts`, and `updated_ts`.
+
+### Task 1: Add Create, List, Get, And OpenAPI Contract
+
+**Files:**
+- Create: `apps/api/tests/test_people_api.py`
+- Create: `apps/api/app/services/people.py`
+- Create: `apps/api/app/routers/people.py`
+- Modify: `apps/api/app/main.py`
+
+- [ ] **Step 1: Write the failing API tests for create, validation, list, get, and OpenAPI registration**
+
+Create `apps/api/tests/test_people_api.py` with this content:
+
+```python
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, insert
+
+from app.dependencies import _get_session_factory
+from app.main import app
+from app.migrations import upgrade_database
+from app.storage import people
+
+
+def _client(tmp_path, monkeypatch, filename: str) -> TestClient:
+    database_url = f"sqlite:///{tmp_path / filename}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+    return TestClient(app)
+
+
+def _database_url(tmp_path, filename: str) -> str:
+    return f"sqlite:///{tmp_path / filename}"
+
+
+def test_people_create_api_trims_display_name_and_returns_created_record(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-create.db")
+
+    response = client.post("/api/v1/people", json={"display_name": "  Jane Doe  "})
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["person_id"]
+    assert payload["display_name"] == "Jane Doe"
+    assert payload["created_ts"]
+    assert payload["updated_ts"] == payload["created_ts"]
+
+
+def test_people_create_api_rejects_blank_display_name(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-create-blank.db")
+
+    response = client.post("/api/v1/people", json={"display_name": "   "})
+
+    assert response.status_code == 422
+    assert any(error["loc"][-1] == "display_name" for error in response.json()["detail"])
+
+
+def test_people_list_api_orders_by_display_name_then_person_id(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "people-list.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(people),
+            [
+                {
+                    "person_id": "person-b",
+                    "display_name": "Alex",
+                    "created_ts": now,
+                    "updated_ts": now,
+                },
+                {
+                    "person_id": "person-c",
+                    "display_name": "Bea",
+                    "created_ts": now,
+                    "updated_ts": now,
+                },
+                {
+                    "person_id": "person-a",
+                    "display_name": "Alex",
+                    "created_ts": now,
+                    "updated_ts": now,
+                },
+            ],
+        )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/people")
+
+    assert response.status_code == 200
+    assert [item["person_id"] for item in response.json()] == [
+        "person-a",
+        "person-b",
+        "person-c",
+    ]
+
+
+def test_people_get_api_returns_existing_person(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "people-get.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(people).values(
+                person_id="person-1",
+                display_name="Jane Doe",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/people/person-1")
+
+    assert response.status_code == 200
+    assert response.json()["person_id"] == "person-1"
+    assert response.json()["display_name"] == "Jane Doe"
+
+
+def test_people_get_api_returns_404_for_missing_person(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-get-missing.db")
+
+    response = client.get("/api/v1/people/missing-person")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Person not found"
+
+
+def test_openapi_schema_includes_people_tag_and_paths(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-openapi.db")
+
+    schema = client.get("/openapi.json").json()
+
+    assert any(tag["name"] == "people" for tag in schema["tags"])
+    assert "/api/v1/people" in schema["paths"]
+    assert "/api/v1/people/{person_id}" in schema["paths"]
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail for the expected reason**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_people_api.py -q
+```
+
+Expected: tests fail because `/api/v1/people` is not registered yet and the OpenAPI schema does not include the people tag or paths.
+
+- [ ] **Step 3: Add the initial people service**
+
+Create `apps/api/app/services/people.py` with this content:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import insert, select
+from sqlalchemy.engine import Connection
+
+from app.storage import people
+
+
+class PersonNotFoundError(LookupError):
+    pass
+
+
+def _normalize_display_name(display_name: str) -> str:
+    return display_name.strip()
+
+
+def create_person(
+    connection: Connection,
+    *,
+    display_name: str,
+    now: datetime,
+) -> dict[str, object]:
+    normalized_name = _normalize_display_name(display_name)
+    values = {
+        "person_id": str(uuid4()),
+        "display_name": normalized_name,
+        "created_ts": now,
+        "updated_ts": now,
+    }
+    connection.execute(insert(people).values(**values))
+    return values
+
+
+def list_people(connection: Connection) -> list[dict[str, object]]:
+    rows = connection.execute(
+        select(people).order_by(people.c.display_name, people.c.person_id)
+    ).mappings()
+    return [dict(row) for row in rows]
+
+
+def get_person(
+    connection: Connection,
+    person_id: str,
+) -> dict[str, object] | None:
+    row = connection.execute(
+        select(people).where(people.c.person_id == person_id)
+    ).mappings().first()
+    if row is None:
+        return None
+    return dict(row)
+```
+
+- [ ] **Step 4: Add the initial people router**
+
+Create `apps/api/app/routers/people.py` with this content:
+
+```python
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_db
+from app.services.people import create_person, get_person, list_people
+
+
+router = APIRouter(prefix="/people", tags=["people"])
+
+DisplayName = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1),
+    Field(description="Human-readable name for a person record."),
+]
+
+
+class CreatePersonRequest(BaseModel):
+    """Create a person record for face-labeling workflows."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Create a person identity that faces can be assigned to later."
+        }
+    )
+
+    display_name: DisplayName
+
+
+class PersonResponse(BaseModel):
+    """Canonical person record."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Person identity and lifecycle timestamps."
+        }
+    )
+
+    person_id: str
+    display_name: str
+    created_ts: datetime
+    updated_ts: datetime
+
+
+@router.post(
+    "",
+    summary="Create person",
+    description="Create a person record for future face-labeling workflows.",
+    response_model=PersonResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_person_route(
+    body: CreatePersonRequest,
+    db: Session = Depends(get_db),
+) -> PersonResponse:
+    row = create_person(
+        db.connection(),
+        display_name=body.display_name,
+        now=datetime.now(tz=UTC),
+    )
+    db.commit()
+    return PersonResponse.model_validate(row)
+
+
+@router.get(
+    "",
+    summary="List people",
+    description="Return all people records in deterministic display order.",
+    response_model=list[PersonResponse],
+)
+def list_people_route(
+    db: Session = Depends(get_db),
+) -> list[PersonResponse]:
+    rows = list_people(db.connection())
+    return [PersonResponse.model_validate(row) for row in rows]
+
+
+@router.get(
+    "/{person_id}",
+    summary="Get person",
+    description="Return a single person record.",
+    response_model=PersonResponse,
+    responses={status.HTTP_404_NOT_FOUND: {"description": "Person not found"}},
+)
+def get_person_route(
+    person_id: str,
+    db: Session = Depends(get_db),
+) -> PersonResponse:
+    row = get_person(db.connection(), person_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Person not found")
+    return PersonResponse.model_validate(row)
+```
+
+- [ ] **Step 5: Register the people router and OpenAPI tag**
+
+Modify `apps/api/app/main.py`.
+
+Add this import with the other router imports:
+
+```python
+from app.routers.people import router as people_router
+```
+
+Add this tag entry inside `openapi_tags`, after `search` and before `storage-sources`:
+
+```python
+        {
+            "name": "people",
+            "description": "Create and manage people identities used by face-labeling workflows.",
+        },
+```
+
+Add this router registration before `photos_router`:
+
+```python
+app.include_router(people_router, prefix="/api/v1")
+```
+
+- [ ] **Step 6: Run the Task 1 tests and verify they pass**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_people_api.py -q
+```
+
+Expected: `6 passed`.
+
+- [ ] **Step 7: Commit Task 1**
+
+Run:
+
+```bash
+git add apps/api/app/main.py apps/api/app/routers/people.py apps/api/app/services/people.py apps/api/tests/test_people_api.py
+git commit -m "feat(api): add people create list get api"
+```
+
+### Task 2: Add Rename Support
+
+**Files:**
+- Modify: `apps/api/tests/test_people_api.py`
+- Modify: `apps/api/app/services/people.py`
+- Modify: `apps/api/app/routers/people.py`
+
+- [ ] **Step 1: Write the failing update tests**
+
+Modify the SQLAlchemy import in `apps/api/tests/test_people_api.py`:
+
+```python
+from sqlalchemy import create_engine, insert, update
+```
+
+Append these tests to `apps/api/tests/test_people_api.py`:
+
+```python
+def test_people_update_api_renames_person_and_refreshes_updated_timestamp(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "people-update.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    client = TestClient(app)
+    created = client.post("/api/v1/people", json={"display_name": "Jane Doe"}).json()
+
+    old_ts = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            update(people)
+            .where(people.c.person_id == created["person_id"])
+            .values(created_ts=old_ts, updated_ts=old_ts)
+        )
+
+    response = client.patch(
+        f"/api/v1/people/{created['person_id']}",
+        json={"display_name": "  Jane Smith  "},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["person_id"] == created["person_id"]
+    assert payload["display_name"] == "Jane Smith"
+    assert payload["created_ts"].startswith("2026-01-01T12:00:00")
+    assert payload["updated_ts"] != payload["created_ts"]
+
+
+def test_people_update_api_rejects_blank_display_name(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-update-blank.db")
+    created = client.post("/api/v1/people", json={"display_name": "Jane Doe"}).json()
+
+    response = client.patch(
+        f"/api/v1/people/{created['person_id']}",
+        json={"display_name": "  "},
+    )
+
+    assert response.status_code == 422
+    assert any(error["loc"][-1] == "display_name" for error in response.json()["detail"])
+
+
+def test_people_update_api_returns_404_for_missing_person(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-update-missing.db")
+
+    response = client.patch(
+        "/api/v1/people/missing-person",
+        json={"display_name": "Jane Smith"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Person not found"
+```
+
+- [ ] **Step 2: Run the update tests and verify they fail**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_people_api.py -k "update_api" -q
+```
+
+Expected: tests fail because `PATCH /api/v1/people/{person_id}` is not implemented.
+
+- [ ] **Step 3: Add update support to the service**
+
+Modify the SQLAlchemy import in `apps/api/app/services/people.py`:
+
+```python
+from sqlalchemy import insert, select, update
+```
+
+Append this function to `apps/api/app/services/people.py`:
+
+```python
+def update_person(
+    connection: Connection,
+    *,
+    person_id: str,
+    display_name: str,
+    now: datetime,
+) -> dict[str, object]:
+    existing = get_person(connection, person_id)
+    if existing is None:
+        raise PersonNotFoundError("Person not found")
+
+    values = {
+        "display_name": _normalize_display_name(display_name),
+        "updated_ts": now,
+    }
+    connection.execute(
+        update(people)
+        .where(people.c.person_id == person_id)
+        .values(**values)
+    )
+    return {
+        **existing,
+        **values,
+    }
+```
+
+- [ ] **Step 4: Add update support to the router**
+
+Modify the service import in `apps/api/app/routers/people.py`:
+
+```python
+from app.services.people import (
+    PersonNotFoundError,
+    create_person,
+    get_person,
+    list_people,
+    update_person,
+)
+```
+
+Add this request model after `CreatePersonRequest`:
+
+```python
+class UpdatePersonRequest(BaseModel):
+    """Update a person record."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Rename a person identity without changing its stable identifier."
+        }
+    )
+
+    display_name: DisplayName
+```
+
+Append this route to `apps/api/app/routers/people.py`:
+
+```python
+@router.patch(
+    "/{person_id}",
+    summary="Update person",
+    description="Rename an existing person record.",
+    response_model=PersonResponse,
+    responses={status.HTTP_404_NOT_FOUND: {"description": "Person not found"}},
+)
+def update_person_route(
+    person_id: str,
+    body: UpdatePersonRequest,
+    db: Session = Depends(get_db),
+) -> PersonResponse:
+    try:
+        row = update_person(
+            db.connection(),
+            person_id=person_id,
+            display_name=body.display_name,
+            now=datetime.now(tz=UTC),
+        )
+    except PersonNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+
+    db.commit()
+    return PersonResponse.model_validate(row)
+```
+
+- [ ] **Step 5: Run the update tests and full people API file**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_people_api.py -k "update_api" -q
+uv run python -m pytest apps/api/tests/test_people_api.py -q
+```
+
+Expected: update slice passes, then the full `test_people_api.py` passes with `9 passed`.
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```bash
+git add apps/api/app/routers/people.py apps/api/app/services/people.py apps/api/tests/test_people_api.py
+git commit -m "feat(api): add people rename endpoint"
+```
+
+### Task 3: Add Conservative Delete Support
+
+**Files:**
+- Modify: `apps/api/tests/test_people_api.py`
+- Modify: `apps/api/app/services/people.py`
+- Modify: `apps/api/app/routers/people.py`
+
+- [ ] **Step 1: Write the failing delete tests**
+
+Modify the storage import in `apps/api/tests/test_people_api.py`:
+
+```python
+from app.storage import face_labels, faces, people, photos
+```
+
+Append these helper functions and tests to `apps/api/tests/test_people_api.py`:
+
+```python
+def _insert_photo(connection, *, photo_id: str) -> None:
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    connection.execute(
+        insert(photos).values(
+            photo_id=photo_id,
+            sha256=f"{photo_id:0<64}"[:64],
+            path=f"/library/{photo_id}.jpg",
+            created_ts=now,
+            updated_ts=now,
+            ext="jpg",
+            filesize=123,
+        )
+    )
+
+
+def test_people_delete_api_removes_unreferenced_person(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-delete.db")
+    created = client.post("/api/v1/people", json={"display_name": "Jane Doe"}).json()
+
+    response = client.delete(f"/api/v1/people/{created['person_id']}")
+
+    assert response.status_code == 204
+    assert response.content == b""
+    assert client.get(f"/api/v1/people/{created['person_id']}").status_code == 404
+
+
+def test_people_delete_api_returns_404_for_missing_person(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "people-delete-missing.db")
+
+    response = client.delete("/api/v1/people/missing-person")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Person not found"
+
+
+def test_people_delete_api_returns_409_when_person_is_referenced_by_face(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "people-delete-face-reference.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    client = TestClient(app)
+    created = client.post("/api/v1/people", json={"display_name": "Jane Doe"}).json()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-face-ref")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-face-ref",
+                person_id=created["person_id"],
+                bbox_x=1,
+                bbox_y=2,
+                bbox_w=3,
+                bbox_h=4,
+            )
+        )
+
+    response = client.delete(f"/api/v1/people/{created['person_id']}")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Person is referenced by face or label data"
+
+
+def test_people_delete_api_returns_409_when_person_is_referenced_by_face_label(
+    tmp_path, monkeypatch
+):
+    database_url = _database_url(tmp_path, "people-delete-label-reference.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    client = TestClient(app)
+    created = client.post("/api/v1/people", json={"display_name": "Jane Doe"}).json()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-label-ref")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-label-ref",
+                photo_id="photo-label-ref",
+                person_id=None,
+                bbox_x=1,
+                bbox_y=2,
+                bbox_w=3,
+                bbox_h=4,
+            )
+        )
+        connection.execute(
+            insert(face_labels).values(
+                face_label_id="face-label-1",
+                face_id="face-label-ref",
+                person_id=created["person_id"],
+                label_source="human",
+                confidence=None,
+                model_version=None,
+                provenance={"source": "test"},
+            )
+        )
+
+    response = client.delete(f"/api/v1/people/{created['person_id']}")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Person is referenced by face or label data"
+```
+
+- [ ] **Step 2: Run the delete tests and verify they fail**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_people_api.py -k "delete_api" -q
+```
+
+Expected: tests fail because `DELETE /api/v1/people/{person_id}` is not implemented.
+
+- [ ] **Step 3: Add delete support and reference checks to the service**
+
+Modify the SQLAlchemy import in `apps/api/app/services/people.py`:
+
+```python
+from sqlalchemy import delete, insert, select, update
+```
+
+Modify the storage import in `apps/api/app/services/people.py`:
+
+```python
+from app.storage import face_labels, faces, people
+```
+
+Add this exception class after `PersonNotFoundError`:
+
+```python
+class PersonInUseError(RuntimeError):
+    pass
+```
+
+Append these functions to `apps/api/app/services/people.py`:
+
+```python
+def _person_has_references(connection: Connection, person_id: str) -> bool:
+    face_reference = connection.execute(
+        select(faces.c.face_id)
+        .where(faces.c.person_id == person_id)
+        .limit(1)
+    ).first()
+    if face_reference is not None:
+        return True
+
+    label_reference = connection.execute(
+        select(face_labels.c.face_label_id)
+        .where(face_labels.c.person_id == person_id)
+        .limit(1)
+    ).first()
+    return label_reference is not None
+
+
+def delete_person(
+    connection: Connection,
+    person_id: str,
+) -> None:
+    existing = get_person(connection, person_id)
+    if existing is None:
+        raise PersonNotFoundError("Person not found")
+
+    if _person_has_references(connection, person_id):
+        raise PersonInUseError("Person is referenced by face or label data")
+
+    connection.execute(delete(people).where(people.c.person_id == person_id))
+```
+
+- [ ] **Step 4: Add the delete route**
+
+Modify the FastAPI import in `apps/api/app/routers/people.py`:
+
+```python
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+```
+
+Modify the service import in `apps/api/app/routers/people.py`:
+
+```python
+from app.services.people import (
+    PersonInUseError,
+    PersonNotFoundError,
+    create_person,
+    delete_person,
+    get_person,
+    list_people,
+    update_person,
+)
+```
+
+Append this route to `apps/api/app/routers/people.py`:
+
+```python
+@router.delete(
+    "/{person_id}",
+    summary="Delete person",
+    description="Delete an unreferenced person record.",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        status.HTTP_404_NOT_FOUND: {"description": "Person not found"},
+        status.HTTP_409_CONFLICT: {"description": "Person is referenced by face or label data"},
+    },
+)
+def delete_person_route(
+    person_id: str,
+    db: Session = Depends(get_db),
+) -> Response:
+    try:
+        delete_person(db.connection(), person_id)
+    except PersonNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except PersonInUseError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+```
+
+- [ ] **Step 5: Run the delete tests and full people API file**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_people_api.py -k "delete_api" -q
+uv run python -m pytest apps/api/tests/test_people_api.py -q
+```
+
+Expected: delete slice passes, then the full `test_people_api.py` passes with `13 passed`.
+
+- [ ] **Step 6: Commit Task 3**
+
+Run:
+
+```bash
+git add apps/api/app/routers/people.py apps/api/app/services/people.py apps/api/tests/test_people_api.py
+git commit -m "feat(api): add safe people deletion"
+```
+
+### Task 4: Final Verification
+
+**Files:**
+- Verify: `apps/api/tests/test_people_api.py`
+- Verify: `apps/api/tests/test_openapi_docs.py`
+- Verify: `apps/api/tests`
+
+- [ ] **Step 1: Run focused people API tests**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_people_api.py -q
+```
+
+Expected: all people API tests pass.
+
+- [ ] **Step 2: Run OpenAPI documentation tests**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_openapi_docs.py -q
+```
+
+Expected: all OpenAPI docs tests pass.
+
+- [ ] **Step 3: Run the full API test suite**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests -q
+```
+
+Expected: the full API suite passes. If this uncovers an unrelated pre-existing failure, record the exact failing test and inspect whether the people API changes contributed to it before deciding whether to fix it in this branch.
+
+- [ ] **Step 4: Inspect git status and commit any verification-only doc updates**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intentional code and test files are present, and they should already be committed by Tasks 1-3. Do not stage generated caches, `.venv`, or unrelated files.

--- a/docs/superpowers/specs/2026-04-24-issue-41-people-management-api-design.md
+++ b/docs/superpowers/specs/2026-04-24-issue-41-people-management-api-design.md
@@ -1,0 +1,230 @@
+# Issue 41 People Management Model And API Design
+
+Date: 2026-04-24
+Issue: #41
+Parent: #11 Phase 4: Face Labeling Workflow
+
+## Summary
+
+Implement the backend people-management slice for Phase 4. This adds API and service support for creating, listing, reading, renaming, and deleting people records without adding UI, face assignment, label correction, or recognition workflows.
+
+The existing `people` table is the source of truth for this slice. It already provides the fields needed for a first people-management contract:
+
+- `person_id`
+- `display_name`
+- `created_ts`
+- `updated_ts`
+
+No schema migration is expected for this issue unless implementation uncovers a missing contract.
+
+## Goals
+
+- expose a stable `/api/v1/people` API for backend clients
+- support creating and managing people records before face-assignment workflows are built
+- keep people management separate from face assignment, label correction, and recognition suggestions
+- prevent deletion of people records that are already referenced by face or label data
+- cover the API and service behavior with focused automated tests
+
+## Non-Goals
+
+- no web UI for people management
+- no face-to-person assignment or correction workflow
+- no validation-permission model
+- no human-confirmed versus machine-applied label behavior beyond preserving existing schema compatibility
+- no recognition suggestions, clustering, or threshold policy work
+- no person search response changes beyond what existing search behavior already supports
+
+## API Design
+
+Add a new router mounted at `/api/v1/people`.
+
+### Create Person
+
+`POST /api/v1/people`
+
+Request:
+
+```json
+{
+  "display_name": "Jane Doe"
+}
+```
+
+Behavior:
+
+- trims surrounding whitespace from `display_name`
+- rejects blank names with FastAPI/Pydantic validation
+- allows duplicate display names
+- creates a UUID-backed `person_id`
+- sets `created_ts` and `updated_ts` to the same current timestamp
+- returns `201 Created`
+
+Response:
+
+```json
+{
+  "person_id": "uuid",
+  "display_name": "Jane Doe",
+  "created_ts": "2026-04-24T12:00:00Z",
+  "updated_ts": "2026-04-24T12:00:00Z"
+}
+```
+
+### List People
+
+`GET /api/v1/people`
+
+Behavior:
+
+- returns all people records
+- orders deterministically by `display_name` then `person_id`
+- does not include face counts or label metadata in this slice
+
+### Get Person
+
+`GET /api/v1/people/{person_id}`
+
+Behavior:
+
+- returns the person record when found
+- returns `404 Not Found` when missing
+
+### Update Person
+
+`PATCH /api/v1/people/{person_id}`
+
+Request:
+
+```json
+{
+  "display_name": "Jane Smith"
+}
+```
+
+Behavior:
+
+- trims surrounding whitespace from `display_name`
+- rejects blank names with FastAPI/Pydantic validation
+- updates `display_name`
+- refreshes `updated_ts`
+- preserves `created_ts`
+- returns `404 Not Found` when missing
+
+### Delete Person
+
+`DELETE /api/v1/people/{person_id}`
+
+Behavior:
+
+- deletes an unreferenced person and returns `204 No Content`
+- returns `404 Not Found` when missing
+- returns `409 Conflict` when the person is referenced by `faces.person_id` or `face_labels.person_id`
+
+Deletion is intentionally conservative. A later label-correction workflow can decide how to reassign or remove dependent labels explicitly.
+
+## Service Design
+
+Create `app.services.people` as the domain-service boundary for people management. It should own:
+
+- UUID generation
+- timestamp assignment
+- display-name normalization at the service boundary
+- deterministic list ordering
+- lookup and not-found behavior
+- delete safety checks against `faces` and `face_labels`
+
+Expected functions:
+
+- `create_person(connection, *, display_name, now) -> dict`
+- `list_people(connection) -> list[dict]`
+- `get_person(connection, person_id) -> dict | None`
+- `update_person(connection, *, person_id, display_name, now) -> dict`
+- `delete_person(connection, person_id) -> None`
+
+Use small exception classes for service-level failures:
+
+- `PersonNotFoundError`
+- `PersonInUseError`
+
+The router should translate those exceptions into HTTP `404` and `409` responses.
+
+## Validation
+
+`display_name` is the only writable field in this slice.
+
+Validation rules:
+
+- strip surrounding whitespace
+- require at least one non-whitespace character
+- do not enforce uniqueness
+- do not impose formatting rules beyond the non-empty requirement
+
+Allowing duplicate display names is intentional. Names are not stable identities, and multiple people may share a display name. The stable identifier is `person_id`.
+
+## Data Flow
+
+Create and update calls flow from FastAPI request models into `app.services.people`, which mutates the existing `people` table through the request-scoped SQLAlchemy connection. The router commits successful mutations through the existing `get_db` session dependency pattern.
+
+Read calls use the same service module and return Pydantic response models. No repository abstraction is needed for this narrow CRUD surface.
+
+Delete calls first verify that the person exists, then check dependent references in `faces` and `face_labels`. If references exist, the service raises `PersonInUseError`; the router maps that to `409 Conflict`.
+
+## Error Handling
+
+- validation errors use FastAPI's default `422 Unprocessable Entity`
+- missing people return `404 Not Found`
+- referenced people return `409 Conflict`
+- unexpected database errors are not caught by this slice and should surface through the normal API error path
+
+## Testing Strategy
+
+Follow TDD.
+
+Add API-focused tests against SQLite migrations, matching existing FastAPI test patterns:
+
+- creating a person trims `display_name` and returns `201`
+- blank `display_name` is rejected
+- listing people returns deterministic `display_name`, `person_id` order
+- getting an existing person returns the record
+- getting a missing person returns `404`
+- updating a person changes `display_name`, refreshes `updated_ts`, and preserves `created_ts`
+- updating a missing person returns `404`
+- deleting an unreferenced person returns `204` and removes the row
+- deleting a missing person returns `404`
+- deleting a person referenced by `faces.person_id` returns `409`
+- deleting a person referenced by `face_labels.person_id` returns `409`
+
+Service-level tests may be added if edge cases become awkward to express through the API, but the API contract is the primary deliverable for this issue.
+
+## Verification
+
+Minimum verification:
+
+```bash
+uv run python -m pytest apps/api/tests/test_people_api.py -q
+uv run python -m pytest apps/api/tests/test_openapi_docs.py -q
+```
+
+Before completion, run the broader API test suite if the implementation touches shared dependencies or OpenAPI metadata:
+
+```bash
+uv run python -m pytest apps/api/tests -q
+```
+
+## OpenAPI Documentation
+
+Add the new router to `app.main` and include a `people` tag in the FastAPI metadata. Request and response models should include concise descriptions consistent with existing router style so the runtime OpenAPI schema documents the new API surface.
+
+No checked-in generated OpenAPI artifact is expected because the repository currently generates `apps/api/.generated/openapi.yaml` on demand rather than tracking it.
+
+## Future Work
+
+This issue creates the people-management foundation for the remaining Phase 4 child issues:
+
+- #42 face-to-person assignment workflow
+- #43 face label correction and reassignment workflow
+- #44 explicit label provenance and assignment source
+- #45 separation of human-confirmed and machine-applied labels
+- #46 permissions for face validation actions
+
+Those workflows should consume this API and service boundary rather than adding parallel person-record mutation paths.


### PR DESCRIPTION
## Summary

Implements Phase 4 issue #41 (people management model and API) on the backend-only scope:

- adds `/api/v1/people` endpoints for create, list, get, update, and delete
- introduces `app.services.people` for people CRUD behavior, timestamp normalization, and error semantics
- enforces conservative delete behavior:
  - `404` when person is missing
  - `409` when person is referenced by `faces` or `face_labels`
- hardens rename and delete behavior for consistency/race windows
- adds focused API tests for create/list/get/update/delete flows and edge cases
- registers the `people` tag and router in FastAPI OpenAPI config

## Key Behavior

- `POST /api/v1/people` returns `201` and trims `display_name`
- `GET /api/v1/people` returns deterministic order (`display_name`, `person_id`)
- `GET /api/v1/people/{person_id}` returns `404` when missing
- `PATCH /api/v1/people/{person_id}` returns `404` when missing and persists canonical timestamps
- `DELETE /api/v1/people/{person_id}` is atomic at SQL decision boundary and returns `404`/`409`/`204` appropriately

## Validation

- `uv run python -m pytest apps/api/tests/test_people_api.py -q` (15 passed)
- `uv run python -m pytest apps/api/tests/test_openapi_docs.py -q` (4 passed)
- `uv run python -m pytest apps/api/tests -q` (322 passed)

## Related

- Parent phase: #11
- Implements: #41