### PR TITLE
[codex] enforce permissions for face validation actions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,12 @@ OpenAPI contribution notes:
 - `GET /docs` serves the Swagger UI docs surface
 - `apps/api/.generated/openapi.yaml` is generated locally and is ignored by git; do not commit it
 
+Face-labeling mutation permission contract:
+
+- `POST /api/v1/faces/{face_id}/assignments` and `POST /api/v1/faces/{face_id}/corrections` require the `X-Face-Validation-Role` request header
+- accepted role values are `contributor` and `admin`
+- requests without an accepted role return `403` with `{"detail":"Face validation role required"}`
+
 The `pre-push` target is intentionally scoped to checks that are currently expected to pass on this repo state.
 As broader lint and type-check coverage is cleaned up, that target should expand rather than drift into a second undocumented workflow.
 

--- a/apps/api/app/dependencies.py
+++ b/apps/api/app/dependencies.py
@@ -10,6 +10,15 @@ from app.db.session import create_session_factory
 
 WORKER_ROLE_HEADER = "X-Worker-Role"
 INGEST_PROCESSOR_ROLE = "ingest-processor"
+FACE_VALIDATION_ROLE_HEADER = "X-Face-Validation-Role"
+FACE_VALIDATION_ROLE_CONTRIBUTOR = "contributor"
+FACE_VALIDATION_ROLE_ADMIN = "admin"
+FACE_VALIDATION_ROLES = frozenset(
+    {
+        FACE_VALIDATION_ROLE_CONTRIBUTOR,
+        FACE_VALIDATION_ROLE_ADMIN,
+    }
+)
 
 
 @lru_cache(maxsize=None)
@@ -33,3 +42,14 @@ def require_worker_role(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Worker role required",
         )
+
+
+def require_face_validation_role(
+    face_validation_role: str | None = Header(default=None, alias=FACE_VALIDATION_ROLE_HEADER),
+) -> str:
+    if face_validation_role not in FACE_VALIDATION_ROLES:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Face validation role required",
+        )
+    return face_validation_role

--- a/apps/api/app/routers/face_assignments.py
+++ b/apps/api/app/routers/face_assignments.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 from sqlalchemy.orm import Session
 
-from app.dependencies import get_db
+from app.dependencies import get_db, require_face_validation_role
 from app.services.face_assignment import (
     FaceAlreadyAssignedError,
     FaceAlreadyAssignedToPersonError,
@@ -71,6 +71,7 @@ class FaceCorrectionResponse(BaseModel):
     response_model=FaceAssignmentResponse,
     status_code=status.HTTP_201_CREATED,
     responses={
+        status.HTTP_403_FORBIDDEN: {"description": "Face validation role required"},
         status.HTTP_404_NOT_FOUND: {"description": "Face or person not found"},
         status.HTTP_409_CONFLICT: {"description": "Face already assigned"},
     },
@@ -79,6 +80,7 @@ def assign_face_to_person_endpoint(
     face_id: str,
     body: AssignFaceRequest,
     db: Session = Depends(get_db),
+    _: str = Depends(require_face_validation_role),
 ) -> FaceAssignmentResponse:
     try:
         assignment = assign_face_to_person(
@@ -103,6 +105,7 @@ def assign_face_to_person_endpoint(
     description="Reassign an already-labeled face to a different person identity.",
     response_model=FaceCorrectionResponse,
     responses={
+        status.HTTP_403_FORBIDDEN: {"description": "Face validation role required"},
         status.HTTP_404_NOT_FOUND: {"description": "Face or person not found"},
         status.HTTP_409_CONFLICT: {
             "description": "Face is unassigned or already assigned to the requested person"
@@ -113,6 +116,7 @@ def correct_face_assignment_endpoint(
     face_id: str,
     body: AssignFaceRequest,
     db: Session = Depends(get_db),
+    _: str = Depends(require_face_validation_role),
 ) -> FaceCorrectionResponse:
     try:
         correction = reassign_face_to_person(

--- a/apps/api/tests/test_face_assignment_api.py
+++ b/apps/api/tests/test_face_assignment_api.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, insert, select
 
-from app.dependencies import _get_session_factory
+from app.dependencies import FACE_VALIDATION_ROLE_HEADER, _get_session_factory
 from app.main import app
 from app.migrations import upgrade_database
 from app.storage import face_labels, faces, people, photos
@@ -21,6 +21,12 @@ def _client(tmp_path, monkeypatch, filename: str) -> TestClient:
 
 def _database_url(tmp_path, filename: str) -> str:
     return f"sqlite:///{tmp_path / filename}"
+
+
+def _authorized_client() -> TestClient:
+    client = TestClient(app)
+    client.headers[FACE_VALIDATION_ROLE_HEADER] = "contributor"
+    return client
 
 
 def _insert_photo(connection, *, photo_id: str) -> None:
@@ -65,7 +71,7 @@ def test_face_assignment_api_assigns_unlabeled_face_to_existing_person(tmp_path,
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/assignments",
         json={"person_id": "person-1"},
@@ -82,6 +88,68 @@ def test_face_assignment_api_assigns_unlabeled_face_to_existing_person(tmp_path,
             select(faces.c.person_id).where(faces.c.face_id == "face-1")
         ).scalar_one_or_none()
     assert persisted_person_id == "person-1"
+
+
+def test_face_assignment_api_rejects_missing_face_validation_role(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-assign-missing-role.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={"person_id": "person-1"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Face validation role required"}
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id is None
+
+
+def test_face_assignment_api_rejects_unrecognized_face_validation_role(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-assign-wrong-role.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        headers={FACE_VALIDATION_ROLE_HEADER: "viewer"},
+        json={"person_id": "person-1"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Face validation role required"}
 
 
 def test_face_assignment_api_persists_human_confirmed_face_label_provenance(
@@ -104,7 +172,7 @@ def test_face_assignment_api_persists_human_confirmed_face_label_provenance(
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/assignments",
         json={"person_id": "person-1"},
@@ -145,7 +213,7 @@ def test_face_assignment_api_returns_404_for_missing_face(tmp_path, monkeypatch)
     with engine.begin() as connection:
         _insert_person(connection, person_id="person-1", display_name="Jane Doe")
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/missing-face/assignments",
         json={"person_id": "person-1"},
@@ -172,7 +240,7 @@ def test_face_assignment_api_returns_404_for_missing_person(tmp_path, monkeypatc
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/assignments",
         json={"person_id": "missing-person"},
@@ -206,7 +274,7 @@ def test_face_assignment_api_returns_409_for_already_assigned_face(tmp_path, mon
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/assignments",
         json={"person_id": "person-1"},
@@ -238,7 +306,7 @@ def test_face_assignment_api_returns_422_for_blank_person_id(tmp_path, monkeypat
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/assignments",
         json={"person_id": "   "},
@@ -270,7 +338,7 @@ def test_face_assignment_api_returns_422_for_missing_person_id(tmp_path, monkeyp
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/assignments",
         json={},
@@ -303,7 +371,7 @@ def test_face_assignment_api_returns_409_when_reassigning_to_same_person(tmp_pat
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/assignments",
         json={"person_id": "person-1"},
@@ -332,7 +400,7 @@ def test_face_correction_api_reassigns_assigned_face_to_different_person(tmp_pat
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/corrections",
         json={"person_id": "person-2"},
@@ -350,6 +418,40 @@ def test_face_correction_api_reassigns_assigned_face_to_different_person(tmp_pat
             select(faces.c.person_id).where(faces.c.face_id == "face-1")
         ).scalar_one_or_none()
     assert persisted_person_id == "person-2"
+
+
+def test_face_correction_api_rejects_missing_face_validation_role(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-correct-missing-role.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        _insert_person(connection, person_id="person-2", display_name="John Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/corrections",
+        json={"person_id": "person-2"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Face validation role required"}
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id == "person-1"
 
 
 def test_face_correction_api_persists_human_confirmed_face_label_provenance(tmp_path, monkeypatch):
@@ -371,7 +473,7 @@ def test_face_correction_api_persists_human_confirmed_face_label_provenance(tmp_
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/corrections",
         json={"person_id": "person-2"},
@@ -413,7 +515,7 @@ def test_face_correction_api_returns_404_for_missing_face(tmp_path, monkeypatch)
     with engine.begin() as connection:
         _insert_person(connection, person_id="person-1", display_name="Jane Doe")
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/missing-face/corrections",
         json={"person_id": "person-1"},
@@ -441,7 +543,7 @@ def test_face_correction_api_returns_404_for_missing_person(tmp_path, monkeypatc
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/corrections",
         json={"person_id": "missing-person"},
@@ -474,7 +576,7 @@ def test_face_correction_api_returns_409_when_face_is_unassigned(tmp_path, monke
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/corrections",
         json={"person_id": "person-1"},
@@ -507,7 +609,7 @@ def test_face_correction_api_returns_409_when_reassigning_to_same_person(tmp_pat
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/corrections",
         json={"person_id": "person-1"},
@@ -535,7 +637,7 @@ def test_face_correction_api_returns_422_for_blank_person_id(tmp_path, monkeypat
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/corrections",
         json={"person_id": "   "},
@@ -563,7 +665,7 @@ def test_face_correction_api_returns_422_for_missing_person_id(tmp_path, monkeyp
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.post(
         "/api/v1/faces/face-1/corrections",
         json={},
@@ -606,7 +708,7 @@ def test_photo_detail_api_includes_face_id_for_assignment_workflow(tmp_path, mon
             )
         )
 
-    client = TestClient(app)
+    client = _authorized_client()
     response = client.get("/api/v1/photos/photo-1")
 
     assert response.status_code == 200
@@ -629,4 +731,20 @@ def test_openapi_schema_includes_face_assignment_path_and_tag(tmp_path, monkeypa
 
     assert "/api/v1/faces/{face_id}/assignments" in schema["paths"]
     assert "/api/v1/faces/{face_id}/corrections" in schema["paths"]
+    assert schema["paths"]["/api/v1/faces/{face_id}/assignments"]["post"]["responses"]["403"][
+        "description"
+    ] == "Face validation role required"
+    assert schema["paths"]["/api/v1/faces/{face_id}/corrections"]["post"]["responses"]["403"][
+        "description"
+    ] == "Face validation role required"
+    assignment_parameters = schema["paths"]["/api/v1/faces/{face_id}/assignments"]["post"]["parameters"]
+    correction_parameters = schema["paths"]["/api/v1/faces/{face_id}/corrections"]["post"]["parameters"]
+    assert any(
+        parameter["in"] == "header" and parameter["name"] == FACE_VALIDATION_ROLE_HEADER
+        for parameter in assignment_parameters
+    )
+    assert any(
+        parameter["in"] == "header" and parameter["name"] == FACE_VALIDATION_ROLE_HEADER
+        for parameter in correction_parameters
+    )
     assert any(tag["name"] == "face-labeling" for tag in schema["tags"])

--- a/docs/adr/0018-enforce-face-validation-action-permissions.md
+++ b/docs/adr/0018-enforce-face-validation-action-permissions.md
@@ -1,0 +1,38 @@
+# ADR-0018: Enforce Face Validation Action Permissions
+
+- Status: Proposed
+- Date: 2026-04-26
+
+## Context
+
+Issue #42 introduced manual face-to-person assignment and Issue #43 added explicit correction and reassignment. Issue #44 then persisted manual labeling provenance in `face_labels`, and Issue #45 enforced source separation for human-confirmed versus machine-applied labels.
+
+Those workflows can currently be invoked by any API caller because there is no permission gate on face-validation mutation endpoints. That leaves no way to enforce the Phase 4 requirement that only authorized contributors can confirm or correct face labels.
+
+## Decision
+
+Require an explicit role header for face-validation mutation endpoints:
+
+- `POST /api/v1/faces/{face_id}/assignments`
+- `POST /api/v1/faces/{face_id}/corrections`
+
+Authorization contract:
+
+- request header: `X-Face-Validation-Role`
+- accepted values: `contributor`, `admin`
+- missing or unrecognized values return `403 Forbidden` with `{"detail":"Face validation role required"}`
+
+This issue intentionally uses a lightweight header contract so the API can enforce authorization boundaries now without blocking on a broader identity system rollout.
+
+## Consequences
+
+- Face-validation mutations are now restricted to authorized callers.
+- UI, CLI, and test clients must include an accepted face-validation role header when issuing assignment or correction actions.
+- OpenAPI now documents both the required permission header and `403` permission-failure responses for these endpoints.
+- Future authentication work can map real user identity claims to the same role gate without changing endpoint paths.
+
+## Alternatives Considered
+
+- Leave face-validation endpoints open to all callers until a full auth stack is introduced.
+- Restrict validation actions to only one role (for example, `admin`) and defer contributor access.
+- Add dedicated user and role persistence in this issue rather than using an explicit request-role contract.


### PR DESCRIPTION
## Summary
- enforce a face-validation role gate for face-labeling mutation endpoints
- require `X-Face-Validation-Role` with accepted values `contributor` or `admin` for assignment and correction actions
- document permission failure semantics (`403` + `Face validation role required`) in endpoint OpenAPI responses and contributor docs
- add ADR-0018 describing the authorization contract and rationale

## Why
Phase 4 requires permissions for face validation actions so only authorized callers can confirm or correct face labels.

## Impact
- callers must include `X-Face-Validation-Role` for `POST /api/v1/faces/{face_id}/assignments`
- callers must include `X-Face-Validation-Role` for `POST /api/v1/faces/{face_id}/corrections`
- missing or unrecognized role values now return `403`

## Validation
- `uv run python -m pytest apps/api/tests/test_face_assignment_api.py -q`
- `uv run python -m pytest apps/api/tests/test_main.py -q`
- `uv run ruff check apps/api/app/dependencies.py apps/api/app/routers/face_assignments.py apps/api/tests/test_face_assignment_api.py`

Closes #46