### PR TITLE
Enforce faces.person_id foreign key integrity

### DIFF
--- a/apps/api/alembic/versions/20260426_000002_faces_person_fk.py
+++ b/apps/api/alembic/versions/20260426_000002_faces_person_fk.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "20260426_000002"
+down_revision = "20260321_000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("faces", schema=None) as batch_op:
+        batch_op.create_foreign_key(
+            "fk_faces_person_id_people",
+            "people",
+            ["person_id"],
+            ["person_id"],
+            ondelete="RESTRICT",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("faces", schema=None) as batch_op:
+        batch_op.drop_constraint("fk_faces_person_id_people", type_="foreignkey")

--- a/apps/api/app/services/face_assignment.py
+++ b/apps/api/app/services/face_assignment.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 from sqlalchemy import insert, select, update
 from sqlalchemy.engine import Connection
+from sqlalchemy.exc import IntegrityError
 
 from photoorg_db_schema import FACE_LABEL_SOURCE_HUMAN_CONFIRMED
 
@@ -36,24 +37,31 @@ def assign_face_to_person(
     face_id: str,
     person_id: str,
 ) -> dict[str, str]:
-    result = connection.execute(
-        update(faces)
-        .where(
-            faces.c.face_id == face_id,
-            faces.c.person_id.is_(None),
-            select(people.c.person_id).where(people.c.person_id == person_id).exists(),
+    try:
+        result = connection.execute(
+            update(faces)
+            .where(
+                faces.c.face_id == face_id,
+                faces.c.person_id.is_(None),
+                select(people.c.person_id).where(people.c.person_id == person_id).exists(),
+            )
+            .values(person_id=person_id)
         )
-        .values(person_id=person_id)
-    )
-    if result.rowcount == 1:
-        assignment = _face_assignment(connection, face_id)
-        _persist_face_label_event(
+        if result.rowcount == 1:
+            assignment = _face_assignment(connection, face_id)
+            _persist_face_label_event(
+                connection,
+                face_id=face_id,
+                person_id=person_id,
+                action="assignment",
+            )
+            return assignment
+    except IntegrityError as exc:
+        _raise_person_not_found_on_fk_violation(
             connection,
-            face_id=face_id,
             person_id=person_id,
-            action="assignment",
+            exc=exc,
         )
-        return assignment
 
     row = _face_row(connection, face_id)
     if row is None:
@@ -61,13 +69,7 @@ def assign_face_to_person(
     if row["person_id"] is not None:
         raise FaceAlreadyAssignedError("Face already assigned")
 
-    person_exists = (
-        connection.execute(
-            select(people.c.person_id).where(people.c.person_id == person_id)
-        ).scalar_one_or_none()
-        is not None
-    )
-    if not person_exists:
+    if not _person_exists(connection, person_id):
         raise PersonNotFoundError("Person not found")
 
     raise FaceAlreadyAssignedError("Face already assigned")
@@ -89,33 +91,34 @@ def reassign_face_to_person(
     if previous_person_id == person_id:
         raise FaceAlreadyAssignedToPersonError("Face already assigned to person")
 
-    person_exists = (
-        connection.execute(
-            select(people.c.person_id).where(people.c.person_id == person_id)
-        ).scalar_one_or_none()
-        is not None
-    )
-    if not person_exists:
+    if not _person_exists(connection, person_id):
         raise PersonNotFoundError("Person not found")
 
-    result = connection.execute(
-        update(faces)
-        .where(
-            faces.c.face_id == face_id,
-            faces.c.person_id == previous_person_id,
+    try:
+        result = connection.execute(
+            update(faces)
+            .where(
+                faces.c.face_id == face_id,
+                faces.c.person_id == previous_person_id,
+            )
+            .values(person_id=person_id)
         )
-        .values(person_id=person_id)
-    )
-    if result.rowcount != 1:
-        raise FaceAlreadyAssignedError("Face assignment changed; retry correction")
+        if result.rowcount != 1:
+            raise FaceAlreadyAssignedError("Face assignment changed; retry correction")
 
-    _persist_face_label_event(
-        connection,
-        face_id=face_id,
-        person_id=person_id,
-        action="correction",
-        previous_person_id=previous_person_id,
-    )
+        _persist_face_label_event(
+            connection,
+            face_id=face_id,
+            person_id=person_id,
+            action="correction",
+            previous_person_id=previous_person_id,
+        )
+    except IntegrityError as exc:
+        _raise_person_not_found_on_fk_violation(
+            connection,
+            person_id=person_id,
+            exc=exc,
+        )
 
     return {
         "face_id": row["face_id"],
@@ -137,6 +140,26 @@ def _face_row(connection: Connection, face_id: str):
         .mappings()
         .first()
     )
+
+
+def _person_exists(connection: Connection, person_id: str) -> bool:
+    return (
+        connection.execute(
+            select(people.c.person_id).where(people.c.person_id == person_id)
+        ).scalar_one_or_none()
+        is not None
+    )
+
+
+def _raise_person_not_found_on_fk_violation(
+    connection: Connection,
+    *,
+    person_id: str,
+    exc: IntegrityError,
+) -> None:
+    if not _person_exists(connection, person_id):
+        raise PersonNotFoundError("Person not found") from exc
+    raise exc
 
 
 def _face_assignment(connection: Connection, face_id: str) -> dict[str, str]:

--- a/apps/api/app/services/people.py
+++ b/apps/api/app/services/people.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 from sqlalchemy import delete, insert, select, update
 from sqlalchemy.engine import Connection
+from sqlalchemy.exc import IntegrityError
 
 from app.storage import face_labels, faces, people
 
@@ -81,15 +82,22 @@ def update_person(
 
 
 def delete_person(connection: Connection, person_id: str) -> None:
-    delete_result = connection.execute(
-        delete(people).where(
-            people.c.person_id == person_id,
-            ~select(faces.c.face_id).where(faces.c.person_id == person_id).exists(),
-            ~select(face_labels.c.face_label_id)
-            .where(face_labels.c.person_id == person_id)
-            .exists(),
+    try:
+        delete_result = connection.execute(
+            delete(people).where(
+                people.c.person_id == person_id,
+                ~select(faces.c.face_id).where(faces.c.person_id == person_id).exists(),
+                ~select(face_labels.c.face_label_id)
+                .where(face_labels.c.person_id == person_id)
+                .exists(),
+            )
         )
-    )
+    except IntegrityError as exc:
+        person = get_person(connection, person_id)
+        if person is None:
+            raise PersonNotFoundError("Person not found") from exc
+        raise PersonInUseError("Person is referenced by face or label data") from exc
+
     if delete_result.rowcount == 1:
         return
 

--- a/apps/api/tests/test_face_assignment_api.py
+++ b/apps/api/tests/test_face_assignment_api.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, insert, select
+from sqlalchemy import create_engine, delete, insert, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.sql.dml import Update
 
 from app.dependencies import FACE_VALIDATION_ROLE_HEADER, _get_session_factory
 from app.main import app
 from app.migrations import upgrade_database
+from app.routers import face_assignments as face_assignments_router
+from app.services import face_assignment as face_assignment_service
 from app.storage import face_labels, faces, people, photos
 
 
@@ -51,6 +55,33 @@ def _insert_person(connection, *, person_id: str, display_name: str) -> None:
             updated_ts=now,
         )
     )
+
+
+class _FacesUpdateForeignKeyViolationConnection:
+    def __init__(self, connection, *, person_id: str) -> None:
+        self._connection = connection
+        self._person_id = person_id
+        self._did_inject = False
+
+    def execute(self, statement, *args, **kwargs):
+        if (
+            not self._did_inject
+            and isinstance(statement, Update)
+            and statement.table.name == faces.name
+        ):
+            self._did_inject = True
+            self._connection.execute(
+                delete(people).where(people.c.person_id == self._person_id)
+            )
+            raise IntegrityError(
+                str(statement),
+                {},
+                Exception("FOREIGN KEY constraint failed"),
+            )
+        return self._connection.execute(statement, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._connection, name)
 
 
 def test_face_assignment_api_assigns_unlabeled_face_to_existing_person(tmp_path, monkeypatch):
@@ -244,6 +275,58 @@ def test_face_assignment_api_returns_404_for_missing_person(tmp_path, monkeypatc
     response = client.post(
         "/api/v1/faces/face-1/assignments",
         json={"person_id": "missing-person"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Person not found"
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id is None
+
+
+def test_face_assignment_api_returns_404_when_assignment_loses_delete_race(
+    tmp_path, monkeypatch
+):
+    database_url = _database_url(tmp_path, "face-assign-delete-race.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+
+    def _assign_face_with_integrity_violation(connection, *, face_id: str, person_id: str):
+        wrapped_connection = _FacesUpdateForeignKeyViolationConnection(
+            connection,
+            person_id=person_id,
+        )
+        return face_assignment_service.assign_face_to_person(
+            wrapped_connection,
+            face_id=face_id,
+            person_id=person_id,
+        )
+
+    monkeypatch.setattr(
+        face_assignments_router,
+        "assign_face_to_person",
+        _assign_face_with_integrity_violation,
+    )
+
+    client = _authorized_client()
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={"person_id": "person-1"},
     )
 
     assert response.status_code == 404
@@ -547,6 +630,59 @@ def test_face_correction_api_returns_404_for_missing_person(tmp_path, monkeypatc
     response = client.post(
         "/api/v1/faces/face-1/corrections",
         json={"person_id": "missing-person"},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Person not found"
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id == "person-1"
+
+
+def test_face_correction_api_returns_404_when_correction_loses_delete_race(
+    tmp_path, monkeypatch
+):
+    database_url = _database_url(tmp_path, "face-correct-delete-race.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        _insert_person(connection, person_id="person-2", display_name="John Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+            )
+        )
+
+    def _reassign_face_with_integrity_violation(connection, *, face_id: str, person_id: str):
+        wrapped_connection = _FacesUpdateForeignKeyViolationConnection(
+            connection,
+            person_id=person_id,
+        )
+        return face_assignment_service.reassign_face_to_person(
+            wrapped_connection,
+            face_id=face_id,
+            person_id=person_id,
+        )
+
+    monkeypatch.setattr(
+        face_assignments_router,
+        "reassign_face_to_person",
+        _reassign_face_with_integrity_violation,
+    )
+
+    client = _authorized_client()
+    response = client.post(
+        "/api/v1/faces/face-1/corrections",
+        json={"person_id": "person-2"},
     )
 
     assert response.status_code == 404

--- a/apps/api/tests/test_migrations.py
+++ b/apps/api/tests/test_migrations.py
@@ -105,6 +105,47 @@ def test_upgrade_database_enforces_face_label_source_constraint(tmp_path):
             )
 
 
+def test_upgrade_database_enforces_faces_person_fk_constraint(tmp_path):
+    from app.migrations import upgrade_database
+
+    database_url = f"sqlite:///{tmp_path / 'faces-person-fk.db'}"
+    upgrade_database(database_url)
+
+    engine = create_engine(database_url, future=True)
+    with engine.connect() as connection:
+        inspector = inspect(connection)
+        foreign_keys = inspector.get_foreign_keys("faces")
+
+    assert any(
+        foreign_key["constrained_columns"] == ["person_id"]
+        and foreign_key["referred_table"] == "people"
+        and foreign_key["referred_columns"] == ["person_id"]
+        and foreign_key["options"] == {"ondelete": "RESTRICT"}
+        for foreign_key in foreign_keys
+    )
+
+    with engine.begin() as connection:
+        connection.exec_driver_sql("PRAGMA foreign_keys=ON")
+        now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                sha256="sha256-photo-1",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+
+        with pytest.raises(IntegrityError):
+            connection.execute(
+                insert(faces).values(
+                    face_id="face-1",
+                    photo_id="photo-1",
+                    person_id="missing-person",
+                )
+            )
+
+
 def test_upgrade_database_creates_ingest_queue_table(tmp_path):
     from app.migrations import upgrade_database
 

--- a/apps/api/tests/test_people_api.py
+++ b/apps/api/tests/test_people_api.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, insert, select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.sql.dml import Delete
 
 from app.dependencies import _get_session_factory
@@ -64,6 +65,29 @@ class _DeleteRowcountZeroConnection:
             self._did_inject = True
             self._connection.execute(statement, *args, **kwargs)
             return _ResultWithRowcountZero()
+        return self._connection.execute(statement, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._connection, name)
+
+
+class _DeleteForeignKeyViolationConnection:
+    def __init__(self, connection) -> None:
+        self._connection = connection
+        self._did_inject = False
+
+    def execute(self, statement, *args, **kwargs):
+        if (
+            not self._did_inject
+            and isinstance(statement, Delete)
+            and statement.table.name == people.name
+        ):
+            self._did_inject = True
+            raise IntegrityError(
+                str(statement),
+                {},
+                Exception("FOREIGN KEY constraint failed"),
+            )
         return self._connection.execute(statement, *args, **kwargs)
 
     def __getattr__(self, name):
@@ -357,6 +381,46 @@ def test_people_delete_api_returns_409_when_person_is_referenced_by_face(tmp_pat
                 person_id="person-1",
             )
         )
+
+    client = TestClient(app)
+    response = client.delete("/api/v1/people/person-1")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Person is referenced by face or label data"
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(people.c.person_id).where(people.c.person_id == "person-1")
+        ).scalar_one_or_none()
+    assert persisted_person_id == "person-1"
+
+
+def test_people_delete_api_returns_409_when_delete_loses_fk_race(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "people-delete-fk-race.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    now = datetime(2026, 4, 24, 12, 0, tzinfo=UTC)
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(people).values(
+                person_id="person-1",
+                display_name="Jane Doe",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+
+    def _delete_person_with_fk_violation(connection, person_id: str) -> None:
+        wrapped_connection = _DeleteForeignKeyViolationConnection(connection)
+        people_service.delete_person(wrapped_connection, person_id)
+
+    monkeypatch.setattr(
+        people_router,
+        "delete_person",
+        _delete_person_with_fk_violation,
+    )
 
     client = TestClient(app)
     response = client.delete("/api/v1/people/person-1")

--- a/docs/adr/0019-enforce-faces-person-foreign-key-integrity.md
+++ b/docs/adr/0019-enforce-faces-person-foreign-key-integrity.md
@@ -1,0 +1,35 @@
+# ADR-0019: Enforce Faces-Person Foreign Key Integrity
+
+- Status: Proposed
+- Date: 2026-04-26
+
+## Context
+
+Issue #133 identifies a race between face assignment and person deletion. The API currently checks person existence before writing `faces.person_id`, but there is no database-level foreign key from `faces.person_id` to `people.person_id`.
+
+Without a foreign key, concurrent deletes can leave `faces.person_id` pointing to a missing person record.
+
+Phase 4 behavior already treats person deletion as conservative: deleting a referenced person returns `409 Conflict` rather than auto-unassigning or cascading.
+
+## Decision
+
+Add an explicit foreign key constraint from `faces.person_id` to `people.person_id` with:
+
+- `ON DELETE RESTRICT`
+
+Keep API contracts deterministic by mapping database integrity races to existing responses:
+
+- assignment/correction race where target person disappears maps to `404 Person not found`
+- delete race where new references appear maps to `409 Person is referenced by face or label data`
+
+## Consequences
+
+- `faces.person_id` can no longer persist dangling references when the database enforces foreign keys.
+- Person deletion semantics remain conservative and aligned with existing Phase 4 API behavior.
+- Service-layer existence checks remain useful for clear errors, while the FK provides last-line integrity under concurrency.
+
+## Alternatives Considered
+
+- `ON DELETE SET NULL` for `faces.person_id`
+- no FK and rely only on application-layer existence checks
+- cascading delete from `people` into `faces`

--- a/packages/db-schema/photoorg_db_schema/schema.py
+++ b/packages/db-schema/photoorg_db_schema/schema.py
@@ -152,7 +152,7 @@ faces = Table(
     metadata,
     Column("face_id", String(36), primary_key=True),
     Column("photo_id", String(36), ForeignKey("photos.photo_id", ondelete="CASCADE"), nullable=False),
-    Column("person_id", String(36)),
+    Column("person_id", String(36), ForeignKey("people.person_id", ondelete="RESTRICT")),
     Column("bbox_x", Integer),
     Column("bbox_y", Integer),
     Column("bbox_w", Integer),


### PR DESCRIPTION
## Summary
- add a migration that creates a foreign key from `faces.person_id` to `people.person_id` with `ON DELETE RESTRICT`
- update service behavior to handle FK race conditions deterministically for assignment/correction/delete flows
- add migration and API regression tests covering FK integrity and concurrent delete races
- document the delete-semantics decision in ADR-0019

## Verification
- `uv run python -m pytest apps/api/tests/test_migrations.py apps/api/tests/test_face_assignment_api.py apps/api/tests/test_people_api.py -q`
- `uv run ruff check apps/api/app/services/face_assignment.py apps/api/app/services/people.py apps/api/tests/test_migrations.py apps/api/tests/test_face_assignment_api.py apps/api/tests/test_people_api.py packages/db-schema/photoorg_db_schema/schema.py docs/adr/0019-enforce-faces-person-foreign-key-integrity.md`

Closes #133