### PR TITLE
Implement threshold-based suggestion policy for #49

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Typical usage is expected to be:
 - admin users register sources through `POST /api/v1/storage-sources`, then add, remove, or disable watched folders under those sources
 - the system ingests new photos in the background
 - users search for photos by person, date, and location
-- suggestion workflows can fetch nearest labeled candidates with `GET /api/v1/faces/{face_id}/candidates`
+- suggestion workflows can fetch nearest labeled candidates with `GET /api/v1/faces/{face_id}/candidates`, which applies the configured threshold policy and returns `auto_apply`, `review_needed`, or `no_suggestion`
 - authorized users confirm or correct face associations
 - users monitor ingestion status and recent issues from the UI
 

--- a/apps/api/app/routers/face_assignments.py
+++ b/apps/api/app/routers/face_assignments.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
@@ -80,6 +80,16 @@ class FaceCandidateResponse(BaseModel):
     display_name: str
     matched_face_id: str
     distance: float
+    confidence: float
+
+
+class FaceSuggestionPolicyResponse(BaseModel):
+    """Threshold policy decision for the source face suggestion flow."""
+
+    decision: Literal["auto_apply", "review_needed", "no_suggestion"]
+    review_threshold: float
+    auto_accept_threshold: float
+    top_candidate_confidence: float | None
 
 
 class FaceCandidateLookupResponse(BaseModel):
@@ -93,6 +103,7 @@ class FaceCandidateLookupResponse(BaseModel):
 
     face_id: str
     candidates: list[FaceCandidateResponse]
+    suggestion_policy: FaceSuggestionPolicyResponse
 
 
 @router.post(

--- a/apps/api/app/services/face_candidates.py
+++ b/apps/api/app/services/face_candidates.py
@@ -5,6 +5,12 @@ from math import sqrt
 from sqlalchemy import func, select
 from sqlalchemy.engine import Connection
 
+from app.services.recognition_policy import (
+    SUGGESTION_DECISION_NO_SUGGESTION,
+    classify_suggestion_confidence,
+    distance_to_confidence,
+    resolve_suggestion_thresholds,
+)
 from app.storage import faces, people
 
 
@@ -48,10 +54,33 @@ def lookup_nearest_neighbor_candidates(
             face_id=face_id,
             source_embedding=source_embedding,
         )
+    candidates_with_confidence = _with_candidate_confidence(ordered_candidates)
+    thresholds = resolve_suggestion_thresholds()
+    top_candidate_confidence = (
+        float(candidates_with_confidence[0]["confidence"]) if candidates_with_confidence else None
+    )
+    if top_candidate_confidence is None:
+        suggestion_decision = SUGGESTION_DECISION_NO_SUGGESTION
+    else:
+        suggestion_decision = classify_suggestion_confidence(
+            top_candidate_confidence,
+            review_threshold=thresholds["review_threshold"],
+            auto_accept_threshold=thresholds["auto_accept_threshold"],
+        )
+    if suggestion_decision == SUGGESTION_DECISION_NO_SUGGESTION:
+        candidates = []
+    else:
+        candidates = candidates_with_confidence[:limit]
 
     return {
         "face_id": face_id,
-        "candidates": ordered_candidates[:limit],
+        "candidates": candidates,
+        "suggestion_policy": {
+            "decision": suggestion_decision,
+            "review_threshold": thresholds["review_threshold"],
+            "auto_accept_threshold": thresholds["auto_accept_threshold"],
+            "top_candidate_confidence": top_candidate_confidence,
+        },
     }
 
 
@@ -162,6 +191,16 @@ def _lookup_candidates_python(
         best_by_person.values(),
         key=lambda item: (float(item["distance"]), str(item["person_id"])),
     )
+
+
+def _with_candidate_confidence(candidates: list[dict[str, object]]) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    for candidate in candidates:
+        distance = float(candidate["distance"])
+        enriched = dict(candidate)
+        enriched["confidence"] = distance_to_confidence(distance)
+        results.append(enriched)
+    return results
 
 
 def _coerce_embedding(value: object) -> list[float] | None:

--- a/apps/api/app/services/recognition_policy.py
+++ b/apps/api/app/services/recognition_policy.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import math
+import os
+
+
+DEFAULT_REVIEW_THRESHOLD = 0.7
+DEFAULT_AUTO_ACCEPT_THRESHOLD = 0.9
+
+REVIEW_THRESHOLD_ENV = "PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD"
+AUTO_ACCEPT_THRESHOLD_ENV = "PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD"
+
+SUGGESTION_DECISION_AUTO_APPLY = "auto_apply"
+SUGGESTION_DECISION_REVIEW_NEEDED = "review_needed"
+SUGGESTION_DECISION_NO_SUGGESTION = "no_suggestion"
+
+
+def resolve_suggestion_thresholds(
+    *,
+    review_threshold: float | None = None,
+    auto_accept_threshold: float | None = None,
+) -> dict[str, float]:
+    if review_threshold is None:
+        review_threshold = float(os.getenv(REVIEW_THRESHOLD_ENV, str(DEFAULT_REVIEW_THRESHOLD)))
+    if auto_accept_threshold is None:
+        auto_accept_threshold = float(
+            os.getenv(
+                AUTO_ACCEPT_THRESHOLD_ENV,
+                str(DEFAULT_AUTO_ACCEPT_THRESHOLD),
+            )
+        )
+
+    _validate_threshold("review threshold", review_threshold)
+    _validate_threshold("auto accept threshold", auto_accept_threshold)
+    if auto_accept_threshold < review_threshold:
+        raise ValueError("auto accept threshold must be greater than or equal to review threshold")
+
+    return {
+        "review_threshold": review_threshold,
+        "auto_accept_threshold": auto_accept_threshold,
+    }
+
+
+def distance_to_confidence(distance: float) -> float:
+    return min(1.0, max(0.0, 1.0 - float(distance)))
+
+
+def classify_suggestion_confidence(
+    confidence: float,
+    *,
+    review_threshold: float,
+    auto_accept_threshold: float,
+) -> str:
+    bounded_confidence = min(1.0, max(0.0, confidence))
+    if bounded_confidence >= auto_accept_threshold:
+        return SUGGESTION_DECISION_AUTO_APPLY
+    if bounded_confidence >= review_threshold:
+        return SUGGESTION_DECISION_REVIEW_NEEDED
+    return SUGGESTION_DECISION_NO_SUGGESTION
+
+
+def _validate_threshold(label: str, value: float) -> None:
+    if not math.isfinite(value):
+        raise ValueError(f"{label} must be finite")
+    if value < 0.0 or value > 1.0:
+        raise ValueError(f"{label} must be within [0.0, 1.0]")

--- a/apps/api/tests/test_face_candidates_api.py
+++ b/apps/api/tests/test_face_candidates_api.py
@@ -56,6 +56,8 @@ def test_face_candidates_api_returns_ranked_person_candidates_with_per_person_be
     tmp_path,
     monkeypatch,
 ):
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD", "0.75")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD", "0.95")
     client = _client(tmp_path, monkeypatch, "face-candidates-ranked.db")
 
     engine = create_engine(f"sqlite:///{tmp_path / 'face-candidates-ranked.db'}", future=True)
@@ -126,6 +128,59 @@ def test_face_candidates_api_returns_ranked_person_candidates_with_per_person_be
     ]
     assert payload["candidates"][0]["distance"] == pytest.approx(0.000051, abs=1e-4)
     assert payload["candidates"][1]["distance"] == pytest.approx(0.2, abs=1e-6)
+    assert payload["candidates"][0]["confidence"] == pytest.approx(0.999949, abs=1e-4)
+    assert payload["candidates"][1]["confidence"] == pytest.approx(0.8, abs=1e-6)
+    assert payload["suggestion_policy"] == {
+        "decision": "auto_apply",
+        "review_threshold": 0.75,
+        "auto_accept_threshold": 0.95,
+        "top_candidate_confidence": pytest.approx(0.999949, abs=1e-4),
+    }
+
+
+def test_face_candidates_api_returns_no_suggestion_when_best_confidence_is_below_review_threshold(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD", "0.95")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD", "0.99")
+    client = _client(tmp_path, monkeypatch, "face-candidates-threshold-policy.db")
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'face-candidates-threshold-policy.db'}", future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_photo(connection, photo_id="photo-2")
+        _insert_person(connection, person_id="person-1", display_name="Alex")
+        connection.execute(
+            insert(faces),
+            [
+                {
+                    "face_id": "source-face",
+                    "photo_id": "photo-1",
+                    "person_id": None,
+                    "embedding": _embedding(1.0, 0.0),
+                },
+                {
+                    "face_id": "candidate-1",
+                    "photo_id": "photo-2",
+                    "person_id": "person-1",
+                    "embedding": _embedding(0.8, 0.6),
+                },
+            ],
+        )
+
+    response = client.get("/api/v1/faces/source-face/candidates")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["face_id"] == "source-face"
+    assert payload["candidates"] == []
+    assert payload["suggestion_policy"] == {
+        "decision": "no_suggestion",
+        "review_threshold": 0.95,
+        "auto_accept_threshold": 0.99,
+        "top_candidate_confidence": pytest.approx(0.8, abs=1e-6),
+    }
 
 
 def test_face_candidates_api_returns_404_for_missing_face(tmp_path, monkeypatch):

--- a/apps/api/tests/test_face_candidates_service.py
+++ b/apps/api/tests/test_face_candidates_service.py
@@ -46,6 +46,8 @@ class _FakeConnection:
 
 
 def test_lookup_nearest_neighbor_candidates_uses_postgresql_strategy_in_isolation(monkeypatch):
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD", "0.6")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD", "0.85")
     connection = _FakeConnection(dialect_name="postgresql", source_embedding=[1.0, 0.0, 0.0])
     called: dict[str, object] = {}
 
@@ -99,12 +101,21 @@ def test_lookup_nearest_neighbor_candidates_uses_postgresql_strategy_in_isolatio
                 "display_name": "Alex",
                 "matched_face_id": "match-face-1",
                 "distance": 0.1,
+                "confidence": 0.9,
             }
         ],
+        "suggestion_policy": {
+            "decision": "auto_apply",
+            "review_threshold": 0.6,
+            "auto_accept_threshold": 0.85,
+            "top_candidate_confidence": 0.9,
+        },
     }
 
 
 def test_lookup_nearest_neighbor_candidates_uses_python_fallback_outside_postgresql(monkeypatch):
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD", "0.75")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD", "0.95")
     connection = _FakeConnection(dialect_name="sqlite", source_embedding=[1.0, 0.0, 0.0])
     called: dict[str, object] = {}
 
@@ -156,6 +167,60 @@ def test_lookup_nearest_neighbor_candidates_uses_python_fallback_outside_postgre
                 "display_name": "Blair",
                 "matched_face_id": "match-face-2",
                 "distance": 0.2,
+                "confidence": 0.8,
             }
         ],
+        "suggestion_policy": {
+            "decision": "review_needed",
+            "review_threshold": 0.75,
+            "auto_accept_threshold": 0.95,
+            "top_candidate_confidence": 0.8,
+        },
+    }
+
+
+def test_lookup_nearest_neighbor_candidates_applies_no_suggestion_policy_for_low_confidence(monkeypatch):
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD", "0.9")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD", "0.95")
+    connection = _FakeConnection(dialect_name="sqlite", source_embedding=[1.0, 0.0, 0.0])
+
+    def _fake_postgresql_strategy(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("PostgreSQL strategy should not be used for SQLite")
+
+    def _fake_python_strategy(*args, **kwargs):  # noqa: ANN002, ANN003
+        return [
+            {
+                "person_id": "person-2",
+                "display_name": "Blair",
+                "matched_face_id": "match-face-2",
+                "distance": 0.2,
+            }
+        ]
+
+    monkeypatch.setattr(
+        face_candidates_service,
+        "_lookup_candidates_postgresql",
+        _fake_postgresql_strategy,
+    )
+    monkeypatch.setattr(
+        face_candidates_service,
+        "_lookup_candidates_python",
+        _fake_python_strategy,
+    )
+
+    result = face_candidates_service.lookup_nearest_neighbor_candidates(
+        connection,
+        face_id="source-face",
+        limit=7,
+    )
+
+    assert result == {
+        "face_id": "source-face",
+        "candidates": [],
+        "suggestion_policy": {
+            "decision": "no_suggestion",
+            "review_threshold": 0.9,
+            "auto_accept_threshold": 0.95,
+            "top_candidate_confidence": 0.8,
+        },
     }

--- a/apps/api/tests/test_recognition_policy.py
+++ b/apps/api/tests/test_recognition_policy.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.recognition_policy import (
+    classify_suggestion_confidence,
+    distance_to_confidence,
+    resolve_suggestion_thresholds,
+)
+
+
+def test_resolve_suggestion_thresholds_reads_environment_overrides(monkeypatch):
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD", "0.7")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD", "0.9")
+
+    thresholds = resolve_suggestion_thresholds()
+
+    assert thresholds == {"review_threshold": 0.7, "auto_accept_threshold": 0.9}
+
+
+def test_resolve_suggestion_thresholds_rejects_invalid_range(monkeypatch):
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD", "0.9")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD", "0.8")
+
+    with pytest.raises(ValueError, match="auto accept threshold must be greater than or equal to review threshold"):
+        resolve_suggestion_thresholds()
+
+
+@pytest.mark.parametrize(
+    ("distance", "expected"),
+    [
+        (0.2, 0.8),
+        (1.2, 0.0),
+        (-0.2, 1.0),
+    ],
+)
+def test_distance_to_confidence_clamps_into_zero_to_one(distance: float, expected: float):
+    assert distance_to_confidence(distance) == pytest.approx(expected, abs=1e-6)
+
+
+def test_classify_suggestion_confidence_supports_three_policy_bands():
+    assert classify_suggestion_confidence(0.95, review_threshold=0.7, auto_accept_threshold=0.9) == "auto_apply"
+    assert classify_suggestion_confidence(0.8, review_threshold=0.7, auto_accept_threshold=0.9) == "review_needed"
+    assert classify_suggestion_confidence(0.6, review_threshold=0.7, auto_accept_threshold=0.9) == "no_suggestion"


### PR DESCRIPTION
## Summary
- add a reusable recognition suggestion threshold policy module with configurable `review` and `auto-accept` thresholds
- apply threshold policy to face candidate lookup by computing candidate confidence, classifying top confidence, and suppressing candidates when policy resolves to `no_suggestion`
- extend face-candidate API response to include per-candidate confidence plus a `suggestion_policy` payload
- add policy/service/API tests and update README usage documentation

## Testing
- `uv run pytest apps/api/tests/test_recognition_policy.py apps/api/tests/test_face_candidates_service.py apps/api/tests/test_face_candidates_api.py`
- `uv run pytest apps/api/tests/test_face_assignment_api.py apps/api/tests/test_openapi_docs.py`
- `uv run ruff check apps/api/app/services/recognition_policy.py apps/api/app/services/face_candidates.py apps/api/app/routers/face_assignments.py apps/api/tests/test_recognition_policy.py apps/api/tests/test_face_candidates_service.py apps/api/tests/test_face_candidates_api.py README.md`

Closes #49