### PR TITLE
[codex] Implement nearest-neighbor candidate lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Typical usage is expected to be:
 - admin users register sources through `POST /api/v1/storage-sources`, then add, remove, or disable watched folders under those sources
 - the system ingests new photos in the background
 - users search for photos by person, date, and location
+- suggestion workflows can fetch nearest labeled candidates with `GET /api/v1/faces/{face_id}/candidates`
 - authorized users confirm or correct face associations
 - users monitor ingestion status and recent issues from the UI
 

--- a/apps/api/app/routers/face_assignments.py
+++ b/apps/api/app/routers/face_assignments.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 from sqlalchemy.orm import Session
 
@@ -15,6 +15,11 @@ from app.services.face_assignment import (
     PersonNotFoundError,
     assign_face_to_person,
     reassign_face_to_person,
+)
+from app.services.face_candidates import (
+    FaceEmbeddingNotAvailableError,
+    FaceNotFoundError as FaceCandidateNotFoundError,
+    lookup_nearest_neighbor_candidates,
 )
 
 
@@ -62,6 +67,32 @@ class FaceCorrectionResponse(BaseModel):
     photo_id: str
     previous_person_id: str
     person_id: str
+
+
+class FaceCandidateResponse(BaseModel):
+    """Nearest-neighbor candidate details for one person identity."""
+
+    model_config = ConfigDict(
+        json_schema_extra={"description": "One candidate identity ranked for a source face."}
+    )
+
+    person_id: str
+    display_name: str
+    matched_face_id: str
+    distance: float
+
+
+class FaceCandidateLookupResponse(BaseModel):
+    """Nearest-neighbor candidate lookup result for one source face."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": "Top person candidates computed from nearest face-embedding neighbors."
+        }
+    )
+
+    face_id: str
+    candidates: list[FaceCandidateResponse]
 
 
 @router.post(
@@ -137,3 +168,32 @@ def correct_face_assignment_endpoint(
 
     db.commit()
     return FaceCorrectionResponse.model_validate(correction)
+
+
+@router.get(
+    "/{face_id}/candidates",
+    summary="Lookup nearest person candidates",
+    description="Return nearest labeled people candidates for the requested face embedding.",
+    response_model=FaceCandidateLookupResponse,
+    responses={
+        status.HTTP_404_NOT_FOUND: {"description": "Face not found"},
+        status.HTTP_409_CONFLICT: {"description": "Face embedding not available"},
+    },
+)
+def lookup_face_candidates_endpoint(
+    face_id: str,
+    limit: Annotated[int, Query(ge=1, le=50)] = 5,
+    db: Session = Depends(get_db),
+) -> FaceCandidateLookupResponse:
+    try:
+        result = lookup_nearest_neighbor_candidates(
+            db.connection(),
+            face_id=face_id,
+            limit=limit,
+        )
+    except FaceCandidateNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except FaceEmbeddingNotAvailableError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    return FaceCandidateLookupResponse.model_validate(result)

--- a/apps/api/app/services/face_candidates.py
+++ b/apps/api/app/services/face_candidates.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from math import sqrt
+
+from sqlalchemy import func, select
+from sqlalchemy.engine import Connection
+
+from app.storage import faces, people
+
+
+class FaceNotFoundError(LookupError):
+    pass
+
+
+class FaceEmbeddingNotAvailableError(RuntimeError):
+    pass
+
+
+def lookup_nearest_neighbor_candidates(
+    connection: Connection,
+    *,
+    face_id: str,
+    limit: int = 5,
+) -> dict[str, object]:
+    source_row = (
+        connection.execute(
+            select(faces.c.face_id, faces.c.embedding).where(faces.c.face_id == face_id)
+        )
+        .mappings()
+        .first()
+    )
+    if source_row is None:
+        raise FaceNotFoundError("Face not found")
+
+    source_embedding = _coerce_embedding(source_row["embedding"])
+    if source_embedding is None:
+        raise FaceEmbeddingNotAvailableError("Face embedding not available")
+    if connection.dialect.name == "postgresql":
+        ordered_candidates = _lookup_candidates_postgresql(
+            connection,
+            face_id=face_id,
+            source_embedding=source_embedding,
+            limit=limit,
+        )
+    else:
+        ordered_candidates = _lookup_candidates_python(
+            connection,
+            face_id=face_id,
+            source_embedding=source_embedding,
+        )
+
+    return {
+        "face_id": face_id,
+        "candidates": ordered_candidates[:limit],
+    }
+
+
+def _lookup_candidates_postgresql(
+    connection: Connection,
+    *,
+    face_id: str,
+    source_embedding: list[float],
+    limit: int,
+) -> list[dict[str, object]]:
+    distance_expression = faces.c.embedding.cosine_distance(source_embedding)
+    ranked_candidates = (
+        select(
+            faces.c.person_id.label("person_id"),
+            people.c.display_name.label("display_name"),
+            faces.c.face_id.label("matched_face_id"),
+            distance_expression.label("distance"),
+            func.row_number()
+            .over(
+                partition_by=faces.c.person_id,
+                order_by=(distance_expression.asc(), faces.c.face_id.asc()),
+            )
+            .label("person_rank"),
+        )
+        .select_from(faces.join(people, faces.c.person_id == people.c.person_id))
+        .where(
+            faces.c.face_id != face_id,
+            faces.c.person_id.is_not(None),
+            faces.c.embedding.is_not(None),
+        )
+        .subquery()
+    )
+
+    rows = (
+        connection.execute(
+            select(
+                ranked_candidates.c.person_id,
+                ranked_candidates.c.display_name,
+                ranked_candidates.c.matched_face_id,
+                ranked_candidates.c.distance,
+            )
+            .where(ranked_candidates.c.person_rank == 1)
+            .order_by(ranked_candidates.c.distance.asc(), ranked_candidates.c.person_id.asc())
+            .limit(limit)
+        )
+        .mappings()
+        .all()
+    )
+    return [
+        {
+            "person_id": str(row["person_id"]),
+            "display_name": str(row["display_name"]),
+            "matched_face_id": str(row["matched_face_id"]),
+            "distance": float(row["distance"]),
+        }
+        for row in rows
+    ]
+
+
+def _lookup_candidates_python(
+    connection: Connection,
+    *,
+    face_id: str,
+    source_embedding: list[float],
+) -> list[dict[str, object]]:
+    candidate_rows = (
+        connection.execute(
+            select(
+                faces.c.face_id,
+                faces.c.person_id,
+                faces.c.embedding,
+                people.c.display_name,
+            )
+            .select_from(faces.join(people, faces.c.person_id == people.c.person_id))
+            .where(
+                faces.c.face_id != face_id,
+                faces.c.person_id.is_not(None),
+                faces.c.embedding.is_not(None),
+            )
+        )
+        .mappings()
+        .all()
+    )
+
+    best_by_person: dict[str, dict[str, object]] = {}
+    for row in candidate_rows:
+        candidate_embedding = _coerce_embedding(row["embedding"])
+        if candidate_embedding is None:
+            continue
+        if len(candidate_embedding) != len(source_embedding):
+            continue
+
+        distance = _cosine_distance(source_embedding, candidate_embedding)
+        if distance is None:
+            continue
+
+        person_id = str(row["person_id"])
+        best_candidate = best_by_person.get(person_id)
+        if best_candidate is None or distance < float(best_candidate["distance"]):
+            best_by_person[person_id] = {
+                "person_id": person_id,
+                "display_name": str(row["display_name"]),
+                "matched_face_id": str(row["face_id"]),
+                "distance": distance,
+            }
+
+    return sorted(
+        best_by_person.values(),
+        key=lambda item: (float(item["distance"]), str(item["person_id"])),
+    )
+
+
+def _coerce_embedding(value: object) -> list[float] | None:
+    if value is None:
+        return None
+
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+
+    if not isinstance(value, list | tuple):
+        return None
+
+    try:
+        return [float(component) for component in value]
+    except (TypeError, ValueError):
+        return None
+
+
+def _cosine_distance(left: list[float], right: list[float]) -> float | None:
+    left_norm = sqrt(sum(component * component for component in left))
+    right_norm = sqrt(sum(component * component for component in right))
+    if left_norm == 0 or right_norm == 0:
+        return None
+
+    dot_product = sum(left_component * right_component for left_component, right_component in zip(left, right))
+    similarity = dot_product / (left_norm * right_norm)
+    bounded_similarity = min(1.0, max(-1.0, similarity))
+    return 1.0 - bounded_similarity

--- a/apps/api/tests/test_face_candidates_api.py
+++ b/apps/api/tests/test_face_candidates_api.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, insert
+
+from app.dependencies import _get_session_factory
+from app.main import app
+from app.migrations import upgrade_database
+from app.storage import faces, people, photos
+from photoorg_db_schema import EMBEDDING_DIMENSION
+
+
+def _client(tmp_path, monkeypatch, filename: str) -> TestClient:
+    database_url = f"sqlite:///{tmp_path / filename}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+    return TestClient(app)
+
+
+def _insert_photo(connection, *, photo_id: str) -> None:
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    connection.execute(
+        insert(photos).values(
+            photo_id=photo_id,
+            sha256=f"sha256-{photo_id}",
+            created_ts=now,
+            updated_ts=now,
+        )
+    )
+
+
+def _insert_person(connection, *, person_id: str, display_name: str) -> None:
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    connection.execute(
+        insert(people).values(
+            person_id=person_id,
+            display_name=display_name,
+            created_ts=now,
+            updated_ts=now,
+        )
+    )
+
+
+def _embedding(first: float, second: float) -> list[float]:
+    values = [0.0] * EMBEDDING_DIMENSION
+    values[0] = first
+    values[1] = second
+    return values
+
+
+def test_face_candidates_api_returns_ranked_person_candidates_with_per_person_best_match(
+    tmp_path,
+    monkeypatch,
+):
+    client = _client(tmp_path, monkeypatch, "face-candidates-ranked.db")
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'face-candidates-ranked.db'}", future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_photo(connection, photo_id="photo-2")
+        _insert_person(connection, person_id="person-1", display_name="Alex")
+        _insert_person(connection, person_id="person-2", display_name="Blair")
+        _insert_person(connection, person_id="person-3", display_name="Casey")
+        connection.execute(
+            insert(faces),
+            [
+                {
+                    "face_id": "source-face",
+                    "photo_id": "photo-1",
+                    "person_id": None,
+                    "embedding": _embedding(1.0, 0.0),
+                },
+                {
+                    "face_id": "candidate-1-best",
+                    "photo_id": "photo-2",
+                    "person_id": "person-1",
+                    "embedding": _embedding(0.99, 0.01),
+                },
+                {
+                    "face_id": "candidate-1-worse",
+                    "photo_id": "photo-2",
+                    "person_id": "person-1",
+                    "embedding": _embedding(0.8, 0.2),
+                },
+                {
+                    "face_id": "candidate-2",
+                    "photo_id": "photo-2",
+                    "person_id": "person-2",
+                    "embedding": _embedding(0.8, 0.6),
+                },
+                {
+                    "face_id": "candidate-3",
+                    "photo_id": "photo-2",
+                    "person_id": "person-3",
+                    "embedding": _embedding(0.0, 1.0),
+                },
+                {
+                    "face_id": "unlabeled-face",
+                    "photo_id": "photo-2",
+                    "person_id": None,
+                    "embedding": _embedding(0.999, 0.001),
+                },
+            ],
+        )
+
+    response = client.get("/api/v1/faces/source-face/candidates", params={"limit": 2})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["face_id"] == "source-face"
+    assert [candidate["person_id"] for candidate in payload["candidates"]] == [
+        "person-1",
+        "person-2",
+    ]
+    assert [candidate["matched_face_id"] for candidate in payload["candidates"]] == [
+        "candidate-1-best",
+        "candidate-2",
+    ]
+    assert [candidate["display_name"] for candidate in payload["candidates"]] == [
+        "Alex",
+        "Blair",
+    ]
+    assert payload["candidates"][0]["distance"] == pytest.approx(0.000051, abs=1e-4)
+    assert payload["candidates"][1]["distance"] == pytest.approx(0.2, abs=1e-6)
+
+
+def test_face_candidates_api_returns_404_for_missing_face(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "face-candidates-missing-face.db")
+
+    response = client.get("/api/v1/faces/missing-face/candidates")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Face not found"}
+
+
+def test_face_candidates_api_returns_409_when_source_embedding_is_missing(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "face-candidates-missing-embedding.db")
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'face-candidates-missing-embedding.db'}",
+        future=True,
+    )
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        connection.execute(
+            insert(faces).values(
+                face_id="source-face",
+                photo_id="photo-1",
+                person_id=None,
+                embedding=None,
+            )
+        )
+
+    response = client.get("/api/v1/faces/source-face/candidates")
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Face embedding not available"}
+
+
+def test_face_candidates_api_rejects_limit_out_of_bounds(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "face-candidates-invalid-limit.db")
+
+    response = client.get("/api/v1/faces/face-1/candidates", params={"limit": 0})
+
+    assert response.status_code == 422
+
+
+def test_openapi_schema_includes_face_candidate_lookup_path(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "face-candidates-openapi.db")
+
+    response = client.get("/openapi.json")
+
+    assert response.status_code == 200
+    schema = response.json()
+    assert "/api/v1/faces/{face_id}/candidates" in schema["paths"]
+    assert schema["paths"]["/api/v1/faces/{face_id}/candidates"]["get"]["responses"]["409"][
+        "description"
+    ] == "Face embedding not available"

--- a/apps/api/tests/test_face_candidates_service.py
+++ b/apps/api/tests/test_face_candidates_service.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.services import face_candidates as face_candidates_service
+
+
+class _FakeMappingsResult:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = rows
+
+    def first(self) -> dict[str, object] | None:
+        if not self._rows:
+            return None
+        return self._rows[0]
+
+    def all(self) -> list[dict[str, object]]:
+        return list(self._rows)
+
+
+class _FakeExecuteResult:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = rows
+
+    def mappings(self) -> _FakeMappingsResult:
+        return _FakeMappingsResult(self._rows)
+
+
+class _FakeConnection:
+    def __init__(self, *, dialect_name: str, source_embedding: list[float] | None) -> None:
+        self.dialect = SimpleNamespace(name=dialect_name)
+        self._source_embedding = source_embedding
+        self.execute_calls = 0
+
+    def execute(self, statement):  # noqa: ANN001
+        self.execute_calls += 1
+        if self.execute_calls == 1:
+            return _FakeExecuteResult(
+                (
+                    []
+                    if self._source_embedding is None
+                    else [{"face_id": "source-face", "embedding": self._source_embedding}]
+                )
+            )
+        raise AssertionError("Unexpected execute call for this fake connection")
+
+
+def test_lookup_nearest_neighbor_candidates_uses_postgresql_strategy_in_isolation(monkeypatch):
+    connection = _FakeConnection(dialect_name="postgresql", source_embedding=[1.0, 0.0, 0.0])
+    called: dict[str, object] = {}
+
+    def _fake_postgresql_strategy(connection_arg, *, face_id, source_embedding, limit):  # noqa: ANN001
+        called["strategy"] = "postgresql"
+        called["connection"] = connection_arg
+        called["face_id"] = face_id
+        called["source_embedding"] = source_embedding
+        called["limit"] = limit
+        return [
+            {
+                "person_id": "person-1",
+                "display_name": "Alex",
+                "matched_face_id": "match-face-1",
+                "distance": 0.1,
+            }
+        ]
+
+    def _fake_python_strategy(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("Python fallback should not be used for PostgreSQL")
+
+    monkeypatch.setattr(
+        face_candidates_service,
+        "_lookup_candidates_postgresql",
+        _fake_postgresql_strategy,
+    )
+    monkeypatch.setattr(
+        face_candidates_service,
+        "_lookup_candidates_python",
+        _fake_python_strategy,
+    )
+
+    result = face_candidates_service.lookup_nearest_neighbor_candidates(
+        connection,
+        face_id="source-face",
+        limit=7,
+    )
+
+    assert called == {
+        "strategy": "postgresql",
+        "connection": connection,
+        "face_id": "source-face",
+        "source_embedding": [1.0, 0.0, 0.0],
+        "limit": 7,
+    }
+    assert result == {
+        "face_id": "source-face",
+        "candidates": [
+            {
+                "person_id": "person-1",
+                "display_name": "Alex",
+                "matched_face_id": "match-face-1",
+                "distance": 0.1,
+            }
+        ],
+    }
+
+
+def test_lookup_nearest_neighbor_candidates_uses_python_fallback_outside_postgresql(monkeypatch):
+    connection = _FakeConnection(dialect_name="sqlite", source_embedding=[1.0, 0.0, 0.0])
+    called: dict[str, object] = {}
+
+    def _fake_postgresql_strategy(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("PostgreSQL strategy should not be used for SQLite")
+
+    def _fake_python_strategy(connection_arg, *, face_id, source_embedding):  # noqa: ANN001
+        called["strategy"] = "python"
+        called["connection"] = connection_arg
+        called["face_id"] = face_id
+        called["source_embedding"] = source_embedding
+        return [
+            {
+                "person_id": "person-2",
+                "display_name": "Blair",
+                "matched_face_id": "match-face-2",
+                "distance": 0.2,
+            }
+        ]
+
+    monkeypatch.setattr(
+        face_candidates_service,
+        "_lookup_candidates_postgresql",
+        _fake_postgresql_strategy,
+    )
+    monkeypatch.setattr(
+        face_candidates_service,
+        "_lookup_candidates_python",
+        _fake_python_strategy,
+    )
+
+    result = face_candidates_service.lookup_nearest_neighbor_candidates(
+        connection,
+        face_id="source-face",
+        limit=7,
+    )
+
+    assert called == {
+        "strategy": "python",
+        "connection": connection,
+        "face_id": "source-face",
+        "source_embedding": [1.0, 0.0, 0.0],
+    }
+    assert result == {
+        "face_id": "source-face",
+        "candidates": [
+            {
+                "person_id": "person-2",
+                "display_name": "Blair",
+                "matched_face_id": "match-face-2",
+                "distance": 0.2,
+            }
+        ],
+    }


### PR DESCRIPTION
## Summary
- add a nearest-neighbor candidate lookup service for faces using embedding similarity
- expose `GET /api/v1/faces/{face_id}/candidates` with typed response and error handling for missing faces/embeddings
- add isolated service tests for PostgreSQL-vs-fallback strategy selection plus API coverage for ranking, validation, and OpenAPI visibility
- document the candidate lookup endpoint in README basic usage

## Why
- delivers the core candidate lookup slice for recognition suggestions in Phase 5
- keeps SQLite testability while enabling PostgreSQL-optimized vector-distance queries

## Validation
- `uv run --group test python -m pytest apps/api/tests/test_face_candidates_service.py apps/api/tests/test_face_candidates_api.py apps/api/tests/test_face_assignment_api.py`
- `uv run ruff check apps/api/app/services/face_candidates.py apps/api/tests/test_face_candidates_service.py apps/api/tests/test_face_candidates_api.py apps/api/app/routers/face_assignments.py`

Closes #48