### PR TITLE
Implement issue #169 browse gallery and include UI in default compose/pre-push flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ export PHOTO_ORG_COMPOSE_DATABASE_URL
 export PHOTO_ORG_UI_API_BASE_URL
 export PHOTO_ORG_API_CORS_ALLOWED_ORIGINS
 
-.PHONY: help sync lint test test-all test-e2e check pre-push migrate env-create compose-up compose-migrate compose-down compose-down-volumes compose-smoke compose-e2e-smoke print-compose-db-url print-compose-api-base-url print-compose-ui-base-url seed-corpus-check seed-corpus-load ensure-environment
+.PHONY: help sync lint test test-all ui-test ui-build test-e2e check pre-push migrate env-create compose-up compose-migrate compose-down compose-down-volumes compose-smoke compose-e2e-smoke print-compose-db-url print-compose-api-base-url print-compose-ui-base-url seed-corpus-check seed-corpus-load ensure-environment
 
 help:
 	@printf '%s\n' \
@@ -69,13 +69,14 @@ help:
 		'make lint      - run the currently enforced ruff checks for Phase 0 schema/tooling surfaces' \
 		'make test      - run the current schema/migration/ingest verification slice' \
 		'make test-all  - run the full apps/api pytest suite with the enforced coverage gate' \
+		'make ui-test   - run the apps/ui unit test suite' \
+		'make ui-build  - run the apps/ui production build' \
 		'make test-e2e  - run the seed-corpus end-to-end verification slice' \
 		'make check     - run lint and the focused test slice' \
-		'make pre-push  - run lint plus the full coverage-enforced test suite' \
+		'make pre-push  - run lint, full API tests, plus UI test and UI build checks' \
 		'make migrate   - apply database migrations through the repo-root wrapper' \
 		'make env-create PHOTO_ORG_ENVIRONMENT=<name> PHOTO_ORG_ENV_STORAGE_MODE=<persistent|ephemeral> - register a local environment with immutable storage mode' \
-		'make compose-up PHOTO_ORG_ENVIRONMENT=<name> - build and start the selected registered environment' \
-		'COMPOSE_PROFILES=ui make compose-up PHOTO_ORG_ENVIRONMENT=<name> - include the web UI service' \
+		'make compose-up PHOTO_ORG_ENVIRONMENT=<name> - build and start the selected registered environment (postgres + api + ui)' \
 		'make compose-migrate PHOTO_ORG_ENVIRONMENT=<name> - rerun database migrations for the selected environment' \
 		'make compose-down PHOTO_ORG_ENVIRONMENT=<name> - stop and remove the selected environment while preserving named volumes' \
 		'make compose-down-volumes PHOTO_ORG_ENVIRONMENT=<name> - stop and remove the selected environment plus named volumes' \
@@ -96,12 +97,18 @@ test:
 test-all:
 	$(PYTEST) apps/api/tests $(PYTEST_COV_ARGS)
 
+ui-test:
+	npm --prefix apps/ui run test
+
+ui-build:
+	npm --prefix apps/ui run build
+
 test-e2e:
 	PYTHONPATH=apps/api $(PYTEST) apps/e2e/tests -q
 
 check: lint test
 
-pre-push: lint test-all
+pre-push: lint test-all ui-test ui-build
 
 migrate:
 	./scripts/photo-org migrate

--- a/README.md
+++ b/README.md
@@ -88,15 +88,14 @@ At a high level, setup should look like this:
 1. configure the application environment
 2. create an environment with `make env-create PHOTO_ORG_ENVIRONMENT=dev PHOTO_ORG_ENV_STORAGE_MODE=persistent`
 3. start it with `PHOTO_ORG_ENVIRONMENT=dev make compose-up`
-4. (optional) include the web UI service with `COMPOSE_PROFILES=ui PHOTO_ORG_ENVIRONMENT=dev make compose-up`
-5. confirm API base URL with `PHOTO_ORG_ENVIRONMENT=dev make print-compose-api-base-url`
-6. confirm UI base URL with `PHOTO_ORG_ENVIRONMENT=dev make print-compose-ui-base-url` when `COMPOSE_PROFILES=ui` is enabled
-7. rerun migrations with `PHOTO_ORG_ENVIRONMENT=dev make compose-migrate` if you need to repair its database
-8. open the web interface once the service is healthy
-9. sign in as an admin
-10. register one or more storage sources through the API at `POST /api/v1/storage-sources`
-11. add one or more watched folders under those sources
-12. let the system ingest the initial corpus
+4. confirm API base URL with `PHOTO_ORG_ENVIRONMENT=dev make print-compose-api-base-url`
+5. confirm UI base URL with `PHOTO_ORG_ENVIRONMENT=dev make print-compose-ui-base-url`
+6. rerun migrations with `PHOTO_ORG_ENVIRONMENT=dev make compose-migrate` if you need to repair its database
+7. open the web interface once the service is healthy
+8. sign in as an admin
+9. register one or more storage sources through the API at `POST /api/v1/storage-sources`
+10. add one or more watched folders under those sources
+11. let the system ingest the initial corpus
 
 Once that is done, users should be able to browse, search, and validate faces from the web UI.
 
@@ -104,8 +103,7 @@ For local operations:
 
 - `make env-create PHOTO_ORG_ENVIRONMENT=<name> PHOTO_ORG_ENV_STORAGE_MODE=persistent` registers a persistent environment with its own named Postgres volume
 - `make env-create PHOTO_ORG_ENVIRONMENT=<name> PHOTO_ORG_ENV_STORAGE_MODE=ephemeral` registers an ephemeral environment whose database lives only for the container lifecycle
-- `PHOTO_ORG_ENVIRONMENT=<name> make compose-up` starts the selected registered environment
-- `COMPOSE_PROFILES=ui PHOTO_ORG_ENVIRONMENT=<name> make compose-up` starts API + database + web UI together
+- `PHOTO_ORG_ENVIRONMENT=<name> make compose-up` starts the selected registered environment (API + database + web UI)
 - `PHOTO_ORG_ENVIRONMENT=<name> make compose-down` removes containers while preserving a persistent environment's named Postgres volume
 - `PHOTO_ORG_ENVIRONMENT=<name> make compose-down-volumes` removes containers and deletes a persistent environment's local Postgres volume
 - `PHOTO_ORG_ENVIRONMENT=<name> make compose-smoke` verifies the selected environment using its registered storage mode
@@ -116,7 +114,7 @@ For local operations:
 
 The default Compose file now bind-mounts `${PHOTO_ORG_PHOTO_LIBRARY_HOST_PATH}` into `${PHOTO_ORG_PHOTO_LIBRARY_CONTAINER_PATH}` for `db-service`, defaulting to `./seed-corpus` mounted at `/photos`. That runtime mount remains an internal deployment concern; watched-folder registration should stay relative to a registered source root.
 
-When the optional UI profile is enabled, the API allows cross-origin browser calls from the configured UI host origins through `PHOTO_ORG_API_CORS_ALLOWED_ORIGINS` (comma-separated origins).
+The API allows cross-origin browser calls from the configured UI host origins through `PHOTO_ORG_API_CORS_ALLOWED_ORIGINS` (comma-separated origins).
 
 ## Basic Usage
 

--- a/apps/ui/src/app/AppRouter.tsx
+++ b/apps/ui/src/app/AppRouter.tsx
@@ -15,6 +15,7 @@ import {
   type PrimaryRouteDefinition
 } from "../routes/routeDefinitions";
 import { PrimaryRoutePage } from "../pages/PrimaryRoutePage";
+import { BrowseRoutePage } from "../pages/BrowseRoutePage";
 import { NotFoundPage } from "../pages/NotFoundPage";
 import {
   resolveInitialSessionIdentity,
@@ -79,7 +80,13 @@ export function AppRouteTree({ initialSessionIdentity }: AppRouteTreeProps = {})
           <Route
             key={route.key}
             path={routePath(route)}
-            element={<PrimaryRoutePage route={route} />}
+            element={
+              route.key === "browse" ? (
+                <BrowseRoutePage />
+              ) : (
+                <PrimaryRoutePage route={route} />
+              )
+            }
           />
         ))}
         <Route path="*" element={<NotFoundPage />} />

--- a/apps/ui/src/app/AppShell.test.tsx
+++ b/apps/ui/src/app/AppShell.test.tsx
@@ -62,6 +62,20 @@ function expectShellContextText(text: string) {
 }
 
 describe("App shell", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockImplementation(
+      () => new Promise<Response>(() => undefined)
+    );
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it.each(PRIMARY_ROUTE_DEFINITIONS)(
     "renders shared shell regions for $path",
     ({ path, title }) => {
@@ -168,36 +182,36 @@ describe("App shell", () => {
 
   it("transitions from route error to ready on retry", async () => {
     const user = userEvent.setup();
-    renderAtPath("/browse?demoState=error");
+    renderAtPath("/search?demoState=error");
 
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
     expect(
       screen.getByRole("heading", {
-        name: "Could not load Browse",
+        name: "Could not load Search",
         level: 2
       })
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Retry" }));
 
-    expect(screen.getByRole("heading", { name: "Browse", level: 1 })).toBeInTheDocument();
-    expect(screen.getByText("Browse is ready.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Search", level: 1 })).toBeInTheDocument();
+    expect(screen.getByText("Search is ready.")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Dismiss notification" }));
-    expect(screen.queryByText("Browse is ready.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Search is ready.")).not.toBeInTheDocument();
   });
 
   it("does not reset feedback state when unrelated query params change", async () => {
     const user = userEvent.setup();
-    renderAtPathWithQueryBump("/browse?demoState=error&panel=primary");
+    renderAtPathWithQueryBump("/search?demoState=error&panel=primary");
 
     await user.click(screen.getByRole("button", { name: "Retry" }));
-    expect(screen.getByText("Browse is ready.")).toBeInTheDocument();
+    expect(screen.getByText("Search is ready.")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Bump query" }));
 
-    expect(screen.getByRole("heading", { name: "Browse", level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Search", level: 1 })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
-    expect(screen.getByText("Browse is ready.")).toBeInTheDocument();
+    expect(screen.getByText("Search is ready.")).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/pages/BrowseRoutePage.test.tsx
+++ b/apps/ui/src/pages/BrowseRoutePage.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { BrowseRoutePage } from "./BrowseRoutePage";
+
+interface SearchResponsePayload {
+  hits: {
+    total: number;
+    cursor: string | null;
+    items: Array<{
+      photo_id: string;
+      path: string;
+      ext: string;
+      camera_make: string | null;
+      orientation: string | null;
+      shot_ts: string | null;
+      filesize: number;
+      tags: string[];
+      people: string[];
+      faces: Array<{ person_id: string | null }>;
+      thumbnail: null;
+      original: {
+        is_available: boolean;
+        availability_state: string;
+        last_failure_reason: string | null;
+      } | null;
+      relevance: number | null;
+    }>;
+  };
+  facets: Record<string, unknown>;
+}
+
+function buildPayload(
+  photoIds: string[],
+  cursor: string | null,
+  total = photoIds.length
+): SearchResponsePayload {
+  return {
+    hits: {
+      total,
+      cursor,
+      items: photoIds.map((photoId, index) => ({
+        photo_id: photoId,
+        path: `/library/${photoId}.jpg`,
+        ext: "jpg",
+        camera_make: "Canon",
+        orientation: "landscape",
+        shot_ts: `2026-04-${String(index + 1).padStart(2, "0")}T12:00:00Z`,
+        filesize: 1024 + index,
+        tags: [],
+        people: [],
+        faces: [],
+        thumbnail: null,
+        original: {
+          is_available: true,
+          availability_state: "available",
+          last_failure_reason: null
+        },
+        relevance: null
+      }))
+    },
+    facets: {}
+  };
+}
+
+function renderBrowseAt(path: string) {
+  return render(
+    <MemoryRouter
+      initialEntries={[path]}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Routes>
+        <Route path="/browse" element={<BrowseRoutePage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("BrowseRoutePage", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads page one with deterministic default sort", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => buildPayload(["photo-a", "photo-b"], "cursor-page-2", 7)
+    } as Response);
+
+    renderBrowseAt("/browse");
+
+    expect(await screen.findByRole("heading", { name: "Browse", level: 1 })).toBeInTheDocument();
+    expect(await screen.findByText("photo-a")).toBeInTheDocument();
+    expect(screen.getByText("photo-b")).toBeInTheDocument();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/search");
+
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const parsedBody = JSON.parse(String(requestInit.body));
+    expect(parsedBody.sort).toEqual({ by: "shot_ts", dir: "desc" });
+    expect(parsedBody.page).toEqual({ limit: 24, cursor: null });
+    expect(screen.getByText("Page 1")).toBeInTheDocument();
+  });
+
+  it("advances to next page with returned cursor and supports previous", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => buildPayload(["photo-a"], "cursor-page-2", 3)
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => buildPayload(["photo-b"], "cursor-page-3", 3)
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => buildPayload(["photo-a"], "cursor-page-2", 3)
+      } as Response);
+
+    renderBrowseAt("/browse");
+
+    expect(await screen.findByText("photo-a")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(await screen.findByText("photo-b")).toBeInTheDocument();
+    expect(screen.getByText("Page 2")).toBeInTheDocument();
+
+    const secondRequest = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    expect(JSON.parse(String(secondRequest.body)).page).toEqual({
+      limit: 24,
+      cursor: "cursor-page-2"
+    });
+
+    await user.click(screen.getByRole("button", { name: "Previous page" }));
+    expect(await screen.findByText("photo-a")).toBeInTheDocument();
+    expect(screen.getByText("Page 1")).toBeInTheDocument();
+  });
+
+  it("resets to page one when sort order changes", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => buildPayload(["photo-a"], "cursor-page-2", 2)
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => buildPayload(["photo-b"], "cursor-page-2-asc", 2)
+      } as Response);
+
+    renderBrowseAt("/browse");
+
+    expect(await screen.findByText("photo-a")).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText("Sort order"), "asc");
+
+    expect(await screen.findByText("photo-b")).toBeInTheDocument();
+    expect(screen.getByText("Page 1")).toBeInTheDocument();
+
+    const secondRequest = fetchMock.mock.calls[1]?.[1] as RequestInit;
+    expect(JSON.parse(String(secondRequest.body)).sort).toEqual({ by: "shot_ts", dir: "asc" });
+    expect(JSON.parse(String(secondRequest.body)).page).toEqual({ limit: 24, cursor: null });
+  });
+
+  it("falls back to page one for unsupported direct page navigation", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => buildPayload(["photo-a"], "cursor-page-2", 2)
+    } as Response);
+
+    renderBrowseAt("/browse?page=3");
+
+    expect(await screen.findByText("photo-a")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Page 1")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Reset to page 1 because that page position is unavailable.")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/ui/src/pages/BrowseRoutePage.tsx
+++ b/apps/ui/src/pages/BrowseRoutePage.tsx
@@ -1,0 +1,354 @@
+import { useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import type { NotificationEntry } from "../app/feedback/feedbackTypes";
+import { ToastStack } from "../app/feedback/ToastStack";
+
+type SortDirection = "asc" | "desc";
+
+type BrowsePhoto = {
+  photo_id: string;
+  path: string;
+  ext: string;
+  camera_make: string | null;
+  orientation: string | null;
+  shot_ts: string | null;
+  filesize: number;
+  tags: string[];
+  people: string[];
+  faces: Array<{ person_id: string | null }>;
+  thumbnail: {
+    mime_type: string;
+    width: number;
+    height: number;
+    data_base64: string;
+  } | null;
+  original: {
+    is_available: boolean;
+    availability_state: string;
+    last_failure_reason: string | null;
+  } | null;
+  relevance: number | null;
+};
+
+type SearchResponsePayload = {
+  hits: {
+    total: number;
+    items: BrowsePhoto[];
+    cursor: string | null;
+  };
+};
+
+const PAGE_LIMIT = 24;
+const INVALID_PAGE_MESSAGE = "Reset to page 1 because that page position is unavailable.";
+
+function formatShotTimestamp(shotTs: string | null): string {
+  if (!shotTs) {
+    return "Unknown capture time";
+  }
+
+  const timestamp = Date.parse(shotTs);
+  if (Number.isNaN(timestamp)) {
+    return shotTs;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC"
+  }).format(timestamp);
+}
+
+function formatFilesize(filesize: number): string {
+  if (filesize < 1024) {
+    return `${filesize} B`;
+  }
+
+  const kb = filesize / 1024;
+  if (kb < 1024) {
+    return `${kb.toFixed(1)} KB`;
+  }
+
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)} MB`;
+}
+
+async function fetchBrowsePage(
+  sortDirection: SortDirection,
+  cursor: string | null
+): Promise<SearchResponsePayload> {
+  const response = await fetch("/api/v1/search", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      sort: {
+        by: "shot_ts",
+        dir: sortDirection
+      },
+      page: {
+        limit: PAGE_LIMIT,
+        cursor
+      }
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Search request failed (${response.status})`);
+  }
+
+  return (await response.json()) as SearchResponsePayload;
+}
+
+function parseRequestedPage(search: string): number {
+  const rawPage = new URLSearchParams(search).get("page");
+  if (!rawPage) {
+    return 1;
+  }
+
+  const parsedPage = Number.parseInt(rawPage, 10);
+  if (!Number.isFinite(parsedPage) || parsedPage < 1) {
+    return 1;
+  }
+
+  return parsedPage;
+}
+
+export function BrowseRoutePage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const requestedPage = parseRequestedPage(location.search);
+
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+  const [cursorByPage, setCursorByPage] = useState<Record<number, string | null>>({ 1: null });
+  const [photos, setPhotos] = useState<BrowsePhoto[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
+
+  const cursorForPage = cursorByPage[requestedPage];
+
+  function setPage(pageNumber: number, replace = false) {
+    const nextParams = new URLSearchParams(location.search);
+    if (pageNumber <= 1) {
+      nextParams.delete("page");
+    } else {
+      nextParams.set("page", String(pageNumber));
+    }
+
+    const nextSearch = nextParams.toString();
+    const nextTarget = `${location.pathname}${nextSearch ? `?${nextSearch}` : ""}`;
+    const currentTarget = `${location.pathname}${location.search}`;
+
+    if (nextTarget !== currentTarget) {
+      navigate(nextTarget, { replace });
+    }
+  }
+
+  function pushWarning(message: string) {
+    setNotifications((current) => [
+      {
+        id: "browse-warning",
+        tone: "warning",
+        message
+      },
+      ...current.filter((entry) => entry.id !== "browse-warning")
+    ]);
+  }
+
+  useEffect(() => {
+    if (requestedPage > 1 && cursorForPage === undefined) {
+      pushWarning(INVALID_PAGE_MESSAGE);
+      setPage(1, true);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    setIsLoading(true);
+    setError(null);
+
+    fetchBrowsePage(sortDirection, cursorForPage ?? null)
+      .then((payload) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        if (requestedPage > 1 && payload.hits.items.length === 0) {
+          pushWarning(INVALID_PAGE_MESSAGE);
+          setPage(1, true);
+          return;
+        }
+
+        setPhotos(payload.hits.items);
+        setTotalCount(payload.hits.total);
+        setNextCursor(payload.hits.cursor);
+        setCursorByPage((current) => {
+          const next = { ...current, [requestedPage]: cursorForPage ?? null };
+          if (payload.hits.cursor === null) {
+            delete next[requestedPage + 1];
+          } else {
+            next[requestedPage + 1] = payload.hits.cursor;
+          }
+          return next;
+        });
+        setIsLoading(false);
+      })
+      .catch((caughtError: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        const message =
+          caughtError instanceof Error
+            ? caughtError.message
+            : "Could not load browse results.";
+        setError(message);
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [cursorForPage, reloadToken, requestedPage, sortDirection]);
+
+  const canGoPrevious = requestedPage > 1 && !isLoading;
+  const canGoNext = nextCursor !== null && !isLoading;
+
+  const summaryLabel = useMemo(() => {
+    if (isLoading) {
+      return `Loading page ${requestedPage}…`;
+    }
+    if (error) {
+      return "Browse results unavailable.";
+    }
+    return `Showing ${photos.length} of ${totalCount} photos`;
+  }, [error, isLoading, photos.length, requestedPage, totalCount]);
+
+  return (
+    <section aria-labelledby="page-title" className="page browse-page">
+      <div className="browse-header">
+        <div>
+          <h1 id="page-title">Browse</h1>
+          <p>Deterministic gallery ordering with stable cursor pagination.</p>
+        </div>
+        <div className="browse-controls" role="group" aria-label="Browse controls">
+          <label className="browse-sort-control">
+            Sort order
+            <select
+              aria-label="Sort order"
+              value={sortDirection}
+              onChange={(event) => {
+                const nextDirection = event.target.value === "asc" ? "asc" : "desc";
+                setSortDirection(nextDirection);
+                setCursorByPage({ 1: null });
+                setPage(1);
+              }}
+            >
+              <option value="desc">Newest first</option>
+              <option value="asc">Oldest first</option>
+            </select>
+          </label>
+          <div className="browse-pagination" aria-label="Pagination controls">
+            <button
+              type="button"
+              onClick={() => setPage(requestedPage - 1)}
+              disabled={!canGoPrevious}
+              aria-label="Previous page"
+            >
+              Previous
+            </button>
+            <p className="browse-page-indicator">Page {requestedPage}</p>
+            <button
+              type="button"
+              onClick={() => setPage(requestedPage + 1)}
+              disabled={!canGoNext}
+              aria-label="Next page"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <p className="browse-summary" aria-live="polite">{summaryLabel}</p>
+
+      {error ? (
+        <div className="feedback-panel feedback-panel-error">
+          <h2>Could not load Browse</h2>
+          <p>{error}</p>
+          <button type="button" onClick={() => setReloadToken((current) => current + 1)}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {!error && isLoading ? (
+        <div className="feedback-panel feedback-panel-loading" role="status" aria-live="polite">
+          Loading browse workflow.
+        </div>
+      ) : null}
+
+      {!error && !isLoading && photos.length === 0 ? (
+        <div className="feedback-panel">
+          <p>No photos available for this page.</p>
+        </div>
+      ) : null}
+
+      {!error && !isLoading && photos.length > 0 ? (
+        <ol className="browse-grid" aria-label="Photo gallery">
+          {photos.map((photo) => (
+            <li key={photo.photo_id} className="browse-card">
+              {photo.thumbnail ? (
+                <img
+                  className="browse-thumbnail"
+                  src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
+                  width={photo.thumbnail.width}
+                  height={photo.thumbnail.height}
+                  alt={`Thumbnail for ${photo.photo_id}`}
+                />
+              ) : (
+                <div className="browse-thumbnail browse-thumbnail-placeholder" aria-hidden="true">
+                  No preview
+                </div>
+              )}
+
+              <div className="browse-card-body">
+                <h2>{photo.photo_id}</h2>
+                <p className="browse-path" title={photo.path}>{photo.path}</p>
+                <dl>
+                  <div>
+                    <dt>Captured</dt>
+                    <dd>{formatShotTimestamp(photo.shot_ts)}</dd>
+                  </div>
+                  <div>
+                    <dt>Size</dt>
+                    <dd>{formatFilesize(photo.filesize)}</dd>
+                  </div>
+                  <div>
+                    <dt>People</dt>
+                    <dd>{photo.people.length}</dd>
+                  </div>
+                  <div>
+                    <dt>Original</dt>
+                    <dd>{photo.original?.availability_state ?? "unknown"}</dd>
+                  </div>
+                </dl>
+              </div>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+
+      <ToastStack
+        notifications={notifications}
+        onDismiss={(id) => {
+          setNotifications((current) => current.filter((entry) => entry.id !== id));
+        }}
+      />
+    </section>
+  );
+}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -185,6 +185,150 @@ body {
   color: #334155;
 }
 
+.browse-page {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.browse-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.browse-controls {
+  display: grid;
+  gap: 0.6rem;
+  justify-items: end;
+}
+
+.browse-sort-control {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: #1e293b;
+}
+
+.browse-sort-control select {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  padding: 0.3rem 0.4rem;
+  background: #ffffff;
+  color: #0f172a;
+  font: inherit;
+}
+
+.browse-pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.browse-pagination button {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.35rem 0.55rem;
+  font: inherit;
+}
+
+.browse-pagination button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.browse-page-indicator {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #1e293b;
+}
+
+.browse-summary {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.browse-grid {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.browse-card {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.7rem;
+  background: #ffffff;
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: 9rem 1fr;
+}
+
+.browse-thumbnail {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background: #e2e8f0;
+}
+
+.browse-thumbnail-placeholder {
+  display: grid;
+  place-items: center;
+  color: #64748b;
+  font-size: 0.85rem;
+}
+
+.browse-card-body {
+  padding: 0.65rem 0.75rem 0.8rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.browse-card-body h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+.browse-path {
+  margin: 0;
+  color: #475569;
+  font-size: 0.8rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.browse-card-body dl {
+  margin: 0;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.browse-card-body dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.browse-card-body dt {
+  font-size: 0.78rem;
+  color: #475569;
+}
+
+.browse-card-body dd {
+  margin: 0;
+  font-size: 0.78rem;
+  color: #0f172a;
+  text-align: right;
+}
+
 .feedback-panel {
   border: 1px solid #cbd5e1;
   border-radius: 0.65rem;
@@ -302,5 +446,13 @@ body {
 
   .shell-content {
     padding: 0.95rem;
+  }
+
+  .browse-controls {
+    justify-items: start;
+  }
+
+  .browse-card {
+    grid-template-rows: 7.5rem 1fr;
   }
 }

--- a/compose.yaml
+++ b/compose.yaml
@@ -38,7 +38,6 @@ services:
       - "${PHOTO_ORG_API_HOST_PORT:-8000}:8000"
 
   ui:
-    profiles: ["ui"]
     build:
       context: .
       dockerfile: apps/ui/Dockerfile


### PR DESCRIPTION
## Summary
- implement the new `/browse` route experience with deterministic sort controls and cursor-based pagination over `POST /api/v1/search`
- add browse-specific UI tests for deterministic ordering requests, page transitions, sort resets, and invalid-page fallback behavior
- style the browse gallery/grid cards and metadata presentation for responsive layouts
- include the `ui` service in the default `compose.yaml` stack so `make compose-up` deploys all services
- expand `Makefile` pre-push coverage to run UI unit tests and UI production build
- update README and make help text to match the new default compose and pre-push behaviors

## Verification
- `npm --prefix apps/ui run test`
- `npm --prefix apps/ui run build`
- `npm test` (from `apps/ui`)

Closes #169