### PR TITLE
[codex] hotfix: close sqlite engines to eliminate pre-push warnings

### DIFF
--- a/apps/api/app/cli.py
+++ b/apps/api/app/cli.py
@@ -61,8 +61,11 @@ def build_parser() -> argparse.ArgumentParser:
 
 def _count_photos(database_url: str | Path | None = None) -> int:
     engine = create_db_engine(database_url)
-    with engine.connect() as connection:
-        return connection.scalar(select(func.count()).select_from(photos)) or 0
+    try:
+        with engine.connect() as connection:
+            return connection.scalar(select(func.count()).select_from(photos)) or 0
+    finally:
+        engine.dispose()
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/apps/api/app/db/ingest_runs.py
+++ b/apps/api/app/db/ingest_runs.py
@@ -8,7 +8,7 @@ from uuid import uuid4
 from sqlalchemy import update
 from sqlalchemy.engine import Connection
 
-from app.db.session import create_session_factory
+from app.db.session import create_session_factory, dispose_session_factory
 from photoorg_db_schema import ingest_run_files, ingest_runs
 
 
@@ -23,6 +23,15 @@ class IngestRunFileOutcome:
 class IngestRunStore:
     def __init__(self, database_url: str | Path | None = None) -> None:
         self._session_factory = create_session_factory(database_url)
+
+    def close(self) -> None:
+        dispose_session_factory(self._session_factory)
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def create_run(
         self,

--- a/apps/api/app/db/queue.py
+++ b/apps/api/app/db/queue.py
@@ -11,7 +11,7 @@ from sqlalchemy import select, update
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
-from app.db.session import create_session_factory
+from app.db.session import create_session_factory, dispose_session_factory
 from photoorg_db_schema import ingest_queue
 
 PROCESSING_LEASE_SECONDS = 300
@@ -40,6 +40,15 @@ class EnqueueResult:
 class IngestQueueStore:
     def __init__(self, database_url: str | Path | None = None) -> None:
         self._session_factory = create_session_factory(database_url)
+
+    def close(self) -> None:
+        dispose_session_factory(self._session_factory)
+
+    def __del__(self) -> None:
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def enqueue(self, *, payload_type: str, payload: dict, idempotency_key: str) -> str:
         queue_id = str(uuid4())

--- a/apps/api/app/db/session.py
+++ b/apps/api/app/db/session.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import weakref
 from pathlib import Path
 
 from sqlalchemy import create_engine
@@ -14,6 +15,7 @@ def create_db_engine(database_url: str | Path | None = None) -> Engine:
     url = resolve_database_url(database_url)
     connect_args = {"check_same_thread": False} if url.startswith("sqlite") else {}
     engine = create_engine(url, future=True, connect_args=connect_args)
+    weakref.finalize(engine, engine.dispose)
     configure_embedding_column(engine)
     return engine
 
@@ -21,3 +23,9 @@ def create_db_engine(database_url: str | Path | None = None) -> Engine:
 def create_session_factory(database_url: str | Path | None = None) -> sessionmaker:
     engine = create_db_engine(database_url)
     return sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+def dispose_session_factory(factory: sessionmaker) -> None:
+    bind = factory.kw.get("bind")
+    if isinstance(bind, Engine):
+        bind.dispose()

--- a/apps/api/app/processing/ingest_polling.py
+++ b/apps/api/app/processing/ingest_polling.py
@@ -71,28 +71,31 @@ def reconcile_directory(
     grace_period_days = resolve_missing_file_grace_period_days(missing_file_grace_period_days)
 
     engine = create_db_engine(database_url)
-    with engine.begin() as connection:
-        watched_folder_id = ensure_watched_folder_exists(
-            connection,
-            scan_path=source_root.as_posix(),
-            now=at,
-        )
-        outcome = _reconcile_watched_folder_root(
-            connection,
-            watched_folder_id=watched_folder_id,
-            source_root=source_root,
-            canonical_path_for_relative_path=lambda relative_path: build_rooted_photo_path(
-                source_root,
-                relative_path,
-            ),
-            reuse_existing_photo_by_sha=False,
-            now=at,
-            missing_file_grace_period_days=grace_period_days,
-        )
-        result.scanned += outcome.scanned
-        result.inserted += outcome.inserted
-        result.updated += outcome.updated
-        result.errors.extend(outcome.error_messages)
+    try:
+        with engine.begin() as connection:
+            watched_folder_id = ensure_watched_folder_exists(
+                connection,
+                scan_path=source_root.as_posix(),
+                now=at,
+            )
+            outcome = _reconcile_watched_folder_root(
+                connection,
+                watched_folder_id=watched_folder_id,
+                source_root=source_root,
+                canonical_path_for_relative_path=lambda relative_path: build_rooted_photo_path(
+                    source_root,
+                    relative_path,
+                ),
+                reuse_existing_photo_by_sha=False,
+                now=at,
+                missing_file_grace_period_days=grace_period_days,
+            )
+            result.scanned += outcome.scanned
+            result.inserted += outcome.inserted
+            result.updated += outcome.updated
+            result.errors.extend(outcome.error_messages)
+    finally:
+        engine.dispose()
 
     return result
 
@@ -111,117 +114,121 @@ def poll_registered_storage_sources(
     engine = create_db_engine(database_url)
     run_store = IngestRunStore(database_url)
     queue_store = IngestQueueStore(database_url)
+    try:
+        with engine.begin() as connection:
+            targets = _load_registered_storage_source_targets(connection)
 
-    with engine.begin() as connection:
-        targets = _load_registered_storage_source_targets(connection)
-
-    for source_target in targets:
-        reason, detail, alias_root = _validate_registered_source_target(
-            storage_source_id=source_target.storage_source_id,
-            alias_paths=source_target.alias_paths,
-        )
-        if reason is not None:
-            with engine.begin() as connection:
-                for target in source_target.watched_folders:
-                    record_watched_folder_scan_failure(
-                        connection,
-                        watched_folder_id=target.watched_folder_id,
-                        reason=reason,
-                        now=at,
-                    )
-                    _record_ingest_run(
-                        run_store,
-                        connection=connection,
-                        watched_folder_id=target.watched_folder_id,
-                        status="failed",
-                        files_seen=0,
-                        files_created=0,
-                        files_updated=0,
-                        error_messages=(detail,),
-                    )
-            result.errors.append(f"storage_source:{source_target.storage_source_id}: {detail}")
-            continue
-
-        for target in source_target.watched_folders:
-            scan_root = _resolve_registered_scan_root(
-                alias_root=alias_root,
-                relative_path=target.relative_path,
+        for source_target in targets:
+            reason, detail, alias_root = _validate_registered_source_target(
+                storage_source_id=source_target.storage_source_id,
+                alias_paths=source_target.alias_paths,
             )
-            observed_relative_paths: set[str] = set()
-            touched_photo_ids: set[str] = set()
-            try:
-                _validate_scan_root(scan_root)
-                for chunk_paths in _iter_chunks(iter_photo_files(scan_root), chunk_size=poll_chunk_size):
-                    outcome: WatchedFolderPollOutcome
-                    chunk_touched_photo_ids: set[str]
-                    with engine.begin() as connection:
-                        outcome, chunk_touched_photo_ids = _process_watched_folder_chunk(
+            if reason is not None:
+                with engine.begin() as connection:
+                    for target in source_target.watched_folders:
+                        record_watched_folder_scan_failure(
                             connection,
                             watched_folder_id=target.watched_folder_id,
-                            source_root=scan_root,
-                            photo_paths=chunk_paths,
-                            canonical_path_for_relative_path=_registered_source_path_builder(
-                                storage_source_id=source_target.storage_source_id,
-                                watched_folder_relative_path=target.relative_path,
-                            ),
-                            reuse_existing_photo_by_sha=True,
+                            reason=reason,
                             now=at,
-                            observed_relative_paths=observed_relative_paths,
-                            queue_store=queue_store,
-                            storage_source_id=source_target.storage_source_id,
                         )
                         _record_ingest_run(
                             run_store,
                             connection=connection,
                             watched_folder_id=target.watched_folder_id,
-                            status=outcome.status,
-                            files_seen=outcome.scanned,
-                            files_created=outcome.inserted,
-                            files_updated=outcome.updated,
-                            error_messages=outcome.error_messages,
+                            status="failed",
+                            files_seen=0,
+                            files_created=0,
+                            files_updated=0,
+                            error_messages=(detail,),
                         )
-                    touched_photo_ids.update(chunk_touched_photo_ids)
-                    result.scanned += outcome.scanned
-                    result.enqueued += outcome.enqueued
-                    result.inserted += outcome.inserted
-                    result.updated += outcome.updated
-                    result.errors.extend(outcome.error_messages)
-                with engine.begin() as connection:
-                    _finalize_watched_folder_scan(
-                        connection,
-                        watched_folder_id=target.watched_folder_id,
-                        observed_relative_paths=observed_relative_paths,
-                        touched_photo_ids=touched_photo_ids,
-                        now=at,
-                        missing_file_grace_period_days=grace_period_days,
-                    )
-                    record_watched_folder_scan_success(
-                        connection,
-                        watched_folder_id=target.watched_folder_id,
-                        now=at,
-                    )
-            except Exception as exc:
-                with engine.begin() as connection:
-                    record_watched_folder_scan_failure(
-                        connection,
-                        watched_folder_id=target.watched_folder_id,
-                        reason=_classify_root_scan_failure(exc) if isinstance(exc, OSError) else "io_error",
-                        now=at,
-                    )
-                    _record_ingest_run(
-                        run_store,
-                        connection=connection,
-                        watched_folder_id=target.watched_folder_id,
-                        status="failed",
-                        files_seen=0,
-                        files_created=0,
-                        files_updated=0,
-                        error_messages=(str(exc),),
-                    )
-                result.errors.append(f"watched_folder:{target.watched_folder_id}: {exc}")
+                result.errors.append(f"storage_source:{source_target.storage_source_id}: {detail}")
                 continue
 
-    return result
+            for target in source_target.watched_folders:
+                scan_root = _resolve_registered_scan_root(
+                    alias_root=alias_root,
+                    relative_path=target.relative_path,
+                )
+                observed_relative_paths: set[str] = set()
+                touched_photo_ids: set[str] = set()
+                try:
+                    _validate_scan_root(scan_root)
+                    for chunk_paths in _iter_chunks(iter_photo_files(scan_root), chunk_size=poll_chunk_size):
+                        outcome: WatchedFolderPollOutcome
+                        chunk_touched_photo_ids: set[str]
+                        with engine.begin() as connection:
+                            outcome, chunk_touched_photo_ids = _process_watched_folder_chunk(
+                                connection,
+                                watched_folder_id=target.watched_folder_id,
+                                source_root=scan_root,
+                                photo_paths=chunk_paths,
+                                canonical_path_for_relative_path=_registered_source_path_builder(
+                                    storage_source_id=source_target.storage_source_id,
+                                    watched_folder_relative_path=target.relative_path,
+                                ),
+                                reuse_existing_photo_by_sha=True,
+                                now=at,
+                                observed_relative_paths=observed_relative_paths,
+                                queue_store=queue_store,
+                                storage_source_id=source_target.storage_source_id,
+                            )
+                            _record_ingest_run(
+                                run_store,
+                                connection=connection,
+                                watched_folder_id=target.watched_folder_id,
+                                status=outcome.status,
+                                files_seen=outcome.scanned,
+                                files_created=outcome.inserted,
+                                files_updated=outcome.updated,
+                                error_messages=outcome.error_messages,
+                            )
+                        touched_photo_ids.update(chunk_touched_photo_ids)
+                        result.scanned += outcome.scanned
+                        result.enqueued += outcome.enqueued
+                        result.inserted += outcome.inserted
+                        result.updated += outcome.updated
+                        result.errors.extend(outcome.error_messages)
+                    with engine.begin() as connection:
+                        _finalize_watched_folder_scan(
+                            connection,
+                            watched_folder_id=target.watched_folder_id,
+                            observed_relative_paths=observed_relative_paths,
+                            touched_photo_ids=touched_photo_ids,
+                            now=at,
+                            missing_file_grace_period_days=grace_period_days,
+                        )
+                        record_watched_folder_scan_success(
+                            connection,
+                            watched_folder_id=target.watched_folder_id,
+                            now=at,
+                        )
+                except Exception as exc:
+                    with engine.begin() as connection:
+                        record_watched_folder_scan_failure(
+                            connection,
+                            watched_folder_id=target.watched_folder_id,
+                            reason=_classify_root_scan_failure(exc) if isinstance(exc, OSError) else "io_error",
+                            now=at,
+                        )
+                        _record_ingest_run(
+                            run_store,
+                            connection=connection,
+                            watched_folder_id=target.watched_folder_id,
+                            status="failed",
+                            files_seen=0,
+                            files_created=0,
+                            files_updated=0,
+                            error_messages=(str(exc),),
+                        )
+                    result.errors.append(f"watched_folder:{target.watched_folder_id}: {exc}")
+                    continue
+
+        return result
+    finally:
+        queue_store.close()
+        run_store.close()
+        engine.dispose()
 
 
 def _validate_scan_root(root: Path) -> None:

--- a/apps/api/app/services/ingest_extraction_worker.py
+++ b/apps/api/app/services/ingest_extraction_worker.py
@@ -46,8 +46,11 @@ def process_candidate_payload(
     warnings: list[str] = []
 
     engine = create_db_engine(database_url)
-    with engine.begin() as connection:
-        existing_artifacts = lookup_existing_artifacts_by_sha(connection, sha256)
+    try:
+        with engine.begin() as connection:
+            existing_artifacts = lookup_existing_artifacts_by_sha(connection, sha256)
+    finally:
+        engine.dispose()
 
     if existing_artifacts is not None:
         try:

--- a/apps/api/app/services/ingest_queue_processor.py
+++ b/apps/api/app/services/ingest_queue_processor.py
@@ -47,6 +47,7 @@ def process_pending_ingest_queue(
     result = ProcessQueueResult()
 
     if not processable_rows:
+        queue_store.close()
         return result
 
     engine = create_db_engine(database_url)
@@ -61,26 +62,86 @@ def process_pending_ingest_queue(
     files_updated = 0
     error_messages: list[str] = []
     file_outcomes: list[str] = []
-    for row in processable_rows:
-        claimed_row = None
-        claimed_path = _file_outcome_path(row)
-        run_created_in_transaction = False
-        try:
-            with engine.begin() as connection:
-                claimed_row = queue_store.begin_processing_attempt(
-                    row.ingest_queue_id,
-                    connection=connection,
-                )
-                if claimed_row is None:
-                    continue
-                files_seen += 1
-                claimed_path = _file_outcome_path(claimed_row)
-                if claimed_row.payload_type not in {
-                    "photo_metadata",
-                    "ingest_candidate",
-                    "extracted_photo",
-                }:
-                    error_detail = f"Unsupported payload_type: {claimed_row.payload_type}"
+
+    try:
+        for row in processable_rows:
+            claimed_row = None
+            claimed_path = _file_outcome_path(row)
+            run_created_in_transaction = False
+            try:
+                with engine.begin() as connection:
+                    claimed_row = queue_store.begin_processing_attempt(
+                        row.ingest_queue_id,
+                        connection=connection,
+                    )
+                    if claimed_row is None:
+                        continue
+                    files_seen += 1
+                    claimed_path = _file_outcome_path(claimed_row)
+                    if claimed_row.payload_type not in {
+                        "photo_metadata",
+                        "ingest_candidate",
+                        "extracted_photo",
+                    }:
+                        error_detail = f"Unsupported payload_type: {claimed_row.payload_type}"
+                        ingest_run_id, run_created_in_transaction = _ensure_ingest_run(
+                            run_store,
+                            ingest_run_id,
+                            connection=connection,
+                        )
+                        run_store.append_file_outcome(
+                            ingest_run_id,
+                            IngestRunFileOutcome(
+                                ingest_queue_id=claimed_row.ingest_queue_id,
+                                path=claimed_path,
+                                outcome="failed",
+                                error_detail=error_detail,
+                            ),
+                            connection=connection,
+                        )
+                        queue_store.mark_failed(
+                            claimed_row.ingest_queue_id,
+                            error_detail,
+                            connection=connection,
+                        )
+                        file_outcomes.append("failed")
+                        failed += 1
+                        error_messages.append(error_detail)
+                        continue
+                    try:
+                        created, completion_warning = _process_claimed_row(
+                            database_url,
+                            queue_store,
+                            connection,
+                            claimed_row,
+                            detector=detector,
+                        )
+                    except (KeyError, TypeError, ValueError, CandidateFileMissingError) as exc:
+                        error_detail = str(exc)
+                        ingest_run_id, run_created_in_transaction = _ensure_ingest_run(
+                            run_store,
+                            ingest_run_id,
+                            connection=connection,
+                        )
+                        run_store.append_file_outcome(
+                            ingest_run_id,
+                            IngestRunFileOutcome(
+                                ingest_queue_id=claimed_row.ingest_queue_id,
+                                path=claimed_path,
+                                outcome="failed",
+                                error_detail=error_detail,
+                            ),
+                            connection=connection,
+                        )
+                        queue_store.mark_failed(
+                            claimed_row.ingest_queue_id,
+                            error_detail,
+                            connection=connection,
+                        )
+                        file_outcomes.append("failed")
+                        failed += 1
+                        error_messages.append(error_detail)
+                        continue
                     ingest_run_id, run_created_in_transaction = _ensure_ingest_run(
                         run_store,
                         ingest_run_id,
@@ -88,64 +149,6 @@ def process_pending_ingest_queue(
                     )
                     run_store.append_file_outcome(
                         ingest_run_id,
-                        IngestRunFileOutcome(
-                            ingest_queue_id=claimed_row.ingest_queue_id,
-                            path=claimed_path,
-                            outcome="failed",
-                            error_detail=error_detail,
-                        ),
-                        connection=connection,
-                    )
-                    queue_store.mark_failed(
-                        claimed_row.ingest_queue_id,
-                        error_detail,
-                        connection=connection,
-                    )
-                    file_outcomes.append("failed")
-                    failed += 1
-                    error_messages.append(error_detail)
-                    continue
-                try:
-                    created, completion_warning = _process_claimed_row(
-                        database_url,
-                        queue_store,
-                        connection,
-                        claimed_row,
-                        detector=detector,
-                    )
-                except (KeyError, TypeError, ValueError, CandidateFileMissingError) as exc:
-                    error_detail = str(exc)
-                    ingest_run_id, run_created_in_transaction = _ensure_ingest_run(
-                        run_store,
-                        ingest_run_id,
-                        connection=connection,
-                    )
-                    run_store.append_file_outcome(
-                        ingest_run_id,
-                        IngestRunFileOutcome(
-                            ingest_queue_id=claimed_row.ingest_queue_id,
-                            path=claimed_path,
-                            outcome="failed",
-                            error_detail=error_detail,
-                        ),
-                        connection=connection,
-                    )
-                    queue_store.mark_failed(
-                        claimed_row.ingest_queue_id,
-                        error_detail,
-                        connection=connection,
-                    )
-                    file_outcomes.append("failed")
-                    failed += 1
-                    error_messages.append(error_detail)
-                    continue
-                ingest_run_id, run_created_in_transaction = _ensure_ingest_run(
-                    run_store,
-                    ingest_run_id,
-                    connection=connection,
-                )
-                run_store.append_file_outcome(
-                    ingest_run_id,
                         IngestRunFileOutcome(
                             ingest_queue_id=claimed_row.ingest_queue_id,
                             path=_file_outcome_path(claimed_row),
@@ -154,75 +157,79 @@ def process_pending_ingest_queue(
                         ),
                         connection=connection,
                     )
-                queue_store.mark_completed(
-                    claimed_row.ingest_queue_id,
-                    last_error=completion_warning,
-                    connection=connection,
+                    queue_store.mark_completed(
+                        claimed_row.ingest_queue_id,
+                        last_error=completion_warning,
+                        connection=connection,
+                    )
+                    file_outcomes.append("completed")
+                    if created is True:
+                        files_created += 1
+                    elif created is False:
+                        files_updated += 1
+                    if completion_warning is not None:
+                        error_messages.append(completion_warning)
+                processed += 1
+            except IntegrityError as exc:
+                if run_created_in_transaction:
+                    ingest_run_id = None
+                error_detail = str(exc)
+                queue_store.record_permanent_failure(row.ingest_queue_id, error_detail)
+                ingest_run_id, _ = _ensure_ingest_run(run_store, ingest_run_id)
+                run_store.append_file_outcome(
+                    ingest_run_id,
+                    IngestRunFileOutcome(
+                        ingest_queue_id=row.ingest_queue_id,
+                        path=claimed_path,
+                        outcome="failed",
+                        error_detail=error_detail,
+                    ),
                 )
-                file_outcomes.append("completed")
-                if created is True:
-                    files_created += 1
-                elif created is False:
-                    files_updated += 1
-                if completion_warning is not None:
-                    error_messages.append(completion_warning)
-            processed += 1
-        except IntegrityError as exc:
-            if run_created_in_transaction:
-                ingest_run_id = None
-            error_detail = str(exc)
-            queue_store.record_permanent_failure(row.ingest_queue_id, error_detail)
-            ingest_run_id, _ = _ensure_ingest_run(run_store, ingest_run_id)
-            run_store.append_file_outcome(
-                ingest_run_id,
-                IngestRunFileOutcome(
-                    ingest_queue_id=row.ingest_queue_id,
-                    path=claimed_path,
-                    outcome="failed",
-                    error_detail=error_detail,
-                ),
-            )
-            file_outcomes.append("failed")
-            failed += 1
-            error_messages.append(error_detail)
-        except Exception as exc:
-            if run_created_in_transaction:
-                ingest_run_id = None
-            error_detail = str(exc)
-            queue_store.record_retryable_failure(row.ingest_queue_id, error_detail)
-            ingest_run_id, _ = _ensure_ingest_run(run_store, ingest_run_id)
-            run_store.append_file_outcome(
-                ingest_run_id,
-                IngestRunFileOutcome(
-                    ingest_queue_id=row.ingest_queue_id,
-                    path=claimed_path,
-                    outcome="retryable_error",
-                    error_detail=error_detail,
-                ),
-            )
-            file_outcomes.append("retryable_error")
-            retryable_errors += 1
-            error_messages.append(error_detail)
-            continue
+                file_outcomes.append("failed")
+                failed += 1
+                error_messages.append(error_detail)
+            except Exception as exc:
+                if run_created_in_transaction:
+                    ingest_run_id = None
+                error_detail = str(exc)
+                queue_store.record_retryable_failure(row.ingest_queue_id, error_detail)
+                ingest_run_id, _ = _ensure_ingest_run(run_store, ingest_run_id)
+                run_store.append_file_outcome(
+                    ingest_run_id,
+                    IngestRunFileOutcome(
+                        ingest_queue_id=row.ingest_queue_id,
+                        path=claimed_path,
+                        outcome="retryable_error",
+                        error_detail=error_detail,
+                    ),
+                )
+                file_outcomes.append("retryable_error")
+                retryable_errors += 1
+                error_messages.append(error_detail)
+                continue
 
-    if ingest_run_id is None:
-        return result
+        if ingest_run_id is None:
+            return result
 
-    run_store.finalize_run(
-        ingest_run_id,
-        status=_run_status(file_outcomes),
-        files_seen=files_seen,
-        files_created=files_created,
-        files_updated=files_updated,
-        error_count=len(error_messages),
-        error_summary=_error_summary(error_messages),
-    )
+        run_store.finalize_run(
+            ingest_run_id,
+            status=_run_status(file_outcomes),
+            files_seen=files_seen,
+            files_created=files_created,
+            files_updated=files_updated,
+            error_count=len(error_messages),
+            error_summary=_error_summary(error_messages),
+        )
 
-    return ProcessQueueResult(
-        processed=processed,
-        failed=failed,
-        retryable_errors=retryable_errors,
-    )
+        return ProcessQueueResult(
+            processed=processed,
+            failed=failed,
+            retryable_errors=retryable_errors,
+        )
+    finally:
+        run_store.close()
+        queue_store.close()
+        engine.dispose()
 
 
 def payload_to_photo_record(payload: dict) -> PhotoRecord:

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import weakref
+from typing import Any
+
+import sqlalchemy
+
+
+_ORIGINAL_CREATE_ENGINE = sqlalchemy.create_engine
+
+
+def _create_engine_with_dispose_finalizer(*args: Any, **kwargs: Any):
+    engine = _ORIGINAL_CREATE_ENGINE(*args, **kwargs)
+    weakref.finalize(engine, engine.dispose)
+    return engine
+
+
+sqlalchemy.create_engine = _create_engine_with_dispose_finalizer

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -2962,238 +2962,244 @@ class TestSeedCorpusSearchFixtureExecution:
         database_url = f"sqlite:///{tmp_path / 'search-fixtures.db'}"
         upgrade_database(database_url)
         engine = create_engine(database_url, future=True)
+        try:
+            with engine.begin() as connection:
+                _seed_search_fixture_catalog(connection)
 
-        with engine.begin() as connection:
-            _seed_search_fixture_catalog(connection)
+            request = SearchRequest.model_validate(fixture["request"])
+            expected_asset_ids = fixture["expected_asset_ids"]
+            asset_by_path = _asset_id_by_manifest_path()
 
-        request = SearchRequest.model_validate(fixture["request"])
-        expected_asset_ids = fixture["expected_asset_ids"]
-        asset_by_path = _asset_id_by_manifest_path()
+            with Session(engine) as session:
+                repo = PhotosRepository(session)
+                service = SearchService(repo=repo)
+                response = service.execute(request)
 
-        with Session(engine) as session:
-            repo = PhotosRepository(session)
-            service = SearchService(repo=repo)
-            response = service.execute(request)
+            returned_asset_ids = [asset_by_path[item.path] for item in response.hits.items]
 
-        returned_asset_ids = [asset_by_path[item.path] for item in response.hits.items]
-
-        assert set(returned_asset_ids) == set(expected_asset_ids)
-        assert response.hits.total == len(expected_asset_ids)
+            assert set(returned_asset_ids) == set(expected_asset_ids)
+            assert response.hits.total == len(expected_asset_ids)
+        finally:
+            engine.dispose()
 
     def test_search_repository_excludes_missing_file_rows_from_original_availability(self, tmp_path):
         database_url = f"sqlite:///{tmp_path / 'search-missing-original-availability.db'}"
         upgrade_database(database_url)
         engine = create_engine(database_url, future=True)
         now = datetime(2026, 3, 28, tzinfo=UTC)
+        try:
+            with engine.begin() as connection:
+                connection.execute(
+                    insert(storage_sources).values(
+                        storage_source_id="source-1",
+                        display_name="Family NAS",
+                        marker_filename=".photo-org-source.json",
+                        marker_version=1,
+                        availability_state="active",
+                        last_failure_reason=None,
+                        last_validated_ts=now,
+                        created_ts=now,
+                        updated_ts=now,
+                    )
+                )
+                connection.execute(
+                    insert(watched_folders).values(
+                        watched_folder_id="watched-folder-1",
+                        scan_path="/photos/seed-corpus",
+                        storage_source_id="source-1",
+                        relative_path=".",
+                        display_name="Family NAS / seed-corpus",
+                        is_enabled=1,
+                        availability_state="active",
+                        last_failure_reason=None,
+                        last_successful_scan_ts=now,
+                        created_ts=now,
+                        updated_ts=now,
+                    )
+                )
+                connection.execute(
+                    insert(photos).values(
+                        photo_id="photo-1",
+                        path="/photos/seed-corpus/family-events/birthday-park/birthday_park_001.jpg",
+                        sha256="e" * 64,
+                        phash=None,
+                        filesize=100,
+                        ext="jpg",
+                        created_ts=now,
+                        modified_ts=now,
+                        shot_ts=now,
+                        shot_ts_source=None,
+                        camera_make="Apple",
+                        camera_model=None,
+                        software=None,
+                        orientation=None,
+                        gps_latitude=None,
+                        gps_longitude=None,
+                        gps_altitude=None,
+                        thumbnail_jpeg=b"thumbnail-bytes",
+                        thumbnail_mime_type="image/jpeg",
+                        thumbnail_width=64,
+                        thumbnail_height=48,
+                        updated_ts=now,
+                        deleted_ts=None,
+                        faces_count=0,
+                        faces_detected_ts=None,
+                    )
+                )
+                connection.execute(
+                    insert(photo_files).values(
+                        photo_file_id="photo-file-1",
+                        photo_id="photo-1",
+                        watched_folder_id="watched-folder-1",
+                        relative_path="family-events/birthday-park/birthday_park_001.jpg",
+                        filename="birthday_park_001.jpg",
+                        extension="jpg",
+                        filesize=100,
+                        created_ts=now,
+                        modified_ts=now,
+                        first_seen_ts=now,
+                        last_seen_ts=now,
+                        missing_ts=now,
+                        deleted_ts=None,
+                        lifecycle_state="missing",
+                        absence_reason="path_removed",
+                    )
+                )
 
-        with engine.begin() as connection:
-            connection.execute(
-                insert(storage_sources).values(
-                    storage_source_id="source-1",
-                    display_name="Family NAS",
-                    marker_filename=".photo-org-source.json",
-                    marker_version=1,
-                    availability_state="active",
-                    last_failure_reason=None,
-                    last_validated_ts=now,
-                    created_ts=now,
-                    updated_ts=now,
+            with Session(engine) as session:
+                repo = PhotosRepository(session)
+                service = SearchService(repo=repo)
+                response = service.execute(
+                    SearchRequest(
+                        filters=SearchFilters(),
+                        sort=SortSpec(by="shot_ts", dir="desc"),
+                        page=PageSpec(limit=50),
+                    )
                 )
-            )
-            connection.execute(
-                insert(watched_folders).values(
-                    watched_folder_id="watched-folder-1",
-                    scan_path="/photos/seed-corpus",
-                    storage_source_id="source-1",
-                    relative_path=".",
-                    display_name="Family NAS / seed-corpus",
-                    is_enabled=1,
-                    availability_state="active",
-                    last_failure_reason=None,
-                    last_successful_scan_ts=now,
-                    created_ts=now,
-                    updated_ts=now,
-                )
-            )
-            connection.execute(
-                insert(photos).values(
-                    photo_id="photo-1",
-                    path="/photos/seed-corpus/family-events/birthday-park/birthday_park_001.jpg",
-                    sha256="e" * 64,
-                    phash=None,
-                    filesize=100,
-                    ext="jpg",
-                    created_ts=now,
-                    modified_ts=now,
-                    shot_ts=now,
-                    shot_ts_source=None,
-                    camera_make="Apple",
-                    camera_model=None,
-                    software=None,
-                    orientation=None,
-                    gps_latitude=None,
-                    gps_longitude=None,
-                    gps_altitude=None,
-                    thumbnail_jpeg=b"thumbnail-bytes",
-                    thumbnail_mime_type="image/jpeg",
-                    thumbnail_width=64,
-                    thumbnail_height=48,
-                    updated_ts=now,
-                    deleted_ts=None,
-                    faces_count=0,
-                    faces_detected_ts=None,
-                )
-            )
-            connection.execute(
-                insert(photo_files).values(
-                    photo_file_id="photo-file-1",
-                    photo_id="photo-1",
-                    watched_folder_id="watched-folder-1",
-                    relative_path="family-events/birthday-park/birthday_park_001.jpg",
-                    filename="birthday_park_001.jpg",
-                    extension="jpg",
-                    filesize=100,
-                    created_ts=now,
-                    modified_ts=now,
-                    first_seen_ts=now,
-                    last_seen_ts=now,
-                    missing_ts=now,
-                    deleted_ts=None,
-                    lifecycle_state="missing",
-                    absence_reason="path_removed",
-                )
-            )
 
-        with Session(engine) as session:
-            repo = PhotosRepository(session)
-            service = SearchService(repo=repo)
-            response = service.execute(
-                SearchRequest(
-                    filters=SearchFilters(),
-                    sort=SortSpec(by="shot_ts", dir="desc"),
-                    page=PageSpec(limit=50),
-                )
-            )
-
-        assert response.hits.total == 1
-        hit = response.hits.items[0]
-        assert hit.original is None
+            assert response.hits.total == 1
+            hit = response.hits.items[0]
+            assert hit.original is None
+        finally:
+            engine.dispose()
 
     def test_search_repository_prefers_watched_folder_health_over_storage_source_state(self, tmp_path):
         database_url = f"sqlite:///{tmp_path / 'search-watched-folder-availability-precedence.db'}"
         upgrade_database(database_url)
         engine = create_engine(database_url, future=True)
         now = datetime(2026, 3, 28, tzinfo=UTC)
+        try:
+            with engine.begin() as connection:
+                connection.execute(
+                    insert(storage_sources).values(
+                        storage_source_id="source-1",
+                        display_name="Family NAS",
+                        marker_filename=".photo-org-source.json",
+                        marker_version=1,
+                        availability_state="active",
+                        last_failure_reason=None,
+                        last_validated_ts=now,
+                        created_ts=now,
+                        updated_ts=now,
+                    )
+                )
+                connection.execute(
+                    insert(watched_folders).values(
+                        [
+                            {
+                                "watched_folder_id": "watched-folder-healthy",
+                                "scan_path": "/photos/healthy",
+                                "storage_source_id": "source-1",
+                                "relative_path": "healthy",
+                                "display_name": "Healthy Folder",
+                                "is_enabled": 1,
+                                "availability_state": "active",
+                                "last_failure_reason": None,
+                                "last_successful_scan_ts": now,
+                                "created_ts": now,
+                                "updated_ts": now,
+                            },
+                            {
+                                "watched_folder_id": "watched-folder-unreachable",
+                                "scan_path": "/photos/offline",
+                                "storage_source_id": "source-1",
+                                "relative_path": "offline",
+                                "display_name": "Offline Folder",
+                                "is_enabled": 1,
+                                "availability_state": "unreachable",
+                                "last_failure_reason": "permission_denied",
+                                "last_successful_scan_ts": now,
+                                "created_ts": now,
+                                "updated_ts": now,
+                            },
+                        ]
+                    )
+                )
+                connection.execute(
+                    insert(photos).values(
+                        photo_id="photo-1",
+                        path="/photos/offline/family-events/birthday-park/birthday_park_001.jpg",
+                        sha256="f" * 64,
+                        phash=None,
+                        filesize=100,
+                        ext="jpg",
+                        created_ts=now,
+                        modified_ts=now,
+                        shot_ts=now,
+                        shot_ts_source=None,
+                        camera_make="Apple",
+                        camera_model=None,
+                        software=None,
+                        orientation=None,
+                        gps_latitude=None,
+                        gps_longitude=None,
+                        gps_altitude=None,
+                        thumbnail_jpeg=b"thumbnail-bytes",
+                        thumbnail_mime_type="image/jpeg",
+                        thumbnail_width=64,
+                        thumbnail_height=48,
+                        updated_ts=now,
+                        deleted_ts=None,
+                        faces_count=0,
+                        faces_detected_ts=None,
+                    )
+                )
+                connection.execute(
+                    insert(photo_files).values(
+                        photo_file_id="photo-file-1",
+                        photo_id="photo-1",
+                        watched_folder_id="watched-folder-unreachable",
+                        relative_path="family-events/birthday-park/birthday_park_001.jpg",
+                        filename="birthday_park_001.jpg",
+                        extension="jpg",
+                        filesize=100,
+                        created_ts=now,
+                        modified_ts=now,
+                        first_seen_ts=now,
+                        last_seen_ts=now,
+                        missing_ts=None,
+                        deleted_ts=None,
+                        lifecycle_state="active",
+                        absence_reason=None,
+                    )
+                )
 
-        with engine.begin() as connection:
-            connection.execute(
-                insert(storage_sources).values(
-                    storage_source_id="source-1",
-                    display_name="Family NAS",
-                    marker_filename=".photo-org-source.json",
-                    marker_version=1,
-                    availability_state="active",
-                    last_failure_reason=None,
-                    last_validated_ts=now,
-                    created_ts=now,
-                    updated_ts=now,
+            with Session(engine) as session:
+                repo = PhotosRepository(session)
+                service = SearchService(repo=repo)
+                response = service.execute(
+                    SearchRequest(
+                        filters=SearchFilters(),
+                        sort=SortSpec(by="shot_ts", dir="desc"),
+                        page=PageSpec(limit=50),
+                    )
                 )
-            )
-            connection.execute(
-                insert(watched_folders).values(
-                    [
-                        {
-                            "watched_folder_id": "watched-folder-healthy",
-                            "scan_path": "/photos/healthy",
-                            "storage_source_id": "source-1",
-                            "relative_path": "healthy",
-                            "display_name": "Healthy Folder",
-                            "is_enabled": 1,
-                            "availability_state": "active",
-                            "last_failure_reason": None,
-                            "last_successful_scan_ts": now,
-                            "created_ts": now,
-                            "updated_ts": now,
-                        },
-                        {
-                            "watched_folder_id": "watched-folder-unreachable",
-                            "scan_path": "/photos/offline",
-                            "storage_source_id": "source-1",
-                            "relative_path": "offline",
-                            "display_name": "Offline Folder",
-                            "is_enabled": 1,
-                            "availability_state": "unreachable",
-                            "last_failure_reason": "permission_denied",
-                            "last_successful_scan_ts": now,
-                            "created_ts": now,
-                            "updated_ts": now,
-                        },
-                    ]
-                )
-            )
-            connection.execute(
-                insert(photos).values(
-                    photo_id="photo-1",
-                    path="/photos/offline/family-events/birthday-park/birthday_park_001.jpg",
-                    sha256="f" * 64,
-                    phash=None,
-                    filesize=100,
-                    ext="jpg",
-                    created_ts=now,
-                    modified_ts=now,
-                    shot_ts=now,
-                    shot_ts_source=None,
-                    camera_make="Apple",
-                    camera_model=None,
-                    software=None,
-                    orientation=None,
-                    gps_latitude=None,
-                    gps_longitude=None,
-                    gps_altitude=None,
-                    thumbnail_jpeg=b"thumbnail-bytes",
-                    thumbnail_mime_type="image/jpeg",
-                    thumbnail_width=64,
-                    thumbnail_height=48,
-                    updated_ts=now,
-                    deleted_ts=None,
-                    faces_count=0,
-                    faces_detected_ts=None,
-                )
-            )
-            connection.execute(
-                insert(photo_files).values(
-                    photo_file_id="photo-file-1",
-                    photo_id="photo-1",
-                    watched_folder_id="watched-folder-unreachable",
-                    relative_path="family-events/birthday-park/birthday_park_001.jpg",
-                    filename="birthday_park_001.jpg",
-                    extension="jpg",
-                    filesize=100,
-                    created_ts=now,
-                    modified_ts=now,
-                    first_seen_ts=now,
-                    last_seen_ts=now,
-                    missing_ts=None,
-                    deleted_ts=None,
-                    lifecycle_state="active",
-                    absence_reason=None,
-                )
-            )
 
-        with Session(engine) as session:
-            repo = PhotosRepository(session)
-            service = SearchService(repo=repo)
-            response = service.execute(
-                SearchRequest(
-                    filters=SearchFilters(),
-                    sort=SortSpec(by="shot_ts", dir="desc"),
-                    page=PageSpec(limit=50),
-                )
-            )
-
-        assert response.hits.total == 1
-        hit = response.hits.items[0]
-        assert hit.original is not None
-        assert hit.original.is_available is False
-        assert hit.original.availability_state == "unreachable"
-        assert hit.original.last_failure_reason == "permission_denied"
+            assert response.hits.total == 1
+            hit = response.hits.items[0]
+            assert hit.original is not None
+            assert hit.original.is_available is False
+            assert hit.original.availability_state == "unreachable"
+            assert hit.original.last_failure_reason == "permission_denied"
+        finally:
+            engine.dispose()


### PR DESCRIPTION
## Summary
This hotfix removes SQLite connection lifecycle leaks that were surfacing as `ResourceWarning: unclosed database` during `make pre-push`.

## Root Cause
Several code and test paths created SQLAlchemy engines/session factories without deterministic disposal. Under Python 3.14 warning handling, those lingering sqlite3 connections were finalized at GC/unraisable-exception time.

## Changes
- Added deterministic cleanup (`engine.dispose()` / store close paths) in CLI and ingest runtime workflows.
- Added session-factory disposal support and applied it to queue/run stores.
- Added engine finalizers for app-created engines and test-created engines to ensure teardown safety.
- Updated `test_search_service` fixture execution tests to explicitly dispose local engines.

## Impact
- Eliminates noisy unclosed SQLite warnings in pre-push checks.
- Preserves existing ingest/search behavior (validated by targeted regressions and full suite).

## Validation
- `uv run pytest -q 'tests/test_search_service.py::TestSeedCorpusSearchFixtureExecution::test_search_fixture_execution_matches_expected_asset_ids[SF01]' -W error`
- `uv run pytest -q tests/test_cli.py::test_poll_storage_sources_cli_scans_registered_watched_folders -W error`
- `uv run pytest -q tests/test_ingest.py::test_ingest_directory_keeps_queue_only_behavior -W error`
- `make pre-push` (332 passed)
