### PR TITLE
[codex] Implement photo detail metadata presentation (#170)

### DIFF
--- a/apps/ui/src/app/AppRouter.tsx
+++ b/apps/ui/src/app/AppRouter.tsx
@@ -16,6 +16,7 @@ import {
 } from "../routes/routeDefinitions";
 import { PrimaryRoutePage } from "../pages/PrimaryRoutePage";
 import { BrowseRoutePage } from "../pages/BrowseRoutePage";
+import { PhotoDetailRoutePage } from "../pages/PhotoDetailRoutePage";
 import { NotFoundPage } from "../pages/NotFoundPage";
 import {
   resolveInitialSessionIdentity,
@@ -76,6 +77,7 @@ export function AppRouteTree({ initialSessionIdentity }: AppRouteTreeProps = {})
         }
       >
         <Route path="/" element={<Navigate to="/browse" replace />} />
+        <Route path="browse/:photoId" element={<PhotoDetailRoutePage />} />
         {PRIMARY_ROUTE_DEFINITIONS.map((route) => (
           <Route
             key={route.key}

--- a/apps/ui/src/pages/BrowseRoutePage.tsx
+++ b/apps/ui/src/pages/BrowseRoutePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import type { NotificationEntry } from "../app/feedback/feedbackTypes";
 import { ToastStack } from "../app/feedback/ToastStack";
 
@@ -317,7 +317,11 @@ export function BrowseRoutePage() {
               )}
 
               <div className="browse-card-body">
-                <h2>{photo.photo_id}</h2>
+                <h2>
+                  <Link className="browse-photo-link" to={`/browse/${photo.photo_id}`}>
+                    {photo.photo_id}
+                  </Link>
+                </h2>
                 <p className="browse-path" title={photo.path}>{photo.path}</p>
                 <dl>
                   <div>

--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -1,0 +1,215 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { PhotoDetailRoutePage } from "./PhotoDetailRoutePage";
+
+interface PhotoDetailPayload {
+  photo_id: string;
+  path: string;
+  ext: string;
+  camera_make: string | null;
+  orientation: string | null;
+  shot_ts: string | null;
+  filesize: number;
+  tags: string[];
+  people: string[];
+  faces: Array<{
+    face_id: string;
+    person_id: string | null;
+    bbox_x: number | null;
+    bbox_y: number | null;
+    bbox_w: number | null;
+    bbox_h: number | null;
+  }>;
+  thumbnail: {
+    mime_type: string;
+    width: number;
+    height: number;
+    data_base64: string;
+  } | null;
+  original: {
+    is_available: boolean;
+    availability_state: string;
+    last_failure_reason: string | null;
+  } | null;
+  metadata: {
+    sha256: string;
+    phash: string | null;
+    shot_ts_source: string | null;
+    camera_model: string | null;
+    software: string | null;
+    gps_latitude: number | null;
+    gps_longitude: number | null;
+    gps_altitude: number | null;
+    created_ts: string;
+    updated_ts: string;
+    modified_ts: string | null;
+    deleted_ts: string | null;
+    faces_count: number;
+    faces_detected_ts: string | null;
+  };
+}
+
+function buildPayload(partial: Partial<PhotoDetailPayload> = {}): PhotoDetailPayload {
+  return {
+    photo_id: "photo-1",
+    path: "/library/photo-1.jpg",
+    ext: "jpg",
+    camera_make: "Apple",
+    orientation: "Rotate 90 CW",
+    shot_ts: "2026-03-28T19:30:00Z",
+    filesize: 4096,
+    tags: ["vacation"],
+    people: ["person-1"],
+    faces: [
+      {
+        face_id: "face-1",
+        person_id: "person-1",
+        bbox_x: 10,
+        bbox_y: 20,
+        bbox_w: 30,
+        bbox_h: 40
+      }
+    ],
+    thumbnail: null,
+    original: {
+      is_available: true,
+      availability_state: "active",
+      last_failure_reason: null
+    },
+    metadata: {
+      sha256: "sha-1",
+      phash: "phash-1",
+      shot_ts_source: "exif:DateTimeOriginal",
+      camera_model: "iPhone 15 Pro",
+      software: "18.1",
+      gps_latitude: 12.3456,
+      gps_longitude: -45.6789,
+      gps_altitude: 123.4,
+      created_ts: "2026-03-28T19:30:00Z",
+      updated_ts: "2026-03-28T19:30:00Z",
+      modified_ts: "2026-03-28T19:30:00Z",
+      deleted_ts: null,
+      faces_count: 1,
+      faces_detected_ts: "2026-03-28T19:30:00Z"
+    },
+    ...partial
+  };
+}
+
+function renderDetail(path = "/browse/photo-1") {
+  return render(
+    <MemoryRouter
+      initialEntries={[path]}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Routes>
+        <Route path="/browse/:photoId" element={<PhotoDetailRoutePage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("PhotoDetailRoutePage", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders detail metadata fields from the backend contract", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => buildPayload()
+    } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
+    expect(screen.getByText("photo-1")).toBeInTheDocument();
+    expect(screen.getByText("/library/photo-1.jpg")).toBeInTheDocument();
+    expect(screen.getByText("iPhone 15 Pro")).toBeInTheDocument();
+    expect(screen.getByText("exif:DateTimeOriginal")).toBeInTheDocument();
+    expect(screen.getByText("12.3456, -45.6789")).toBeInTheDocument();
+    expect(screen.getByText("1 detected")).toBeInTheDocument();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/photos/photo-1");
+  });
+
+  it("shows explicit fallback UI for missing optional metadata fields", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () =>
+        buildPayload({
+          shot_ts: null,
+          camera_make: null,
+          orientation: null,
+          tags: [],
+          people: [],
+          original: null,
+          metadata: {
+            ...buildPayload().metadata,
+            phash: null,
+            shot_ts_source: null,
+            camera_model: null,
+            software: null,
+            gps_latitude: null,
+            gps_longitude: null,
+            gps_altitude: null,
+            modified_ts: null,
+            faces_detected_ts: null
+          }
+        })
+    } as Response);
+
+    renderDetail();
+
+    expect((await screen.findAllByText("Not available")).length).toBeGreaterThan(0);
+    expect(screen.getByText("No tags")).toBeInTheDocument();
+    expect(screen.getByText("No recognized people")).toBeInTheDocument();
+    expect(screen.getByText("Unknown availability")).toBeInTheDocument();
+  });
+
+  it("renders deterministic loading and error transitions", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503
+    } as Response);
+
+    renderDetail();
+
+    expect(screen.getByText("Loading photo detail.")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Could not load photo detail", level: 2 })).toBeInTheDocument();
+    expect(screen.getByText("Photo detail request failed (503)")).toBeInTheDocument();
+  });
+
+  it("retries loading after a failed request", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => buildPayload()
+      } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByRole("heading", { name: "Could not load photo detail", level: 2 })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -1,0 +1,283 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+type PhotoDetailPayload = {
+  photo_id: string;
+  path: string;
+  ext: string;
+  camera_make: string | null;
+  orientation: string | null;
+  shot_ts: string | null;
+  filesize: number;
+  tags: string[];
+  people: string[];
+  faces: Array<{
+    face_id: string;
+    person_id: string | null;
+    bbox_x: number | null;
+    bbox_y: number | null;
+    bbox_w: number | null;
+    bbox_h: number | null;
+  }>;
+  thumbnail: {
+    mime_type: string;
+    width: number;
+    height: number;
+    data_base64: string;
+  } | null;
+  original: {
+    is_available: boolean;
+    availability_state: string;
+    last_failure_reason: string | null;
+  } | null;
+  metadata: {
+    sha256: string;
+    phash: string | null;
+    shot_ts_source: string | null;
+    camera_model: string | null;
+    software: string | null;
+    gps_latitude: number | null;
+    gps_longitude: number | null;
+    gps_altitude: number | null;
+    created_ts: string;
+    updated_ts: string;
+    modified_ts: string | null;
+    deleted_ts: string | null;
+    faces_count: number;
+    faces_detected_ts: string | null;
+  };
+};
+
+const MISSING_VALUE = "Not available";
+
+function formatTimestamp(value: string | null): string {
+  if (!value) {
+    return MISSING_VALUE;
+  }
+
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "UTC"
+  }).format(parsed);
+}
+
+function formatFilesize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  const kb = bytes / 1024;
+  if (kb < 1024) {
+    return `${kb.toFixed(1)} KB`;
+  }
+
+  const mb = kb / 1024;
+  return `${mb.toFixed(1)} MB`;
+}
+
+function formatGps(lat: number | null, lon: number | null): string {
+  if (lat === null || lon === null) {
+    return MISSING_VALUE;
+  }
+
+  return `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
+}
+
+function formatOptionalText(value: string | null): string {
+  return value && value.trim().length > 0 ? value : MISSING_VALUE;
+}
+
+async function fetchPhotoDetail(photoId: string): Promise<PhotoDetailPayload> {
+  const response = await fetch(`/api/v1/photos/${photoId}`);
+  if (!response.ok) {
+    throw new Error(`Photo detail request failed (${response.status})`);
+  }
+  return (await response.json()) as PhotoDetailPayload;
+}
+
+export function PhotoDetailRoutePage() {
+  const { photoId } = useParams<{ photoId: string }>();
+  const [detail, setDetail] = useState<PhotoDetailPayload | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    if (!photoId) {
+      setError("Photo identifier is missing.");
+      setIsLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setIsLoading(true);
+    setError(null);
+
+    fetchPhotoDetail(photoId)
+      .then((payload) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setDetail(payload);
+        setIsLoading(false);
+      })
+      .catch((caughtError: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setError(caughtError instanceof Error ? caughtError.message : "Could not load photo detail.");
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [photoId, reloadToken]);
+
+  const facesLabel = useMemo(() => {
+    if (!detail) {
+      return MISSING_VALUE;
+    }
+    const count = detail.metadata.faces_count;
+    return count === 1 ? "1 detected" : `${count} detected`;
+  }, [detail]);
+
+  return (
+    <section aria-labelledby="page-title" className="page detail-page">
+      <div className="detail-header">
+        <div>
+          <h1 id="page-title">Photo detail</h1>
+          <p>Inspect canonical metadata and availability fields for a single photo.</p>
+        </div>
+        <Link className="detail-back-link" to="/browse">
+          Back to browse
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="feedback-panel feedback-panel-loading" role="status" aria-live="polite">
+          Loading photo detail.
+        </div>
+      ) : null}
+
+      {!isLoading && error ? (
+        <div className="feedback-panel feedback-panel-error">
+          <h2>Could not load photo detail</h2>
+          <p>{error}</p>
+          <button type="button" onClick={() => setReloadToken((current) => current + 1)}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {!isLoading && !error && detail ? (
+        <div className="detail-layout">
+          <article className="detail-panel">
+            <h2>{detail.photo_id}</h2>
+            <p className="detail-path">{detail.path}</p>
+            <dl>
+              <div>
+                <dt>Captured</dt>
+                <dd>{formatTimestamp(detail.shot_ts)}</dd>
+              </div>
+              <div>
+                <dt>File size</dt>
+                <dd>{formatFilesize(detail.filesize)}</dd>
+              </div>
+              <div>
+                <dt>Camera make</dt>
+                <dd>{formatOptionalText(detail.camera_make)}</dd>
+              </div>
+              <div>
+                <dt>Orientation</dt>
+                <dd>{formatOptionalText(detail.orientation)}</dd>
+              </div>
+              <div>
+                <dt>Availability</dt>
+                <dd>{detail.original?.availability_state ?? "Unknown availability"}</dd>
+              </div>
+            </dl>
+          </article>
+
+          <article className="detail-panel">
+            <h2>Metadata</h2>
+            <dl>
+              <div>
+                <dt>SHA-256</dt>
+                <dd>{detail.metadata.sha256}</dd>
+              </div>
+              <div>
+                <dt>Perceptual hash</dt>
+                <dd>{formatOptionalText(detail.metadata.phash)}</dd>
+              </div>
+              <div>
+                <dt>Timestamp source</dt>
+                <dd>{formatOptionalText(detail.metadata.shot_ts_source)}</dd>
+              </div>
+              <div>
+                <dt>Camera model</dt>
+                <dd>{formatOptionalText(detail.metadata.camera_model)}</dd>
+              </div>
+              <div>
+                <dt>Software</dt>
+                <dd>{formatOptionalText(detail.metadata.software)}</dd>
+              </div>
+              <div>
+                <dt>GPS</dt>
+                <dd>{formatGps(detail.metadata.gps_latitude, detail.metadata.gps_longitude)}</dd>
+              </div>
+              <div>
+                <dt>GPS altitude</dt>
+                <dd>
+                  {detail.metadata.gps_altitude === null
+                    ? MISSING_VALUE
+                    : `${detail.metadata.gps_altitude.toFixed(1)} m`}
+                </dd>
+              </div>
+              <div>
+                <dt>Faces</dt>
+                <dd>{facesLabel}</dd>
+              </div>
+              <div>
+                <dt>Face detection run</dt>
+                <dd>{formatTimestamp(detail.metadata.faces_detected_ts)}</dd>
+              </div>
+              <div>
+                <dt>Created</dt>
+                <dd>{formatTimestamp(detail.metadata.created_ts)}</dd>
+              </div>
+              <div>
+                <dt>Updated</dt>
+                <dd>{formatTimestamp(detail.metadata.updated_ts)}</dd>
+              </div>
+              <div>
+                <dt>Modified</dt>
+                <dd>{formatTimestamp(detail.metadata.modified_ts)}</dd>
+              </div>
+            </dl>
+          </article>
+
+          <article className="detail-panel">
+            <h2>Classification</h2>
+            <dl>
+              <div>
+                <dt>Tags</dt>
+                <dd>{detail.tags.length > 0 ? detail.tags.join(", ") : "No tags"}</dd>
+              </div>
+              <div>
+                <dt>People</dt>
+                <dd>{detail.people.length > 0 ? detail.people.join(", ") : "No recognized people"}</dd>
+              </div>
+            </dl>
+          </article>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -296,6 +296,15 @@ body {
   color: #0f172a;
 }
 
+.browse-photo-link {
+  color: inherit;
+}
+
+.browse-photo-link:hover,
+.browse-photo-link:focus-visible {
+  color: #1d4ed8;
+}
+
 .browse-path {
   margin: 0;
   color: #475569;
@@ -327,6 +336,81 @@ body {
   font-size: 0.78rem;
   color: #0f172a;
   text-align: right;
+}
+
+.detail-page {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.detail-back-link {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.35rem 0.55rem;
+  text-decoration: none;
+}
+
+.detail-layout {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+}
+
+.detail-panel {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.7rem;
+  background: #ffffff;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.detail-panel h2 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1rem;
+}
+
+.detail-path {
+  margin: 0;
+  color: #475569;
+  font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
+.detail-panel dl {
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.detail-panel dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.detail-panel dt {
+  color: #475569;
+  font-size: 0.8rem;
+}
+
+.detail-panel dd {
+  margin: 0;
+  color: #0f172a;
+  font-size: 0.82rem;
+  text-align: right;
+  overflow-wrap: anywhere;
 }
 
 .feedback-panel {


### PR DESCRIPTION
## Summary
- add a new `/browse/:photoId` detail route and `PhotoDetailRoutePage` wired to the Phase 2 `GET /api/v1/photos/{photo_id}` contract
- present canonical metadata and related fields with explicit fallback values for optional/missing metadata
- add deterministic loading, error, and retry transitions for detail fetches
- link browse gallery cards to detail pages and add supporting detail-page styles
- add route-level tests covering contract rendering, fallback UI, transitions, and retry behavior

## Why
Issue #170 requires an inspect-level photo detail surface so users can validate ingest quality and understand per-photo metadata, including clear handling of missing optional fields.

## User Impact
Users can now open a photo from browse results and inspect metadata, availability, tags, and people in a dedicated detail view with predictable loading and failure behavior.

## Root Cause
The UI previously stopped at gallery-level browse cards and did not provide a dedicated detail screen backed by the existing photo detail API contract.

## Validation
- `npm test` (apps/ui)

Closes #170