### PR TITLE
feat(api): implement face-to-person assignment workflow (#42)

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 
+from app.routers.face_assignments import router as face_assignments_router
 from app.routers.ingest_queue import router as ingest_queue_router
 from app.routers.operations import router as operations_router
 from app.routers.people import router as people_router
@@ -25,6 +26,10 @@ app = FastAPI(
             "description": "Create and manage people identities used by face-labeling workflows.",
         },
         {
+            "name": "face-labeling",
+            "description": "Assign detected faces to people identities.",
+        },
+        {
             "name": "search",
             "description": "Search photos using text, filters, and similarity signals.",
         },
@@ -46,6 +51,7 @@ app = FastAPI(
 
 app.include_router(ingest_queue_router, prefix="/api/v1")
 app.include_router(operations_router, prefix="/api/v1")
+app.include_router(face_assignments_router, prefix="/api/v1")
 app.include_router(people_router, prefix="/api/v1")
 app.include_router(photos_router, prefix="/api/v1")
 app.include_router(storage_sources_router, prefix="/api/v1")

--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -406,6 +406,7 @@ class PhotosRepository:
         if include_face_regions:
             face_columns.extend(
                 [
+                    self.faces.c.face_id,
                     self.faces.c.bbox_x,
                     self.faces.c.bbox_y,
                     self.faces.c.bbox_w,
@@ -416,6 +417,7 @@ class PhotosRepository:
         for r in self.db.execute(
             select(*face_columns)
             .where(self.faces.c.photo_id.in_(pids))
+            .order_by(self.faces.c.photo_id, self.faces.c.face_id)
         ).all():
             if r.person_id:
                 ppl_map[r.photo_id].append(r.person_id)
@@ -423,6 +425,7 @@ class PhotosRepository:
             if include_face_regions:
                 face_item.update(
                     {
+                        "face_id": r.face_id,
                         "bbox_x": r.bbox_x,
                         "bbox_y": r.bbox_y,
                         "bbox_w": r.bbox_w,

--- a/apps/api/app/routers/face_assignments.py
+++ b/apps/api/app/routers/face_assignments.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from sqlalchemy.orm import Session
+
+from app.dependencies import get_db
+from app.services.face_assignment import (
+    FaceAlreadyAssignedError,
+    FaceNotFoundError,
+    PersonNotFoundError,
+    assign_face_to_person,
+)
+
+
+router = APIRouter(prefix="/faces", tags=["face-labeling"])
+
+PersonId = Annotated[
+    str,
+    StringConstraints(strip_whitespace=True, min_length=1),
+    Field(...),
+]
+
+
+class AssignFaceRequest(BaseModel):
+    """Request payload to assign one detected face to one person."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Assign an unlabeled face to an existing person identity."
+        }
+    )
+
+    person_id: PersonId
+
+
+class FaceAssignmentResponse(BaseModel):
+    """Assignment result for one face and one person."""
+
+    model_config = ConfigDict(
+        json_schema_extra={"description": "Resolved face-to-person assignment details."}
+    )
+
+    face_id: str
+    photo_id: str
+    person_id: str
+
+
+@router.post(
+    "/{face_id}/assignments",
+    summary="Assign face to person",
+    description="Assign an unlabeled face to a person identity.",
+    response_model=FaceAssignmentResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses={
+        status.HTTP_404_NOT_FOUND: {"description": "Face or person not found"},
+        status.HTTP_409_CONFLICT: {"description": "Face already assigned"},
+    },
+)
+def assign_face_to_person_endpoint(
+    face_id: str,
+    body: AssignFaceRequest,
+    db: Session = Depends(get_db),
+) -> FaceAssignmentResponse:
+    try:
+        assignment = assign_face_to_person(
+            db.connection(),
+            face_id=face_id,
+            person_id=body.person_id,
+        )
+    except FaceNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except PersonNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except FaceAlreadyAssignedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    db.commit()
+    return FaceAssignmentResponse.model_validate(assignment)

--- a/apps/api/app/schemas/photo_response.py
+++ b/apps/api/app/schemas/photo_response.py
@@ -14,6 +14,7 @@ class PhotoDetailFace(BaseModel):
         json_schema_extra={"description": "A single detected face and its bounding box."}
     )
 
+    face_id: str = Field(description="Stable face identifier.")
     person_id: str | None = Field(default=None, description="Recognized person identifier.")
     bbox_x: int | None = Field(default=None, description="Bounding-box x coordinate.")
     bbox_y: int | None = Field(default=None, description="Bounding-box y coordinate.")

--- a/apps/api/app/services/face_assignment.py
+++ b/apps/api/app/services/face_assignment.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from sqlalchemy import select, update
+from sqlalchemy.engine import Connection
+
+from app.storage import faces, people
+
+
+class FaceNotFoundError(LookupError):
+    pass
+
+
+class PersonNotFoundError(LookupError):
+    pass
+
+
+class FaceAlreadyAssignedError(RuntimeError):
+    pass
+
+
+def assign_face_to_person(
+    connection: Connection,
+    *,
+    face_id: str,
+    person_id: str,
+) -> dict[str, str]:
+    result = connection.execute(
+        update(faces)
+        .where(
+            faces.c.face_id == face_id,
+            faces.c.person_id.is_(None),
+            select(people.c.person_id).where(people.c.person_id == person_id).exists(),
+        )
+        .values(person_id=person_id)
+    )
+    if result.rowcount == 1:
+        return _face_assignment(connection, face_id)
+
+    row = _face_row(connection, face_id)
+    if row is None:
+        raise FaceNotFoundError("Face not found")
+    if row["person_id"] is not None:
+        raise FaceAlreadyAssignedError("Face already assigned")
+
+    person_exists = (
+        connection.execute(
+            select(people.c.person_id).where(people.c.person_id == person_id)
+        ).scalar_one_or_none()
+        is not None
+    )
+    if not person_exists:
+        raise PersonNotFoundError("Person not found")
+
+    raise FaceAlreadyAssignedError("Face already assigned")
+
+
+def _face_row(connection: Connection, face_id: str):
+    return (
+        connection.execute(
+            select(
+                faces.c.face_id,
+                faces.c.photo_id,
+                faces.c.person_id,
+            ).where(faces.c.face_id == face_id)
+        )
+        .mappings()
+        .first()
+    )
+
+
+def _face_assignment(connection: Connection, face_id: str) -> dict[str, str]:
+    row = _face_row(connection, face_id)
+    if row is None:
+        raise FaceNotFoundError("Face not found")
+    person_id = row["person_id"]
+    if person_id is None:
+        raise RuntimeError("Face assignment persisted without person_id")
+    return {
+        "face_id": row["face_id"],
+        "photo_id": row["photo_id"],
+        "person_id": person_id,
+    }

--- a/apps/api/tests/test_face_assignment_api.py
+++ b/apps/api/tests/test_face_assignment_api.py
@@ -1,0 +1,352 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, insert, select
+
+from app.dependencies import _get_session_factory
+from app.main import app
+from app.migrations import upgrade_database
+from app.storage import face_labels, faces, people, photos
+
+
+def _client(tmp_path, monkeypatch, filename: str) -> TestClient:
+    database_url = f"sqlite:///{tmp_path / filename}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+    return TestClient(app)
+
+
+def _database_url(tmp_path, filename: str) -> str:
+    return f"sqlite:///{tmp_path / filename}"
+
+
+def _insert_photo(connection, *, photo_id: str) -> None:
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    connection.execute(
+        insert(photos).values(
+            photo_id=photo_id,
+            sha256=f"sha256-{photo_id}",
+            created_ts=now,
+            updated_ts=now,
+        )
+    )
+
+
+def _insert_person(connection, *, person_id: str, display_name: str) -> None:
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    connection.execute(
+        insert(people).values(
+            person_id=person_id,
+            display_name=display_name,
+            created_ts=now,
+            updated_ts=now,
+        )
+    )
+
+
+def test_face_assignment_api_assigns_unlabeled_face_to_existing_person(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-assign.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={"person_id": "person-1"},
+    )
+
+    assert response.status_code == 201
+    assert response.json() == {
+        "face_id": "face-1",
+        "photo_id": "photo-1",
+        "person_id": "person-1",
+    }
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id == "person-1"
+
+
+def test_face_assignment_api_does_not_create_face_label_records_in_issue_42_slice(
+    tmp_path, monkeypatch
+):
+    database_url = _database_url(tmp_path, "face-assign-no-face-label-write.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={"person_id": "person-1"},
+    )
+
+    assert response.status_code == 201
+    with engine.connect() as connection:
+        face_label_count = connection.execute(select(face_labels.c.face_label_id)).all()
+    assert face_label_count == []
+
+
+def test_face_assignment_api_returns_404_for_missing_face(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-assign-missing-face.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/missing-face/assignments",
+        json={"person_id": "person-1"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Face not found"
+
+
+def test_face_assignment_api_returns_404_for_missing_person(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-assign-missing-person.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={"person_id": "missing-person"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Person not found"
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id is None
+
+
+def test_face_assignment_api_returns_409_for_already_assigned_face(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-assign-already-assigned.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        _insert_person(connection, person_id="person-2", display_name="John Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-2",
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={"person_id": "person-1"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Face already assigned"
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id == "person-2"
+
+
+def test_face_assignment_api_returns_422_for_blank_person_id(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-assign-blank-person-id.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={"person_id": "   "},
+    )
+
+    assert response.status_code == 422
+    assert any(error["loc"][-1] == "person_id" for error in response.json()["detail"])
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id is None
+
+
+def test_face_assignment_api_returns_422_for_missing_person_id(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-assign-missing-person-id.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={},
+    )
+
+    assert response.status_code == 422
+    assert any(error["loc"][-1] == "person_id" for error in response.json()["detail"])
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id is None
+
+
+def test_face_assignment_api_returns_409_when_reassigning_to_same_person(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-assign-same-person-conflict.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={"person_id": "person-1"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Face already assigned"
+
+
+def test_photo_detail_api_includes_face_id_for_assignment_workflow(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-assign-photo-detail.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                sha256="sha-1",
+                created_ts=now,
+                updated_ts=now,
+                path="/photos/photo-1.jpg",
+                filesize=1024,
+                ext="jpg",
+                faces_count=1,
+            )
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+                bbox_x=10,
+                bbox_y=20,
+                bbox_w=30,
+                bbox_h=40,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/photos/photo-1")
+
+    assert response.status_code == 200
+    assert response.json()["faces"] == [
+        {
+            "face_id": "face-1",
+            "person_id": None,
+            "bbox_x": 10,
+            "bbox_y": 20,
+            "bbox_w": 30,
+            "bbox_h": 40,
+        }
+    ]
+
+
+def test_openapi_schema_includes_face_assignment_path_and_tag(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "face-assign-openapi.db")
+
+    schema = client.get("/openapi.json").json()
+
+    assert "/api/v1/faces/{face_id}/assignments" in schema["paths"]
+    assert any(tag["name"] == "face-labeling" for tag in schema["tags"])

--- a/apps/api/tests/test_photo_detail_api.py
+++ b/apps/api/tests/test_photo_detail_api.py
@@ -69,6 +69,7 @@ def test_photo_detail_api_returns_projected_metadata_and_related_fields(tmp_path
     assert payload["people"] == ["person-1"]
     assert payload["faces"] == [
         {
+            "face_id": "face-1",
             "person_id": "person-1",
             "bbox_x": 10,
             "bbox_y": 20,

--- a/docs/adr/0015-introduce-face-to-person-assignment-api-workflow.md
+++ b/docs/adr/0015-introduce-face-to-person-assignment-api-workflow.md
@@ -1,0 +1,62 @@
+# ADR-0015: Introduce Face-To-Person Assignment API Workflow
+
+- Status: Proposed
+- Date: 2026-04-25
+
+## Context
+
+Phase 4 requires a concrete workflow to assign detected faces to existing people records.
+
+Issue #41 introduced people-management APIs (`/api/v1/people`) and established person identities as the source of truth for user-managed names. The next delivery slice must make those identities usable by enabling assignment of an unlabeled face to a person.
+
+The current schema already contains two related paths:
+
+- `faces.person_id` (nullable)
+- `face_labels` records with provenance fields
+
+Later Phase 4 issues are explicitly reserved for:
+
+- correction and reassignment workflows (#43)
+- explicit provenance and assignment source behavior (#44)
+- policy separation between human-confirmed and machine-applied labels (#45)
+
+The assignment workflow for this slice therefore needs to be narrow, deterministic, and compatible with those upcoming behaviors without prematurely expanding into correction/provenance scope.
+
+## Decision
+
+Add a dedicated face-assignment API operation:
+
+- `POST /api/v1/faces/{face_id}/assignments`
+
+Request shape:
+
+- `{ "person_id": "<id>" }`
+
+Behavior:
+
+- Assign only if the face exists and is currently unlabeled (`faces.person_id IS NULL`).
+- Require the target person to exist in `people`.
+- Persist the assignment by setting `faces.person_id`.
+- Return `201 Created` with `{face_id, photo_id, person_id}` on success.
+- Return `404 Not Found` when the face or person does not exist.
+- Return `409 Conflict` when the face is already assigned.
+
+To support caller workflows, include `face_id` in photo-detail face payloads (`GET /api/v1/photos/{photo_id}`) so clients can identify which detected face to assign.
+
+Expose this workflow in OpenAPI under a dedicated `face-labeling` tag.
+
+## Consequences
+
+- Phase 4 has a concrete first assignment workflow that is usable in local development.
+- Existing people records become actionable for labeling without requiring UI completion.
+- Assignment semantics are intentionally conservative (no overwrite), reducing accidental relabeling and preserving space for explicit correction flows in #43.
+- Persisting into `faces.person_id` keeps search and browse behavior compatible with current repository logic that already reads person links from `faces`.
+- Provenance capture for assignments remains deferred to #44; this slice does not yet write `face_labels`.
+- Future correction/reassignment work must define how `faces.person_id` and `face_labels` interact and whether historical label events are backfilled.
+
+## Alternatives Considered
+
+- Write assignments directly to `face_labels` in this slice
+- Allow reassignment in-place within the same endpoint
+- Infer assignment targets from display names instead of requiring `person_id`
+- Delay API work until a web labeling UI exists

--- a/docs/superpowers/specs/2026-04-07-issue-131-api-owned-polling-design.md
+++ b/docs/superpowers/specs/2026-04-07-issue-131-api-owned-polling-design.md
@@ -1,0 +1,241 @@
+# Issue 131 API-Owned Polling Design
+
+Date: 2026-04-07
+Issue: #131
+
+## Summary
+
+Move storage-source polling fully into the API service and retire the CLI polling command. The API should expose a dedicated internal polling endpoint that performs one bounded poll pass and enqueues ingest candidates only. Queue ingestion remains a separate bounded endpoint that can be invoked concurrently by multiple clients with different `limit` values.
+
+The core design decision is that polling and ingest processing scale differently and therefore should remain separate responsibilities even though they now both live inside the db-service. Polling should reject overlapping scans for the same scope with an explicit HTTP conflict, while ingest queue processing should continue allowing concurrent callers and rely on lease-based row claiming for correctness.
+
+## Goals
+
+- make the db-service the single runtime owner of storage access, polling, extraction, and persistence
+- remove the operational need for the `poll-storage-sources` CLI command
+- add a dedicated API endpoint that performs polling only and never drains the ingest queue inline
+- preserve the existing bounded ingest queue endpoint so multiple clients can process queued work in parallel
+- reject overlapping poll requests for the same scope with a dedicated HTTP response and meaningful error payload
+- reuse existing ingest-run and operational-activity visibility where practical instead of inventing a second polling-state mechanism
+
+## Non-Goals
+
+- no attempt to merge polling and queue processing into one endpoint
+- no redesign of lease-based queue claiming for ingest processing
+- no move to an external broker or scheduler for polling kickoff
+- no change to watched-folder registration, storage-source identity, or source-marker validation rules beyond what the new endpoint requires
+- no broad redesign of developer utilities unrelated to polling ownership
+
+## Current Problem
+
+The current codebase still carries an outdated split:
+
+- the CLI owns `poll-storage-sources`
+- the API owns `/api/v1/internal/ingest-queue/process`
+- the CLI command also drains the ingest queue after polling finishes
+
+That shape no longer matches the actual deployment reality. The db-service now needs runtime access to photo file contents for staged ingest work such as hashing, metadata extraction, thumbnail generation, and face detection. Keeping polling outside that service no longer creates a clean boundary.
+
+It also creates two practical problems:
+
+- the CLI path violates single-responsibility expectations by polling and then draining the queue in one command
+- overlapping poll requests cannot be rejected cleanly at the API boundary because polling does not currently expose a durable in-flight lock or conflict signal
+
+## Recommended Approach
+
+Adopt an API-owned polling model with two independent internal worker endpoints.
+
+### Endpoint 1: Poll Storage Sources
+
+Add an internal endpoint, expected at `POST /api/v1/internal/storage-sources/poll`, with worker-role protection similar to the existing ingest queue endpoint.
+
+Its responsibility is:
+
+- validate the requested poll scope
+- reject overlapping poll requests for the same scope
+- perform one bounded polling pass
+- enqueue ingest candidates
+- return aggregate polling counts and errors
+
+It must not:
+
+- process queued ingest work
+- loop until the queue is empty
+- become a long-running background scheduler separate from the request
+
+### Endpoint 2: Process Ingest Queue
+
+Keep `POST /api/v1/internal/ingest-queue/process` as the ingest-only endpoint.
+
+Its responsibility remains:
+
+- claim processable queue rows
+- perform bounded extraction and persistence work
+- rely on lease-based queue claiming so multiple callers can overlap safely
+
+This endpoint continues to scale horizontally through concurrent requests and row-level lease semantics. It does not participate in poll overlap control.
+
+## API Contract
+
+### Poll Request
+
+The poll endpoint should accept a compact request body with:
+
+- `poll_chunk_size`, bounded similarly to the current polling function contract
+- optional `storage_source_id` to scope the request to one registered source
+
+If `storage_source_id` is omitted, the endpoint polls all enabled registered sources.
+
+Future scope selectors can be added later if operationally justified, but the initial contract should stay minimal.
+
+### Poll Success Response
+
+The response should report polling-only work:
+
+- `scanned`
+- `enqueued`
+- `inserted`
+- `updated`
+- `errors`
+
+These fields should preserve the current `IngestResult` semantics so the polling implementation can be reused rather than translated into a different result model.
+
+### Poll Conflict Response
+
+If the requested scope overlaps an active poll, the endpoint should return `409 Conflict` with a specific payload that includes:
+
+- a clear message that polling is already active for the requested scope
+- the blocking `storage_source_id`
+- the blocking `watched_folder_id` when relevant
+- the active `ingest_run_id`
+- the active run `started_ts`
+
+This should be precise enough for operators or automation to understand whether the conflict is transient and what work is already underway.
+
+## Scope And Overlap Rules
+
+Overlap should be prevented per watched-folder polling scope, not through a single global poll lock.
+
+The intended behavior is:
+
+- poll-all requests conflict with any active watched-folder poll
+- a source-scoped poll request conflicts only with active polls touching watched folders under that source
+- different storage sources may be polled independently when their scopes do not overlap
+
+This is stricter than the ingest queue model by design. Filesystem scans should not duplicate work for the same watched folder, while queue row processing is already designed for safe overlap through leases.
+
+## Poll Run Lifecycle
+
+The current polling implementation records completed or failed poll runs after work finishes, but it does not create a durable in-flight marker early enough to reject overlap.
+
+That needs to change.
+
+For each watched-folder scan, polling should:
+
+1. create an ingest run with `status="processing"` before scanning begins
+2. keep that run as the active marker for overlap checks and operational activity
+3. finalize the run to `completed` or `failed` when the watched-folder poll finishes
+
+Chunk-level progress should continue to be visible through run statistics where useful, but overlap detection must rely on an explicit in-flight run that exists before file enumeration starts.
+
+This design intentionally reuses `ingest_runs` instead of adding a separate poll-lock table unless implementation proves the existing run model cannot express the state cleanly.
+
+## Conflict Detection Source Of Truth
+
+The source of truth for active polling should be `ingest_runs.status == "processing"` for watched-folder-backed runs.
+
+That allows the system to:
+
+- reject overlapping poll requests using state already visible to operational activity
+- keep a single operator-facing model for “what is polling right now”
+- avoid inventing a second coordination channel just for endpoint conflict handling
+
+If a later implementation needs a more explicit “poll coordinator” abstraction, it should still be backed by this same durable run state rather than in-memory guards alone.
+
+## CLI Changes
+
+Retire the `poll-storage-sources` CLI command from the API app.
+
+The CLI should no longer:
+
+- own storage-source polling
+- drain the ingest queue after polling
+- present itself as the operator-facing way to run ingestion
+
+Developer utilities such as `migrate` and `seed-corpus` can remain if they still serve local workflows, but polling should move entirely behind the internal API.
+
+## Operational Activity Impact
+
+The existing live activity endpoint already treats `ingest_runs.status == "processing"` as active polling. That aligns well with the new design and should continue to work once polling creates processing runs before scan work begins.
+
+This means:
+
+- the live polling view becomes the same state used for conflict detection
+- conflict responses can cite active run identifiers already visible through operations activity
+- no separate poll-status endpoint is required for the first version
+
+## Documentation And ADR Direction
+
+Documentation should stop describing polling as a CLI-owned operation and should update the architecture narrative to reflect db-service ownership of file-accessing ingest work.
+
+At minimum:
+
+- contributor docs should replace `poll-storage-sources` instructions with the new internal poll endpoint contract
+- README status text should describe polling and queue processing as separate API-owned internal endpoints
+- ADR-0003 should be updated or superseded because its original rationale assumed the API service would not need to read photo contents during background ingest work
+
+The revised architectural position is:
+
+- db-service owns polling, hashing, extraction, face detection, and persistence
+- separation now exists between polling and ingest-processing responsibilities, not between CLI and API runtimes
+
+## Failure Handling
+
+Failure behavior should remain responsibility-specific.
+
+### Polling Failures
+
+Source validation and watched-folder access failures still belong to the polling path. A failed poll request should return normal polling counts plus error details for the affected sources or folders. It should not attempt compensating queue processing.
+
+### Overlap Failures
+
+Overlap is not an internal error. It is a deliberate API-level conflict and should return `409 Conflict`, not `500`, not silent skipping, and not queue-style lease retry semantics.
+
+### Queue Processing Failures
+
+Queue processing keeps its existing model:
+
+- terminal failures mark rows failed
+- transient failures remain retryable
+- overlapping processors are acceptable as long as row claiming is exclusive per lease rules
+
+## Testing Strategy
+
+Follow TDD.
+
+Add or update coverage for:
+
+- successful poll endpoint invocation returning polling-only counts
+- `409 Conflict` when a poll request overlaps an active poll in the same scope
+- source-scoped polls not conflicting with active polls for a different source
+- polling creating a `processing` ingest run before scan work starts and finalizing it afterward
+- removal of the CLI `poll-storage-sources` command
+- docs and OpenAPI coverage for the new endpoint
+- existing ingest queue endpoint behavior remaining concurrent and limit-driven
+
+Existing polling tests should be updated where they currently assume only terminal poll runs exist.
+
+## Verification
+
+Minimum verification for implementation:
+
+- targeted API tests for the new polling endpoint, including conflict handling
+- targeted polling tests covering the new processing-run lifecycle
+- targeted CLI tests confirming `poll-storage-sources` is removed
+- targeted ingest queue API tests confirming the current limit-based processing contract still holds
+
+## Open Questions Resolved
+
+- Polling and ingest processing remain separate endpoints to preserve SRP.
+- Poll overlap should be rejected with a dedicated HTTP conflict and meaningful payload.
+- Queue processing should continue allowing concurrent clients and should scale by saturating the db-service only when needed.


### PR DESCRIPTION
## Summary

Implements Issue #42 by adding the first backend face-to-person assignment workflow slice.

- adds `POST /api/v1/faces/{face_id}/assignments`
- adds face assignment service with deterministic `201 / 404 / 409` outcomes
- exposes `face_id` in photo detail `faces[]` payloads for assignment targeting
- documents the workflow decision as ADR-0015
- hardens coverage for validation and no-provenance-write behavior in this slice

## API Behavior

- assigns only unlabeled faces (`faces.person_id IS NULL`)
- returns `404` when face or person is missing
- returns `409` when face is already assigned
- keeps provenance writes (`face_labels`) out of this issue scope

## Follow-up

- FK integrity hardening is tracked in #133 and added as a child issue under #11

## Verification

- `uv run python -m pytest apps/api/tests/test_face_assignment_api.py apps/api/tests/test_photo_detail_api.py -q`
- `uv run python -m pytest apps/api/tests -q`

Closes #42