### PR TITLE
feat(ui): implement global navigation state model for routes

### DIFF
--- a/apps/ui/src/app/AppRouter.tsx
+++ b/apps/ui/src/app/AppRouter.tsx
@@ -10,8 +10,8 @@ import {
 import { useState } from "react";
 import { AppShell } from "./AppShell";
 import {
-  findPrimaryRoute,
   PRIMARY_ROUTE_DEFINITIONS,
+  resolveNavigationState,
   type PrimaryRouteDefinition
 } from "../routes/routeDefinitions";
 import { PrimaryRoutePage } from "../pages/PrimaryRoutePage";
@@ -29,8 +29,7 @@ interface AppShellLayoutProps {
 function AppShellLayout({ sessionIdentity, onSignOut }: AppShellLayoutProps) {
   const location = useLocation();
   const navigate = useNavigate();
-  const activeRoute =
-    findPrimaryRoute(location.pathname) ?? PRIMARY_ROUTE_DEFINITIONS[0];
+  const navigationState = resolveNavigationState(location.pathname);
 
   function handleSignOut() {
     onSignOut();
@@ -39,7 +38,7 @@ function AppShellLayout({ sessionIdentity, onSignOut }: AppShellLayoutProps) {
 
   return (
     <AppShell
-      activeRoute={activeRoute}
+      navigationState={navigationState}
       sessionIdentity={sessionIdentity}
       onSignOut={handleSignOut}
     >

--- a/apps/ui/src/app/AppShell.test.tsx
+++ b/apps/ui/src/app/AppShell.test.tsx
@@ -22,6 +22,12 @@ function renderAtPath(path: string, sessionIdentity: SessionIdentity | null = TE
   );
 }
 
+function expectShellContextText(text: string) {
+  const shellContext = document.querySelector(".shell-context");
+  expect(shellContext).not.toBeNull();
+  expect(shellContext).toHaveTextContent(text);
+}
+
 describe("App shell", () => {
   it.each(PRIMARY_ROUTE_DEFINITIONS)(
     "renders shared shell regions for $path",
@@ -61,6 +67,9 @@ describe("App shell", () => {
         level: 1
       })
     ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Search" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "Browse" })).not.toHaveAttribute("aria-current");
+    expectShellContextText("Search");
   });
 
   it("renders user identity and exposes keyboard-accessible account actions", async () => {
@@ -103,5 +112,13 @@ describe("App shell", () => {
       })
     ).toBeDisabled();
     expect(screen.getByRole("heading", { name: "Browse", level: 1 })).toBeInTheDocument();
+  });
+
+  it("uses deterministic fallback nav and context for unknown route paths", () => {
+    renderAtPath("/unknown-route");
+
+    expect(screen.getByRole("heading", { name: "Page Not Found", level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Browse" })).toHaveAttribute("aria-current", "page");
+    expectShellContextText("Browse");
   });
 });

--- a/apps/ui/src/app/AppShell.tsx
+++ b/apps/ui/src/app/AppShell.tsx
@@ -1,13 +1,13 @@
-import { NavLink } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import {
   PRIMARY_ROUTE_DEFINITIONS,
-  type PrimaryRouteDefinition
+  type NavigationState
 } from "../routes/routeDefinitions";
 import type { SessionIdentity } from "../session/sessionIdentity";
 
 interface AppShellProps {
-  activeRoute: PrimaryRouteDefinition;
+  navigationState: NavigationState;
   sessionIdentity: SessionIdentity | null;
   onSignOut: () => void;
   children: ReactNode;
@@ -108,34 +108,38 @@ function AccountMenu({ sessionIdentity, onSignOut }: AccountMenuProps) {
 }
 
 export function AppShell({
-  activeRoute,
+  navigationState,
   sessionIdentity,
   onSignOut,
   children
 }: AppShellProps) {
   return (
-    <div className="app-shell" data-shell-route={activeRoute.key}>
+    <div className="app-shell" data-shell-route={navigationState.activeRoute.key}>
       <header className="shell-header">
         <div className="shell-title">
           <p className="shell-product">Photo Organizer</p>
-          <p className="shell-context">{activeRoute.title}</p>
+          <p className="shell-context">{navigationState.pageContext}</p>
         </div>
         <AccountMenu sessionIdentity={sessionIdentity} onSignOut={onSignOut} />
       </header>
 
       <nav aria-label="Primary" className="shell-nav">
         <ul>
-          {PRIMARY_ROUTE_DEFINITIONS.map((route) => (
-            <li key={route.key}>
-              <NavLink
-                to={route.path}
-                className={({ isActive }) => (isActive ? "active" : undefined)}
-                end
-              >
-                {route.navLabel}
-              </NavLink>
-            </li>
-          ))}
+          {PRIMARY_ROUTE_DEFINITIONS.map((route) => {
+            const isActive = route.key === navigationState.activeRoute.key;
+
+            return (
+              <li key={route.key}>
+                <Link
+                  to={route.path}
+                  className={isActive ? "active" : undefined}
+                  aria-current={isActive ? "page" : undefined}
+                >
+                  {route.navLabel}
+                </Link>
+              </li>
+            );
+          })}
         </ul>
       </nav>
 

--- a/apps/ui/src/routes/routeDefinitions.test.ts
+++ b/apps/ui/src/routes/routeDefinitions.test.ts
@@ -1,4 +1,7 @@
-import { PRIMARY_ROUTE_DEFINITIONS } from "./routeDefinitions";
+import {
+  PRIMARY_ROUTE_DEFINITIONS,
+  resolveNavigationState
+} from "./routeDefinitions";
 
 describe("Shell handoff expectations", () => {
   it("defines loading and error behavior for each primary route", () => {
@@ -7,5 +10,31 @@ describe("Shell handoff expectations", () => {
       expect(route.handoff.error).not.toHaveLength(0);
       expect(route.handoff.transition).not.toHaveLength(0);
     }
+  });
+});
+
+describe("Navigation state", () => {
+  it("maps an exact primary route pathname to matching nav and context", () => {
+    const navigationState = resolveNavigationState("/search");
+
+    expect(navigationState.activeRoute.key).toBe("search");
+    expect(navigationState.pageContext).toBe("Search");
+    expect(navigationState.usesFallback).toBe(false);
+  });
+
+  it("maps nested route pathnames to the owning primary nav destination", () => {
+    const navigationState = resolveNavigationState("/operations/activity/123");
+
+    expect(navigationState.activeRoute.key).toBe("operations");
+    expect(navigationState.pageContext).toBe("Operations");
+    expect(navigationState.usesFallback).toBe(false);
+  });
+
+  it("falls back deterministically when pathname is unknown", () => {
+    const navigationState = resolveNavigationState("/not-a-real-route");
+
+    expect(navigationState.activeRoute.key).toBe("browse");
+    expect(navigationState.pageContext).toBe("Browse");
+    expect(navigationState.usesFallback).toBe(true);
   });
 });

--- a/apps/ui/src/routes/routeDefinitions.ts
+++ b/apps/ui/src/routes/routeDefinitions.ts
@@ -20,6 +20,12 @@ export interface PrimaryRouteDefinition {
   handoff: ShellHandoffExpectations;
 }
 
+export interface NavigationState {
+  activeRoute: PrimaryRouteDefinition;
+  pageContext: string;
+  usesFallback: boolean;
+}
+
 const baseHandoffExpectation: ShellHandoffExpectations = {
   loading:
     "Keep header and navigation visible while content shows a route-local loading state.",
@@ -72,6 +78,37 @@ export const PRIMARY_ROUTE_DEFINITIONS: PrimaryRouteDefinition[] = [
   }
 ];
 
+export const FALLBACK_PRIMARY_ROUTE = PRIMARY_ROUTE_DEFINITIONS[0];
+
+function normalizePathname(pathname: string): string {
+  const withLeadingSlash = pathname.startsWith("/") ? pathname : `/${pathname}`;
+
+  if (withLeadingSlash === "/") {
+    return withLeadingSlash;
+  }
+
+  return withLeadingSlash.replace(/\/+$/, "");
+}
+
+function routeOwnsPathname(route: PrimaryRouteDefinition, pathname: string): boolean {
+  return pathname === route.path || pathname.startsWith(`${route.path}/`);
+}
+
 export function findPrimaryRoute(pathname: string): PrimaryRouteDefinition | undefined {
-  return PRIMARY_ROUTE_DEFINITIONS.find((route) => route.path === pathname);
+  const normalizedPathname = normalizePathname(pathname);
+
+  return PRIMARY_ROUTE_DEFINITIONS.find((route) =>
+    routeOwnsPathname(route, normalizedPathname)
+  );
+}
+
+export function resolveNavigationState(pathname: string): NavigationState {
+  const matchedRoute = findPrimaryRoute(pathname);
+  const activeRoute = matchedRoute ?? FALLBACK_PRIMARY_ROUTE;
+
+  return {
+    activeRoute,
+    pageContext: activeRoute.title,
+    usesFallback: matchedRoute === undefined
+  };
 }


### PR DESCRIPTION
## Summary
- add a centralized navigation state resolver for primary-route active nav and page context
- drive shell active nav highlighting from the global navigation state model
- apply deterministic fallback behavior for unknown routes and nested route pathnames
- expand unit tests to cover route mapping and unknown-route fallback shell state

## Verification
- npm test -- src/routes/routeDefinitions.test.ts src/app/AppShell.test.tsx
- npm run test:e2e -- tests/e2e/technical/navigation-state.spec.ts
- npm run build

Closes #166