### PR TITLE
feat(api): implement face label correction and reassignment workflow (#43)

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -27,7 +27,7 @@ app = FastAPI(
         },
         {
             "name": "face-labeling",
-            "description": "Assign detected faces to people identities.",
+            "description": "Assign and correct detected face-to-person associations.",
         },
         {
             "name": "search",

--- a/apps/api/app/routers/face_assignments.py
+++ b/apps/api/app/routers/face_assignments.py
@@ -9,9 +9,12 @@ from sqlalchemy.orm import Session
 from app.dependencies import get_db
 from app.services.face_assignment import (
     FaceAlreadyAssignedError,
+    FaceAlreadyAssignedToPersonError,
+    FaceNotAssignedError,
     FaceNotFoundError,
     PersonNotFoundError,
     assign_face_to_person,
+    reassign_face_to_person,
 )
 
 
@@ -48,6 +51,19 @@ class FaceAssignmentResponse(BaseModel):
     person_id: str
 
 
+class FaceCorrectionResponse(BaseModel):
+    """Correction result for one face reassigned to a different person."""
+
+    model_config = ConfigDict(
+        json_schema_extra={"description": "Resolved face reassignment details."}
+    )
+
+    face_id: str
+    photo_id: str
+    previous_person_id: str
+    person_id: str
+
+
 @router.post(
     "/{face_id}/assignments",
     summary="Assign face to person",
@@ -79,3 +95,41 @@ def assign_face_to_person_endpoint(
 
     db.commit()
     return FaceAssignmentResponse.model_validate(assignment)
+
+
+@router.post(
+    "/{face_id}/corrections",
+    summary="Correct face assignment",
+    description="Reassign an already-labeled face to a different person identity.",
+    response_model=FaceCorrectionResponse,
+    responses={
+        status.HTTP_404_NOT_FOUND: {"description": "Face or person not found"},
+        status.HTTP_409_CONFLICT: {
+            "description": "Face is unassigned or already assigned to the requested person"
+        },
+    },
+)
+def correct_face_assignment_endpoint(
+    face_id: str,
+    body: AssignFaceRequest,
+    db: Session = Depends(get_db),
+) -> FaceCorrectionResponse:
+    try:
+        correction = reassign_face_to_person(
+            db.connection(),
+            face_id=face_id,
+            person_id=body.person_id,
+        )
+    except FaceNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except PersonNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except FaceNotAssignedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except FaceAlreadyAssignedToPersonError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except FaceAlreadyAssignedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    db.commit()
+    return FaceCorrectionResponse.model_validate(correction)

--- a/apps/api/app/services/face_assignment.py
+++ b/apps/api/app/services/face_assignment.py
@@ -18,6 +18,14 @@ class FaceAlreadyAssignedError(RuntimeError):
     pass
 
 
+class FaceNotAssignedError(RuntimeError):
+    pass
+
+
+class FaceAlreadyAssignedToPersonError(RuntimeError):
+    pass
+
+
 def assign_face_to_person(
     connection: Connection,
     *,
@@ -52,6 +60,50 @@ def assign_face_to_person(
         raise PersonNotFoundError("Person not found")
 
     raise FaceAlreadyAssignedError("Face already assigned")
+
+
+def reassign_face_to_person(
+    connection: Connection,
+    *,
+    face_id: str,
+    person_id: str,
+) -> dict[str, str]:
+    row = _face_row(connection, face_id)
+    if row is None:
+        raise FaceNotFoundError("Face not found")
+
+    previous_person_id = row["person_id"]
+    if previous_person_id is None:
+        raise FaceNotAssignedError("Face is not assigned")
+    if previous_person_id == person_id:
+        raise FaceAlreadyAssignedToPersonError("Face already assigned to person")
+
+    person_exists = (
+        connection.execute(
+            select(people.c.person_id).where(people.c.person_id == person_id)
+        ).scalar_one_or_none()
+        is not None
+    )
+    if not person_exists:
+        raise PersonNotFoundError("Person not found")
+
+    result = connection.execute(
+        update(faces)
+        .where(
+            faces.c.face_id == face_id,
+            faces.c.person_id == previous_person_id,
+        )
+        .values(person_id=person_id)
+    )
+    if result.rowcount != 1:
+        raise FaceAlreadyAssignedError("Face assignment changed; retry correction")
+
+    return {
+        "face_id": row["face_id"],
+        "photo_id": row["photo_id"],
+        "previous_person_id": previous_person_id,
+        "person_id": person_id,
+    }
 
 
 def _face_row(connection: Connection, face_id: str):

--- a/apps/api/tests/test_face_assignment_api.py
+++ b/apps/api/tests/test_face_assignment_api.py
@@ -294,6 +294,248 @@ def test_face_assignment_api_returns_409_when_reassigning_to_same_person(tmp_pat
     assert response.json()["detail"] == "Face already assigned"
 
 
+def test_face_correction_api_reassigns_assigned_face_to_different_person(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-correct-reassign.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        _insert_person(connection, person_id="person-2", display_name="John Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/corrections",
+        json={"person_id": "person-2"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "face_id": "face-1",
+        "photo_id": "photo-1",
+        "previous_person_id": "person-1",
+        "person_id": "person-2",
+    }
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id == "person-2"
+
+
+def test_face_correction_api_does_not_create_face_label_records_in_issue_43_slice(
+    tmp_path, monkeypatch
+):
+    database_url = _database_url(tmp_path, "face-correct-no-face-label-write.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        _insert_person(connection, person_id="person-2", display_name="John Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/corrections",
+        json={"person_id": "person-2"},
+    )
+
+    assert response.status_code == 200
+    with engine.connect() as connection:
+        face_label_count = connection.execute(select(face_labels.c.face_label_id)).all()
+    assert face_label_count == []
+
+
+def test_face_correction_api_returns_404_for_missing_face(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-correct-missing-face.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/missing-face/corrections",
+        json={"person_id": "person-1"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Face not found"
+
+
+def test_face_correction_api_returns_404_for_missing_person(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-correct-missing-person.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/corrections",
+        json={"person_id": "missing-person"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Person not found"
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id == "person-1"
+
+
+def test_face_correction_api_returns_409_when_face_is_unassigned(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-correct-unassigned.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/corrections",
+        json={"person_id": "person-1"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Face is not assigned"
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id is None
+
+
+def test_face_correction_api_returns_409_when_reassigning_to_same_person(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-correct-same-person-conflict.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/corrections",
+        json={"person_id": "person-1"},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Face already assigned to person"
+
+
+def test_face_correction_api_returns_422_for_blank_person_id(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-correct-blank-person-id.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/corrections",
+        json={"person_id": "   "},
+    )
+
+    assert response.status_code == 422
+    assert any(error["loc"][-1] == "person_id" for error in response.json()["detail"])
+
+
+def test_face_correction_api_returns_422_for_missing_person_id(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-correct-missing-person-id.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/corrections",
+        json={},
+    )
+
+    assert response.status_code == 422
+    assert any(error["loc"][-1] == "person_id" for error in response.json()["detail"])
+
+
 def test_photo_detail_api_includes_face_id_for_assignment_workflow(tmp_path, monkeypatch):
     database_url = _database_url(tmp_path, "face-assign-photo-detail.db")
     upgrade_database(database_url)
@@ -349,4 +591,5 @@ def test_openapi_schema_includes_face_assignment_path_and_tag(tmp_path, monkeypa
     schema = client.get("/openapi.json").json()
 
     assert "/api/v1/faces/{face_id}/assignments" in schema["paths"]
+    assert "/api/v1/faces/{face_id}/corrections" in schema["paths"]
     assert any(tag["name"] == "face-labeling" for tag in schema["tags"])

--- a/docs/adr/0016-introduce-face-assignment-correction-api-workflow.md
+++ b/docs/adr/0016-introduce-face-assignment-correction-api-workflow.md
@@ -1,0 +1,54 @@
+# ADR-0016: Introduce Face Assignment Correction API Workflow
+
+- Status: Proposed
+- Date: 2026-04-25
+
+## Context
+
+Issue #42 introduced first-pass face assignment with conservative semantics:
+
+- `POST /api/v1/faces/{face_id}/assignments`
+- assign only when `faces.person_id IS NULL`
+- reject already-assigned faces with `409 Conflict`
+
+That behavior preserved a clean boundary for the next workflow slice: explicit correction and reassignment of already-labeled faces (Issue #43).
+
+The system needs a deterministic way to fix incorrect labels without changing the initial-assignment contract and without prematurely implementing provenance-event persistence that belongs to Issue #44.
+
+## Decision
+
+Add a dedicated correction endpoint:
+
+- `POST /api/v1/faces/{face_id}/corrections`
+
+Request shape:
+
+- `{ "person_id": "<id>" }`
+
+Behavior:
+
+- require the face to exist
+- require the face to already be assigned (`faces.person_id IS NOT NULL`)
+- require the target person to exist
+- reject no-op corrections when the face is already assigned to the requested person
+- update `faces.person_id` to the new person on success
+- return `200 OK` with `{face_id, photo_id, previous_person_id, person_id}`
+
+Failure semantics:
+
+- `404 Not Found` for missing face or person
+- `409 Conflict` for unassigned faces or no-op same-person corrections
+
+## Consequences
+
+- Initial assignment and correction are separate operations with separate intent.
+- Callers can keep using assignment for unlabeled faces while using correction for reassignment.
+- Responses include `previous_person_id`, giving clients explicit correction context.
+- This slice intentionally keeps writing confined to `faces.person_id`; it does not create `face_labels` provenance events.
+- Provenance and label-source persistence remains deferred to Issue #44.
+
+## Alternatives Considered
+
+- Allow in-place reassignment through `POST /assignments`
+- Add correction by overloading existing assignment conflict behavior
+- Start writing correction history directly to `face_labels` in this issue


### PR DESCRIPTION
## Summary
- add a dedicated correction endpoint for face reassignment: `POST /api/v1/faces/{face_id}/corrections`
- keep assignment and correction as separate workflows with explicit `404/409` semantics
- add service-level correction logic with conflict handling for unassigned and same-person no-op cases
- add API tests for reassignment success, not-found/conflict/validation behavior, OpenAPI path coverage, and no `face_labels` writes in this slice
- document the design boundary in ADR-0016

## Verification
- `uv run python -m pytest apps/api/tests/test_face_assignment_api.py -q`
- `uv run python -m pytest apps/api/tests/test_main.py apps/api/tests/test_openapi_docs.py -q`
- `uv run python -m pytest apps/api/tests -q`

Closes #43