### PR TITLE
[codex] Persist explicit label provenance and assignment source

### DIFF
--- a/apps/api/app/services/face_assignment.py
+++ b/apps/api/app/services/face_assignment.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from sqlalchemy import select, update
+from uuid import uuid4
+
+from sqlalchemy import insert, select, update
 from sqlalchemy.engine import Connection
 
-from app.storage import faces, people
+from app.storage import face_labels, faces, people
 
 
 class FaceNotFoundError(LookupError):
@@ -26,6 +28,9 @@ class FaceAlreadyAssignedToPersonError(RuntimeError):
     pass
 
 
+_MANUAL_LABEL_SOURCE = "manual"
+
+
 def assign_face_to_person(
     connection: Connection,
     *,
@@ -42,7 +47,14 @@ def assign_face_to_person(
         .values(person_id=person_id)
     )
     if result.rowcount == 1:
-        return _face_assignment(connection, face_id)
+        assignment = _face_assignment(connection, face_id)
+        _persist_face_label_event(
+            connection,
+            face_id=face_id,
+            person_id=person_id,
+            action="assignment",
+        )
+        return assignment
 
     row = _face_row(connection, face_id)
     if row is None:
@@ -98,6 +110,14 @@ def reassign_face_to_person(
     if result.rowcount != 1:
         raise FaceAlreadyAssignedError("Face assignment changed; retry correction")
 
+    _persist_face_label_event(
+        connection,
+        face_id=face_id,
+        person_id=person_id,
+        action="correction",
+        previous_person_id=previous_person_id,
+    )
+
     return {
         "face_id": row["face_id"],
         "photo_id": row["photo_id"],
@@ -132,3 +152,32 @@ def _face_assignment(connection: Connection, face_id: str) -> dict[str, str]:
         "photo_id": row["photo_id"],
         "person_id": person_id,
     }
+
+
+def _persist_face_label_event(
+    connection: Connection,
+    *,
+    face_id: str,
+    person_id: str,
+    action: str,
+    previous_person_id: str | None = None,
+) -> None:
+    provenance: dict[str, object] = {
+        "workflow": "face-labeling",
+        "surface": "api",
+        "action": action,
+    }
+    if previous_person_id is not None:
+        provenance["previous_person_id"] = previous_person_id
+
+    connection.execute(
+        insert(face_labels).values(
+            face_label_id=str(uuid4()),
+            face_id=face_id,
+            person_id=person_id,
+            label_source=_MANUAL_LABEL_SOURCE,
+            confidence=None,
+            model_version=None,
+            provenance=provenance,
+        )
+    )

--- a/apps/api/tests/test_face_assignment_api.py
+++ b/apps/api/tests/test_face_assignment_api.py
@@ -84,7 +84,7 @@ def test_face_assignment_api_assigns_unlabeled_face_to_existing_person(tmp_path,
     assert persisted_person_id == "person-1"
 
 
-def test_face_assignment_api_does_not_create_face_label_records_in_issue_42_slice(
+def test_face_assignment_api_persists_manual_face_label_provenance(
     tmp_path, monkeypatch
 ):
     database_url = _database_url(tmp_path, "face-assign-no-face-label-write.db")
@@ -112,8 +112,27 @@ def test_face_assignment_api_does_not_create_face_label_records_in_issue_42_slic
 
     assert response.status_code == 201
     with engine.connect() as connection:
-        face_label_count = connection.execute(select(face_labels.c.face_label_id)).all()
-    assert face_label_count == []
+        face_label_rows = connection.execute(
+            select(
+                face_labels.c.face_id,
+                face_labels.c.person_id,
+                face_labels.c.label_source,
+                face_labels.c.confidence,
+                face_labels.c.model_version,
+                face_labels.c.provenance,
+            )
+        ).mappings().all()
+    assert len(face_label_rows) == 1
+    assert face_label_rows[0]["face_id"] == "face-1"
+    assert face_label_rows[0]["person_id"] == "person-1"
+    assert face_label_rows[0]["label_source"] == "manual"
+    assert face_label_rows[0]["confidence"] is None
+    assert face_label_rows[0]["model_version"] is None
+    assert face_label_rows[0]["provenance"] == {
+        "workflow": "face-labeling",
+        "surface": "api",
+        "action": "assignment",
+    }
 
 
 def test_face_assignment_api_returns_404_for_missing_face(tmp_path, monkeypatch):
@@ -333,9 +352,7 @@ def test_face_correction_api_reassigns_assigned_face_to_different_person(tmp_pat
     assert persisted_person_id == "person-2"
 
 
-def test_face_correction_api_does_not_create_face_label_records_in_issue_43_slice(
-    tmp_path, monkeypatch
-):
+def test_face_correction_api_persists_manual_face_label_provenance(tmp_path, monkeypatch):
     database_url = _database_url(tmp_path, "face-correct-no-face-label-write.db")
     upgrade_database(database_url)
     monkeypatch.setenv("DATABASE_URL", database_url)
@@ -362,8 +379,28 @@ def test_face_correction_api_does_not_create_face_label_records_in_issue_43_slic
 
     assert response.status_code == 200
     with engine.connect() as connection:
-        face_label_count = connection.execute(select(face_labels.c.face_label_id)).all()
-    assert face_label_count == []
+        face_label_rows = connection.execute(
+            select(
+                face_labels.c.face_id,
+                face_labels.c.person_id,
+                face_labels.c.label_source,
+                face_labels.c.confidence,
+                face_labels.c.model_version,
+                face_labels.c.provenance,
+            )
+        ).mappings().all()
+    assert len(face_label_rows) == 1
+    assert face_label_rows[0]["face_id"] == "face-1"
+    assert face_label_rows[0]["person_id"] == "person-2"
+    assert face_label_rows[0]["label_source"] == "manual"
+    assert face_label_rows[0]["confidence"] is None
+    assert face_label_rows[0]["model_version"] is None
+    assert face_label_rows[0]["provenance"] == {
+        "workflow": "face-labeling",
+        "surface": "api",
+        "action": "correction",
+        "previous_person_id": "person-1",
+    }
 
 
 def test_face_correction_api_returns_404_for_missing_face(tmp_path, monkeypatch):

--- a/docs/adr/0017-persist-face-label-provenance-for-manual-api-labeling.md
+++ b/docs/adr/0017-persist-face-label-provenance-for-manual-api-labeling.md
@@ -1,0 +1,39 @@
+# ADR-0017: Persist Face Label Provenance For Manual API Labeling
+
+- Status: Proposed
+- Date: 2026-04-26
+
+## Context
+
+Issue #42 introduced conservative face assignment and Issue #43 added explicit correction and reassignment. Both slices intentionally only updated `faces.person_id` and deferred provenance writes to Issue #44.
+
+The schema already includes a `face_labels` table with provenance-oriented fields (`label_source`, `confidence`, `model_version`, `provenance`). Without writing label events, manual labeling actions are not audit-friendly and later policy work (#45) has no persisted source trail to enforce.
+
+## Decision
+
+Persist one `face_labels` event row for each successful manual API labeling action:
+
+- assignment endpoint (`POST /api/v1/faces/{face_id}/assignments`)
+- correction endpoint (`POST /api/v1/faces/{face_id}/corrections`)
+
+Event persistence rules:
+
+- continue using `faces.person_id` as the current resolved label
+- append one `face_labels` row after each successful write
+- set `label_source = "manual"` for these API actions
+- set `confidence` and `model_version` to `NULL` for manual writes
+- persist `provenance` JSON with operation metadata (`workflow`, `surface`, `action`)
+- include `previous_person_id` in correction provenance
+
+## Consequences
+
+- Manual labeling operations now produce durable provenance events.
+- Reassignment history is captured as append-only events in `face_labels`.
+- Existing assignment and correction API request/response contracts remain stable.
+- Issue #45 can enforce policy distinctions (human-confirmed vs machine-applied) on top of persisted source metadata rather than inferred behavior.
+
+## Alternatives Considered
+
+- Keep provenance implicit in endpoint behavior and avoid writing `face_labels`
+- Replace `faces.person_id` with `face_labels` as the only source of current truth in this slice
+- Add machine-label policy enforcement in this issue


### PR DESCRIPTION
## Summary
- persist explicit manual label provenance events for face assignment and correction workflows
- append `face_labels` rows on successful assignment/correction while preserving `faces.person_id` as the resolved current label
- document the #44 slice boundary and decisions in ADR-0017

## Why
Issue #44 requires explicit persistence of label provenance and assignment source so downstream policy and audit behavior can rely on durable data.

## What Changed
- service logic now writes `face_labels` with `label_source="manual"`, null confidence/model version, and operation provenance metadata
- correction provenance includes `previous_person_id`
- assignment/correction API tests now assert provenance-event persistence instead of asserting no `face_labels` writes
- added ADR: `docs/adr/0017-persist-face-label-provenance-for-manual-api-labeling.md`

## Validation
- `uv run python -m pytest apps/api/tests/test_face_assignment_api.py -q`
- `uv run python -m pytest apps/api/tests/test_people_api.py -q`
- `uv run python -m pytest apps/api/tests -q`

Closes #44