### PR TITLE
[codex] implement conservative auto-apply for high-confidence matches

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Typical usage is expected to be:
 - admin users register sources through `POST /api/v1/storage-sources`, then add, remove, or disable watched folders under those sources
 - the system ingests new photos in the background
 - users search for photos by person, date, and location
-- suggestion workflows can fetch nearest labeled candidates with `GET /api/v1/faces/{face_id}/candidates`, which applies the configured threshold policy and returns `auto_apply`, `review_needed`, or `no_suggestion`
+- suggestion workflows can fetch nearest labeled candidates with `GET /api/v1/faces/{face_id}/candidates`; when policy resolves to `auto_apply` and the source face is still unlabeled, the API auto-assigns the top candidate, records a `machine_applied` label event, and returns `auto_applied_assignment` in the response
 - authorized users confirm or correct face associations
 - users monitor ingestion status and recent issues from the UI
 

--- a/apps/api/app/routers/face_assignments.py
+++ b/apps/api/app/routers/face_assignments.py
@@ -13,6 +13,7 @@ from app.services.face_assignment import (
     FaceNotAssignedError,
     FaceNotFoundError,
     PersonNotFoundError,
+    auto_apply_face_suggestion,
     assign_face_to_person,
     reassign_face_to_person,
 )
@@ -21,6 +22,7 @@ from app.services.face_candidates import (
     FaceNotFoundError as FaceCandidateNotFoundError,
     lookup_nearest_neighbor_candidates,
 )
+from app.services.recognition_policy import SUGGESTION_DECISION_AUTO_APPLY
 
 
 router = APIRouter(prefix="/faces", tags=["face-labeling"])
@@ -83,6 +85,15 @@ class FaceCandidateResponse(BaseModel):
     confidence: float
 
 
+class AutoAppliedFaceAssignmentResponse(BaseModel):
+    """Auto-applied assignment details for high-confidence suggestions."""
+
+    face_id: str
+    photo_id: str
+    person_id: str
+    confidence: float
+
+
 class FaceSuggestionPolicyResponse(BaseModel):
     """Threshold policy decision for the source face suggestion flow."""
 
@@ -104,6 +115,7 @@ class FaceCandidateLookupResponse(BaseModel):
     face_id: str
     candidates: list[FaceCandidateResponse]
     suggestion_policy: FaceSuggestionPolicyResponse
+    auto_applied_assignment: AutoAppliedFaceAssignmentResponse | None = None
 
 
 @router.post(
@@ -206,5 +218,26 @@ def lookup_face_candidates_endpoint(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     except FaceEmbeddingNotAvailableError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    suggestion_policy = result["suggestion_policy"]
+    candidates = result["candidates"]
+    if (
+        suggestion_policy["decision"] == SUGGESTION_DECISION_AUTO_APPLY
+        and isinstance(candidates, list)
+        and candidates
+    ):
+        top_candidate = candidates[0]
+        auto_applied_assignment = auto_apply_face_suggestion(
+            db.connection(),
+            face_id=face_id,
+            person_id=str(top_candidate["person_id"]),
+            confidence=float(top_candidate["confidence"]),
+            matched_face_id=str(top_candidate["matched_face_id"]),
+            review_threshold=float(suggestion_policy["review_threshold"]),
+            auto_accept_threshold=float(suggestion_policy["auto_accept_threshold"]),
+        )
+        if auto_applied_assignment is not None:
+            result["auto_applied_assignment"] = auto_applied_assignment
+            db.commit()
 
     return FaceCandidateLookupResponse.model_validate(result)

--- a/apps/api/app/services/face_assignment.py
+++ b/apps/api/app/services/face_assignment.py
@@ -6,7 +6,10 @@ from sqlalchemy import insert, select, update
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
-from photoorg_db_schema import FACE_LABEL_SOURCE_HUMAN_CONFIRMED
+from photoorg_db_schema import (
+    FACE_LABEL_SOURCE_HUMAN_CONFIRMED,
+    FACE_LABEL_SOURCE_MACHINE_APPLIED,
+)
 
 from app.storage import face_labels, faces, people
 
@@ -128,6 +131,55 @@ def reassign_face_to_person(
     }
 
 
+def auto_apply_face_suggestion(
+    connection: Connection,
+    *,
+    face_id: str,
+    person_id: str,
+    confidence: float,
+    matched_face_id: str,
+    review_threshold: float,
+    auto_accept_threshold: float,
+) -> dict[str, object] | None:
+    if not _person_exists(connection, person_id):
+        return None
+
+    try:
+        result = connection.execute(
+            update(faces)
+            .where(
+                faces.c.face_id == face_id,
+                faces.c.person_id.is_(None),
+            )
+            .values(person_id=person_id)
+        )
+    except IntegrityError as exc:
+        _raise_person_not_found_on_fk_violation(
+            connection,
+            person_id=person_id,
+            exc=exc,
+        )
+        return None
+
+    if result.rowcount != 1:
+        return None
+
+    assignment = _face_assignment(connection, face_id)
+    _persist_machine_applied_face_label_event(
+        connection,
+        face_id=face_id,
+        person_id=person_id,
+        confidence=confidence,
+        matched_face_id=matched_face_id,
+        review_threshold=review_threshold,
+        auto_accept_threshold=auto_accept_threshold,
+    )
+    return {
+        **assignment,
+        "confidence": float(confidence),
+    }
+
+
 def _face_row(connection: Connection, face_id: str):
     return (
         connection.execute(
@@ -201,5 +253,35 @@ def _persist_face_label_event(
             confidence=None,
             model_version=None,
             provenance=provenance,
+        )
+    )
+
+
+def _persist_machine_applied_face_label_event(
+    connection: Connection,
+    *,
+    face_id: str,
+    person_id: str,
+    confidence: float,
+    matched_face_id: str,
+    review_threshold: float,
+    auto_accept_threshold: float,
+) -> None:
+    connection.execute(
+        insert(face_labels).values(
+            face_label_id=str(uuid4()),
+            face_id=face_id,
+            person_id=person_id,
+            label_source=FACE_LABEL_SOURCE_MACHINE_APPLIED,
+            confidence=float(confidence),
+            model_version=None,
+            provenance={
+                "workflow": "recognition-suggestions",
+                "surface": "api",
+                "action": "auto_apply",
+                "matched_face_id": matched_face_id,
+                "review_threshold": float(review_threshold),
+                "auto_accept_threshold": float(auto_accept_threshold),
+            },
         )
     )

--- a/apps/api/tests/test_face_candidates_api.py
+++ b/apps/api/tests/test_face_candidates_api.py
@@ -4,12 +4,12 @@ from datetime import UTC, datetime
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, insert
+from sqlalchemy import create_engine, insert, select
 
 from app.dependencies import _get_session_factory
 from app.main import app
 from app.migrations import upgrade_database
-from app.storage import faces, people, photos
+from app.storage import face_labels, faces, people, photos
 from photoorg_db_schema import EMBEDDING_DIMENSION
 
 
@@ -136,6 +136,41 @@ def test_face_candidates_api_returns_ranked_person_candidates_with_per_person_be
         "auto_accept_threshold": 0.95,
         "top_candidate_confidence": pytest.approx(0.999949, abs=1e-4),
     }
+    assert payload["auto_applied_assignment"] == {
+        "face_id": "source-face",
+        "photo_id": "photo-1",
+        "person_id": "person-1",
+        "confidence": pytest.approx(0.999949, abs=1e-4),
+    }
+
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "source-face")
+        ).scalar_one()
+        persisted_label = connection.execute(
+            select(
+                face_labels.c.face_id,
+                face_labels.c.person_id,
+                face_labels.c.label_source,
+                face_labels.c.confidence,
+                face_labels.c.model_version,
+                face_labels.c.provenance,
+            ).where(face_labels.c.face_id == "source-face")
+        ).mappings().one()
+    assert persisted_person_id == "person-1"
+    assert persisted_label["face_id"] == "source-face"
+    assert persisted_label["person_id"] == "person-1"
+    assert persisted_label["label_source"] == "machine_applied"
+    assert persisted_label["confidence"] == pytest.approx(0.999949, abs=1e-4)
+    assert persisted_label["model_version"] is None
+    assert persisted_label["provenance"] == {
+        "workflow": "recognition-suggestions",
+        "surface": "api",
+        "action": "auto_apply",
+        "matched_face_id": "candidate-1-best",
+        "review_threshold": 0.75,
+        "auto_accept_threshold": 0.95,
+    }
 
 
 def test_face_candidates_api_returns_no_suggestion_when_best_confidence_is_below_review_threshold(
@@ -181,6 +216,56 @@ def test_face_candidates_api_returns_no_suggestion_when_best_confidence_is_below
         "auto_accept_threshold": 0.99,
         "top_candidate_confidence": pytest.approx(0.8, abs=1e-6),
     }
+    assert payload.get("auto_applied_assignment") is None
+
+
+def test_face_candidates_api_does_not_overwrite_existing_assignment_when_policy_is_auto_apply(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD", "0.75")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD", "0.95")
+    client = _client(tmp_path, monkeypatch, "face-candidates-no-overwrite.db")
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'face-candidates-no-overwrite.db'}", future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_photo(connection, photo_id="photo-2")
+        _insert_person(connection, person_id="person-1", display_name="Alex")
+        _insert_person(connection, person_id="person-2", display_name="Blair")
+        connection.execute(
+            insert(faces),
+            [
+                {
+                    "face_id": "source-face",
+                    "photo_id": "photo-1",
+                    "person_id": "person-2",
+                    "embedding": _embedding(1.0, 0.0),
+                },
+                {
+                    "face_id": "candidate-1-best",
+                    "photo_id": "photo-2",
+                    "person_id": "person-1",
+                    "embedding": _embedding(0.99, 0.01),
+                },
+            ],
+        )
+
+    response = client.get("/api/v1/faces/source-face/candidates", params={"limit": 1})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["suggestion_policy"]["decision"] == "auto_apply"
+    assert payload.get("auto_applied_assignment") is None
+    with engine.connect() as connection:
+        persisted_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "source-face")
+        ).scalar_one()
+        machine_labels = connection.execute(
+            select(face_labels.c.face_label_id).where(face_labels.c.face_id == "source-face")
+        ).all()
+    assert persisted_person_id == "person-2"
+    assert machine_labels == []
 
 
 def test_face_candidates_api_returns_404_for_missing_face(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- implement conservative high-confidence auto-apply for `GET /api/v1/faces/{face_id}/candidates`
- only auto-apply when the source face is still unlabeled (`faces.person_id IS NULL`)
- persist a `machine_applied` `face_labels` event with confidence and threshold/match provenance
- include `auto_applied_assignment` in the candidate lookup response when an auto-apply write occurs
- document the API behavior in `README.md`

## Why
Issue #50 requires a bounded, conservative auto-apply slice for high-confidence matches. The recognition policy already produced `auto_apply`, but no write path existed to apply that decision.

## Behavior Notes
- no overwrite: existing face assignments are never changed by this path
- no-op if the candidate person no longer exists
- auto-apply metadata is explicit and auditable through `face_labels`

## Validation
- `uv run pytest apps/api/tests/test_face_candidates_api.py -q`
- `uv run pytest apps/api/tests/test_face_candidates_service.py apps/api/tests/test_face_assignment_api.py -q`
- `uv run ruff check apps/api/app/services/face_assignment.py apps/api/app/routers/face_assignments.py apps/api/tests/test_face_candidates_api.py`

Closes #50