### PR TITLE
[codex] implement logged-in user menu and account action entry points

### DIFF
--- a/apps/ui/docs/account-menu-handoff.md
+++ b/apps/ui/docs/account-menu-handoff.md
@@ -1,0 +1,22 @@
+# Account Menu Handoff Expectations
+
+Story: #165 (`Implement logged-in user menu and account action entry points`)
+
+The shell account surface behavior is:
+
+- When session identity context exists, header shows signed-in identity name and email.
+- Account actions are exposed through a keyboard-focusable `Account` button with:
+  - `Account settings (coming soon)` placeholder entry point
+  - `Sign out` entry point
+- Selecting `Sign out` transitions shell identity into the deterministic fallback state.
+
+Fallback behavior for missing identity context:
+
+- Header shows `Session unavailable`.
+- Account action button is disabled with accessible label `Account actions unavailable`.
+
+Bootstrap notes:
+
+- `window.__PHOTO_ORG_SESSION__` may provide initial identity payload.
+- When no bootstrap value is set, UI uses deterministic local demo identity.
+- Invalid bootstrap payload or explicit `null` uses fallback state.

--- a/apps/ui/src/app/AppRouter.tsx
+++ b/apps/ui/src/app/AppRouter.tsx
@@ -4,8 +4,10 @@ import {
   Outlet,
   Route,
   Routes,
+  useNavigate,
   useLocation
 } from "react-router-dom";
+import { useState } from "react";
 import { AppShell } from "./AppShell";
 import {
   findPrimaryRoute,
@@ -14,14 +16,33 @@ import {
 } from "../routes/routeDefinitions";
 import { PrimaryRoutePage } from "../pages/PrimaryRoutePage";
 import { NotFoundPage } from "../pages/NotFoundPage";
+import {
+  resolveInitialSessionIdentity,
+  type SessionIdentity
+} from "../session/sessionIdentity";
 
-function AppShellLayout() {
+interface AppShellLayoutProps {
+  sessionIdentity: SessionIdentity | null;
+  onSignOut: () => void;
+}
+
+function AppShellLayout({ sessionIdentity, onSignOut }: AppShellLayoutProps) {
   const location = useLocation();
+  const navigate = useNavigate();
   const activeRoute =
     findPrimaryRoute(location.pathname) ?? PRIMARY_ROUTE_DEFINITIONS[0];
 
+  function handleSignOut() {
+    onSignOut();
+    navigate("/browse", { replace: true });
+  }
+
   return (
-    <AppShell activeRoute={activeRoute}>
+    <AppShell
+      activeRoute={activeRoute}
+      sessionIdentity={sessionIdentity}
+      onSignOut={handleSignOut}
+    >
       <Outlet />
     </AppShell>
   );
@@ -31,10 +52,29 @@ function routePath(route: PrimaryRouteDefinition): string {
   return route.path.replace(/^\//, "");
 }
 
-export function AppRouteTree() {
+interface AppRouteTreeProps {
+  initialSessionIdentity?: SessionIdentity | null;
+}
+
+export function AppRouteTree({ initialSessionIdentity }: AppRouteTreeProps = {}) {
+  const [sessionIdentity, setSessionIdentity] = useState<SessionIdentity | null>(() => {
+    if (initialSessionIdentity !== undefined) {
+      return initialSessionIdentity;
+    }
+
+    return resolveInitialSessionIdentity();
+  });
+
   return (
     <Routes>
-      <Route element={<AppShellLayout />}>
+      <Route
+        element={
+          <AppShellLayout
+            sessionIdentity={sessionIdentity}
+            onSignOut={() => setSessionIdentity(null)}
+          />
+        }
+      >
         <Route path="/" element={<Navigate to="/browse" replace />} />
         {PRIMARY_ROUTE_DEFINITIONS.map((route) => (
           <Route

--- a/apps/ui/src/app/AppShell.test.tsx
+++ b/apps/ui/src/app/AppShell.test.tsx
@@ -3,14 +3,21 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { AppRouteTree } from "./AppRouter";
 import { PRIMARY_ROUTE_DEFINITIONS } from "../routes/routeDefinitions";
+import type { SessionIdentity } from "../session/sessionIdentity";
 
-function renderAtPath(path: string) {
+const TEST_SESSION_IDENTITY: SessionIdentity = {
+  userId: "test-operator",
+  displayName: "Avery Operator",
+  email: "avery.operator@example.com"
+};
+
+function renderAtPath(path: string, sessionIdentity: SessionIdentity | null = TEST_SESSION_IDENTITY) {
   return render(
     <MemoryRouter
       initialEntries={[path]}
       future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
     >
-      <AppRouteTree />
+      <AppRouteTree initialSessionIdentity={sessionIdentity} />
     </MemoryRouter>
   );
 }
@@ -54,5 +61,47 @@ describe("App shell", () => {
         level: 1
       })
     ).toBeInTheDocument();
+  });
+
+  it("renders user identity and exposes keyboard-accessible account actions", async () => {
+    const user = userEvent.setup();
+    renderAtPath("/browse");
+
+    expect(screen.getByText("Avery Operator")).toBeInTheDocument();
+    expect(screen.getByText("avery.operator@example.com")).toBeInTheDocument();
+
+    const accountActions = screen.getByRole("button", { name: "Account actions" });
+    accountActions.focus();
+    await user.keyboard("{Enter}");
+
+    expect(accountActions).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: "Sign out" })).toBeInTheDocument();
+  });
+
+  it("shows deterministic fallback when identity context is missing", () => {
+    renderAtPath("/browse", null);
+
+    expect(screen.getByText("Session unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Account actions unavailable"
+      })
+    ).toBeDisabled();
+  });
+
+  it("switches to fallback state after sign-out entry point", async () => {
+    const user = userEvent.setup();
+    renderAtPath("/search");
+
+    await user.click(screen.getByRole("button", { name: "Account actions" }));
+    await user.click(screen.getByRole("button", { name: "Sign out" }));
+
+    expect(screen.getByText("Session unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Account actions unavailable"
+      })
+    ).toBeDisabled();
+    expect(screen.getByRole("heading", { name: "Browse", level: 1 })).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/app/AppShell.tsx
+++ b/apps/ui/src/app/AppShell.tsx
@@ -1,23 +1,126 @@
 import { NavLink } from "react-router-dom";
-import type { ReactNode } from "react";
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import {
   PRIMARY_ROUTE_DEFINITIONS,
   type PrimaryRouteDefinition
 } from "../routes/routeDefinitions";
+import type { SessionIdentity } from "../session/sessionIdentity";
 
 interface AppShellProps {
   activeRoute: PrimaryRouteDefinition;
+  sessionIdentity: SessionIdentity | null;
+  onSignOut: () => void;
   children: ReactNode;
 }
 
-export function AppShell({ activeRoute, children }: AppShellProps) {
+interface AccountMenuProps {
+  sessionIdentity: SessionIdentity | null;
+  onSignOut: () => void;
+}
+
+function AccountMenu({ sessionIdentity, onSignOut }: AccountMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const menuId = useId();
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    function handleOutsideClick(event: MouseEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleOutsideClick);
+    document.addEventListener("keydown", handleEscape);
+
+    return () => {
+      document.removeEventListener("mousedown", handleOutsideClick);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [isOpen]);
+
+  if (!sessionIdentity) {
+    return (
+      <div className="shell-account" data-session-state="missing">
+        <p className="shell-account-label">Session</p>
+        <p className="shell-account-name">Session unavailable</p>
+        <button
+          type="button"
+          className="shell-account-trigger"
+          disabled
+          aria-label="Account actions unavailable"
+        >
+          Account
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="shell-account" data-session-state="available" ref={containerRef}>
+      <p className="shell-account-label">Signed in</p>
+      <p className="shell-account-name">{sessionIdentity.displayName}</p>
+      <p className="shell-account-email">{sessionIdentity.email}</p>
+      <button
+        type="button"
+        className="shell-account-trigger"
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        aria-controls={menuId}
+        aria-label="Account actions"
+        onClick={() => setIsOpen((open) => !open)}
+      >
+        Account
+      </button>
+      {isOpen ? (
+        <ul className="shell-account-menu" id={menuId} aria-label="Account actions list">
+          <li>
+            <button type="button" className="shell-account-action" disabled>
+              Account settings (coming soon)
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              className="shell-account-action"
+              onClick={() => {
+                onSignOut();
+                setIsOpen(false);
+              }}
+            >
+              Sign out
+            </button>
+          </li>
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+export function AppShell({
+  activeRoute,
+  sessionIdentity,
+  onSignOut,
+  children
+}: AppShellProps) {
   return (
     <div className="app-shell" data-shell-route={activeRoute.key}>
       <header className="shell-header">
-        <div>
+        <div className="shell-title">
           <p className="shell-product">Photo Organizer</p>
           <p className="shell-context">{activeRoute.title}</p>
         </div>
+        <AccountMenu sessionIdentity={sessionIdentity} onSignOut={onSignOut} />
       </header>
 
       <nav aria-label="Primary" className="shell-nav">

--- a/apps/ui/src/session/sessionIdentity.ts
+++ b/apps/ui/src/session/sessionIdentity.ts
@@ -1,0 +1,58 @@
+export interface SessionIdentity {
+  userId: string;
+  displayName: string;
+  email: string;
+}
+
+export const DEMO_SESSION_IDENTITY: SessionIdentity = {
+  userId: "demo-operator",
+  displayName: "Demo Operator",
+  email: "operator@photo-org.local"
+};
+
+interface SessionIdentityBootstrapShape {
+  userId?: unknown;
+  displayName?: unknown;
+  email?: unknown;
+}
+
+declare global {
+  interface Window {
+    __PHOTO_ORG_SESSION__?: SessionIdentityBootstrapShape | null;
+  }
+}
+
+function isSessionIdentity(value: unknown): value is SessionIdentity {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as SessionIdentityBootstrapShape;
+
+  return (
+    typeof candidate.userId === "string" &&
+    candidate.userId.length > 0 &&
+    typeof candidate.displayName === "string" &&
+    candidate.displayName.length > 0 &&
+    typeof candidate.email === "string" &&
+    candidate.email.length > 0
+  );
+}
+
+export function resolveInitialSessionIdentity(): SessionIdentity | null {
+  if (typeof window === "undefined") {
+    return DEMO_SESSION_IDENTITY;
+  }
+
+  const bootstrappedIdentity = window.__PHOTO_ORG_SESSION__;
+
+  if (bootstrappedIdentity === undefined) {
+    return DEMO_SESSION_IDENTITY;
+  }
+
+  if (isSessionIdentity(bootstrappedIdentity)) {
+    return bootstrappedIdentity;
+  }
+
+  return null;
+}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -26,8 +26,16 @@ body {
   grid-area: header;
   background: #0f2a43;
   color: #f8fafc;
-  padding: 0.8rem 1.2rem;
+  padding: 0.8rem 1.2rem 1rem;
   border-bottom: 3px solid #1d4ed8;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.shell-title {
+  min-width: 0;
 }
 
 .shell-product {
@@ -42,6 +50,88 @@ body {
   margin: 0.2rem 0 0;
   font-size: 1.2rem;
   font-weight: 600;
+}
+
+.shell-account {
+  position: relative;
+  text-align: right;
+  max-width: min(21rem, 100%);
+}
+
+.shell-account-label {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 0.65rem;
+  opacity: 0.78;
+}
+
+.shell-account-name {
+  margin: 0.2rem 0 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.shell-account-email {
+  margin: 0.12rem 0 0.5rem;
+  font-size: 0.78rem;
+  opacity: 0.88;
+}
+
+.shell-account[data-session-state="missing"] .shell-account-email {
+  display: none;
+}
+
+.shell-account-trigger {
+  border: 1px solid #7aa2d8;
+  background: #11395f;
+  color: #f8fafc;
+  border-radius: 0.45rem;
+  padding: 0.4rem 0.65rem;
+  font: inherit;
+  cursor: pointer;
+}
+
+.shell-account-trigger:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.shell-account-menu {
+  margin: 0.45rem 0 0;
+  padding: 0.35rem;
+  list-style: none;
+  border: 1px solid #bfdbfe;
+  border-radius: 0.5rem;
+  background: #f8fbff;
+  color: #0f172a;
+  min-width: 13rem;
+  box-shadow: 0 10px 28px rgba(15, 42, 67, 0.25);
+  position: absolute;
+  right: 0;
+  z-index: 10;
+}
+
+.shell-account-action {
+  width: 100%;
+  text-align: left;
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  border-radius: 0.35rem;
+  padding: 0.4rem 0.5rem;
+  font: inherit;
+}
+
+.shell-account-action:not(:disabled):hover {
+  background: #dbeafe;
+  border-color: #93c5fd;
+  cursor: pointer;
+}
+
+.shell-account-action:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .shell-nav {

--- a/apps/ui/tests/e2e/technical/navigation-state.spec.ts
+++ b/apps/ui/tests/e2e/technical/navigation-state.spec.ts
@@ -41,3 +41,24 @@ test(
     await expect(page.getByRole("heading", { name: "Operations", level: 1 })).toBeVisible();
   }
 );
+
+test(
+  "technical: account actions are keyboard-accessible and sign-out reaches fallback state @technical",
+  async ({ page }) => {
+    await page.goto("/browse");
+
+    const accountButton = page.getByRole("button", { name: "Account actions" });
+
+    await expect(accountButton).toBeVisible();
+    await accountButton.focus();
+    await page.keyboard.press("Enter");
+
+    await expect(page.getByRole("button", { name: "Sign out" })).toBeVisible();
+    await page.getByRole("button", { name: "Sign out" }).click();
+
+    await expect(page.getByText("Session unavailable")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Account actions unavailable" })
+    ).toBeDisabled();
+  }
+);


### PR DESCRIPTION
## Summary
- add a logged-in user identity surface in the global shell header
- add an account actions menu with a sign-out entry point
- add deterministic fallback behavior when session identity context is missing

## What Changed
- wired shell session identity bootstrap and sign-out state transitions in `AppRouteTree`
- implemented account actions UI in `AppShell` with keyboard-open interaction support
- added shell styles for account identity and fallback states
- added unit + Playwright technical coverage for account menu behavior and fallback
- documented account menu handoff expectations

## Validation
- `npm test`
- `npm run test:e2e:smoke`
- `npm run test:e2e:technical`
- `npm run build`

Closes #165