### PR TITLE
[codex] Enforce separation of human-confirmed and machine-applied labels

### DIFF
--- a/apps/api/alembic/versions/20260321_000001_initial_schema.py
+++ b/apps/api/alembic/versions/20260321_000001_initial_schema.py
@@ -202,6 +202,10 @@ def upgrade() -> None:
         sa.Column("provenance", sa.JSON(), nullable=True),
         sa.Column("created_ts", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
         sa.Column("updated_ts", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.CheckConstraint(
+            "label_source IN ('human_confirmed', 'machine_applied')",
+            name="ck_face_labels_label_source",
+        ),
     )
     op.create_index("idx_face_labels_face_id", "face_labels", ["face_id"], unique=False)
     op.create_index("idx_face_labels_person_id", "face_labels", ["person_id"], unique=False)

--- a/apps/api/app/services/face_assignment.py
+++ b/apps/api/app/services/face_assignment.py
@@ -5,6 +5,8 @@ from uuid import uuid4
 from sqlalchemy import insert, select, update
 from sqlalchemy.engine import Connection
 
+from photoorg_db_schema import FACE_LABEL_SOURCE_HUMAN_CONFIRMED
+
 from app.storage import face_labels, faces, people
 
 
@@ -26,9 +28,6 @@ class FaceNotAssignedError(RuntimeError):
 
 class FaceAlreadyAssignedToPersonError(RuntimeError):
     pass
-
-
-_MANUAL_LABEL_SOURCE = "manual"
 
 
 def assign_face_to_person(
@@ -175,7 +174,7 @@ def _persist_face_label_event(
             face_label_id=str(uuid4()),
             face_id=face_id,
             person_id=person_id,
-            label_source=_MANUAL_LABEL_SOURCE,
+            label_source=FACE_LABEL_SOURCE_HUMAN_CONFIRMED,
             confidence=None,
             model_version=None,
             provenance=provenance,

--- a/apps/api/tests/test_face_assignment_api.py
+++ b/apps/api/tests/test_face_assignment_api.py
@@ -84,7 +84,7 @@ def test_face_assignment_api_assigns_unlabeled_face_to_existing_person(tmp_path,
     assert persisted_person_id == "person-1"
 
 
-def test_face_assignment_api_persists_manual_face_label_provenance(
+def test_face_assignment_api_persists_human_confirmed_face_label_provenance(
     tmp_path, monkeypatch
 ):
     database_url = _database_url(tmp_path, "face-assign-no-face-label-write.db")
@@ -125,7 +125,7 @@ def test_face_assignment_api_persists_manual_face_label_provenance(
     assert len(face_label_rows) == 1
     assert face_label_rows[0]["face_id"] == "face-1"
     assert face_label_rows[0]["person_id"] == "person-1"
-    assert face_label_rows[0]["label_source"] == "manual"
+    assert face_label_rows[0]["label_source"] == "human_confirmed"
     assert face_label_rows[0]["confidence"] is None
     assert face_label_rows[0]["model_version"] is None
     assert face_label_rows[0]["provenance"] == {
@@ -352,7 +352,7 @@ def test_face_correction_api_reassigns_assigned_face_to_different_person(tmp_pat
     assert persisted_person_id == "person-2"
 
 
-def test_face_correction_api_persists_manual_face_label_provenance(tmp_path, monkeypatch):
+def test_face_correction_api_persists_human_confirmed_face_label_provenance(tmp_path, monkeypatch):
     database_url = _database_url(tmp_path, "face-correct-no-face-label-write.db")
     upgrade_database(database_url)
     monkeypatch.setenv("DATABASE_URL", database_url)
@@ -392,7 +392,7 @@ def test_face_correction_api_persists_manual_face_label_provenance(tmp_path, mon
     assert len(face_label_rows) == 1
     assert face_label_rows[0]["face_id"] == "face-1"
     assert face_label_rows[0]["person_id"] == "person-2"
-    assert face_label_rows[0]["label_source"] == "manual"
+    assert face_label_rows[0]["label_source"] == "human_confirmed"
     assert face_label_rows[0]["confidence"] is None
     assert face_label_rows[0]["model_version"] is None
     assert face_label_rows[0]["provenance"] == {

--- a/apps/api/tests/test_migrations.py
+++ b/apps/api/tests/test_migrations.py
@@ -1,13 +1,16 @@
 import importlib.util
 import shutil
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 
-from sqlalchemy import create_engine, func, inspect, select
+import pytest
+from sqlalchemy import create_engine, func, inspect, insert, select
+from sqlalchemy.exc import IntegrityError
 
 from app.db.queue import IngestQueueStore
 from app.processing.ingest import ingest_directory
-from app.storage import photos
+from app.storage import face_labels, faces, people, photos
 
 
 def _resolve_seed_corpus_dir(start: Path | None = None) -> Path:
@@ -42,6 +45,64 @@ def test_upgrade_database_creates_schema(tmp_path):
         tables = set(inspect(connection).get_table_names())
 
     assert {"photos", "faces", "photo_tags", "people", "face_labels"} <= tables
+
+
+def test_upgrade_database_enforces_face_label_source_constraint(tmp_path):
+    from app.migrations import upgrade_database
+
+    database_url = f"sqlite:///{tmp_path / 'label-source-constraint.db'}"
+    upgrade_database(database_url)
+
+    engine = create_engine(database_url, future=True)
+    with engine.connect() as connection:
+        inspector = inspect(connection)
+        check_constraints = inspector.get_check_constraints("face_labels")
+
+    assert any(
+        constraint["name"] == "ck_face_labels_label_source" for constraint in check_constraints
+    )
+
+    with engine.begin() as connection:
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+        connection.execute(
+            insert(people).values(
+                person_id="person-1",
+                display_name="Jane Doe",
+            )
+        )
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                sha256="sha256-photo-1",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+            )
+        )
+        connection.execute(
+            insert(face_labels).values(
+                face_label_id="face-label-1",
+                face_id="face-1",
+                person_id="person-1",
+                label_source="human_confirmed",
+            )
+        )
+
+    with engine.begin() as connection:
+        with pytest.raises(IntegrityError):
+            connection.execute(
+                insert(face_labels).values(
+                    face_label_id="face-label-2",
+                    face_id="face-1",
+                    person_id="person-1",
+                    label_source="manual",
+                )
+            )
 
 
 def test_upgrade_database_creates_ingest_queue_table(tmp_path):

--- a/apps/api/tests/test_people_api.py
+++ b/apps/api/tests/test_people_api.py
@@ -401,7 +401,7 @@ def test_people_delete_api_returns_409_when_person_is_referenced_by_face_label(
                 face_label_id="face-label-1",
                 face_id="face-1",
                 person_id="person-1",
-                label_source="manual",
+                label_source="human_confirmed",
             )
         )
 

--- a/docs/adr/0017-persist-face-label-provenance-for-manual-api-labeling.md
+++ b/docs/adr/0017-persist-face-label-provenance-for-manual-api-labeling.md
@@ -20,7 +20,7 @@ Event persistence rules:
 
 - continue using `faces.person_id` as the current resolved label
 - append one `face_labels` row after each successful write
-- set `label_source = "manual"` for these API actions
+- set `label_source = "human_confirmed"` for these API actions
 - set `confidence` and `model_version` to `NULL` for manual writes
 - persist `provenance` JSON with operation metadata (`workflow`, `surface`, `action`)
 - include `previous_person_id` in correction provenance

--- a/packages/db-schema/photoorg_db_schema/__init__.py
+++ b/packages/db-schema/photoorg_db_schema/__init__.py
@@ -1,5 +1,7 @@
 from .schema import (
     EMBEDDING_DIMENSION,
+    FACE_LABEL_SOURCE_HUMAN_CONFIRMED,
+    FACE_LABEL_SOURCE_MACHINE_APPLIED,
     embedding_column_type,
     face_labels,
     faces,
@@ -19,6 +21,8 @@ from .schema import (
 
 __all__ = [
     "EMBEDDING_DIMENSION",
+    "FACE_LABEL_SOURCE_HUMAN_CONFIRMED",
+    "FACE_LABEL_SOURCE_MACHINE_APPLIED",
     "configure_embedding_column",
     "embedding_column_type",
     "face_labels",

--- a/packages/db-schema/photoorg_db_schema/schema.py
+++ b/packages/db-schema/photoorg_db_schema/schema.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from sqlalchemy import (
+    CheckConstraint,
     JSON,
     TIMESTAMP,
     Column,
@@ -22,6 +23,8 @@ from sqlalchemy.engine import Connection, Engine
 
 
 EMBEDDING_DIMENSION = 128
+FACE_LABEL_SOURCE_HUMAN_CONFIRMED = "human_confirmed"
+FACE_LABEL_SOURCE_MACHINE_APPLIED = "machine_applied"
 
 
 try:
@@ -190,6 +193,10 @@ face_labels = Table(
     Column("provenance", JSON()),
     Column("created_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
     Column("updated_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    CheckConstraint(
+        "label_source IN ('human_confirmed', 'machine_applied')",
+        name="ck_face_labels_label_source",
+    ),
 )
 
 ingest_runs = Table(


### PR DESCRIPTION
## Summary
- enforce explicit face-label provenance categories with shared constants for `human_confirmed` and `machine_applied`
- update face assignment/correction event writes to persist `human_confirmed` for manual API actions
- enforce `face_labels.label_source` allowed values in shared schema metadata and the initial Alembic schema
- align tests and ADR wording with the new label-source contract

## Why
Issue #45 requires the system to keep human-confirmed labels distinct from machine-applied labels so downstream workflows can treat provenance classes differently.

## Impact
- new and test-created `face_labels` rows must use `human_confirmed` or `machine_applied`
- legacy `manual` label source usage in current tests and API write paths is removed
- local migrations from scratch now enforce the label-source check constraint at DB level

## Validation
- `uv run pytest apps/api/tests/test_face_assignment_api.py apps/api/tests/test_people_api.py::test_people_delete_api_returns_409_when_person_is_referenced_by_face_label apps/api/tests/test_migrations.py::test_upgrade_database_enforces_face_label_source_constraint apps/api/tests/test_schema_definition.py`
- `uv run ruff check apps/api/alembic/versions/20260321_000001_initial_schema.py apps/api/app/services/face_assignment.py apps/api/tests/test_face_assignment_api.py apps/api/tests/test_migrations.py apps/api/tests/test_people_api.py packages/db-schema/photoorg_db_schema/schema.py packages/db-schema/photoorg_db_schema/__init__.py`

Closes #45