### PR TITLE
Implement face-region overlays in photo detail

### DIFF
--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -71,7 +71,12 @@ function buildPayload(partial: Partial<PhotoDetailPayload> = {}): PhotoDetailPay
         bbox_h: 40
       }
     ],
-    thumbnail: null,
+    thumbnail: {
+      mime_type: "image/jpeg",
+      width: 100,
+      height: 100,
+      data_base64: "dGh1bWI="
+    },
     original: {
       is_available: true,
       availability_state: "active",
@@ -137,6 +142,9 @@ describe("PhotoDetailRoutePage", () => {
     expect(screen.getByText("exif:DateTimeOriginal")).toBeInTheDocument();
     expect(screen.getByText("12.3456, -45.6789")).toBeInTheDocument();
     expect(screen.getByText("1 detected")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Preview for photo-1" })).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Detected face regions" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Face region 1 for person-1")).toBeInTheDocument();
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/photos/photo-1");
@@ -174,6 +182,44 @@ describe("PhotoDetailRoutePage", () => {
     expect(screen.getByText("No tags")).toBeInTheDocument();
     expect(screen.getByText("No recognized people")).toBeInTheDocument();
     expect(screen.getByText("Unknown availability")).toBeInTheDocument();
+  });
+
+  it("shows explicit no-face state when no face regions are present", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () =>
+        buildPayload({
+          faces: [],
+          people: [],
+          metadata: {
+            ...buildPayload().metadata,
+            faces_count: 0
+          }
+        })
+    } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByText("No face regions detected for this photo.")).toBeInTheDocument();
+    expect(screen.queryByRole("list", { name: "Detected face regions" })).not.toBeInTheDocument();
+  });
+
+  it("keeps face overlays coherent when switching image presentation mode", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => buildPayload()
+    } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
+    expect(screen.getByLabelText("Face region 1 for person-1")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Actual pixels" }));
+
+    expect(screen.getByLabelText("Face region 1 for person-1")).toBeInTheDocument();
   });
 
   it("renders deterministic loading and error transitions", async () => {

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -50,6 +50,17 @@ type PhotoDetailPayload = {
 
 const MISSING_VALUE = "Not available";
 
+type MediaPresentationMode = "fit" | "actual";
+
+type FaceOverlayRegion = {
+  faceId: string;
+  personId: string | null;
+  leftPercent: number;
+  topPercent: number;
+  widthPercent: number;
+  heightPercent: number;
+};
+
 function formatTimestamp(value: string | null): string {
   if (!value) {
     return MISSING_VALUE;
@@ -93,6 +104,10 @@ function formatOptionalText(value: string | null): string {
   return value && value.trim().length > 0 ? value : MISSING_VALUE;
 }
 
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
 async function fetchPhotoDetail(photoId: string): Promise<PhotoDetailPayload> {
   const response = await fetch(`/api/v1/photos/${photoId}`);
   if (!response.ok) {
@@ -107,6 +122,7 @@ export function PhotoDetailRoutePage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
+  const [mediaMode, setMediaMode] = useState<MediaPresentationMode>("fit");
 
   useEffect(() => {
     if (!photoId) {
@@ -148,6 +164,66 @@ export function PhotoDetailRoutePage() {
     return count === 1 ? "1 detected" : `${count} detected`;
   }, [detail]);
 
+  const faceOverlayRegions = useMemo<FaceOverlayRegion[]>(() => {
+    if (!detail?.thumbnail || detail.thumbnail.width <= 0 || detail.thumbnail.height <= 0) {
+      return [];
+    }
+
+    const thumbnailWidth = detail.thumbnail.width;
+    const thumbnailHeight = detail.thumbnail.height;
+
+    return detail.faces
+      .map((face) => {
+        if (
+          face.bbox_x === null ||
+          face.bbox_y === null ||
+          face.bbox_w === null ||
+          face.bbox_h === null ||
+          face.bbox_w <= 0 ||
+          face.bbox_h <= 0
+        ) {
+          return null;
+        }
+
+        const left = clamp((face.bbox_x / thumbnailWidth) * 100, 0, 100);
+        const top = clamp((face.bbox_y / thumbnailHeight) * 100, 0, 100);
+        const right = clamp(((face.bbox_x + face.bbox_w) / thumbnailWidth) * 100, 0, 100);
+        const bottom = clamp(((face.bbox_y + face.bbox_h) / thumbnailHeight) * 100, 0, 100);
+        const width = right - left;
+        const height = bottom - top;
+
+        if (width <= 0 || height <= 0) {
+          return null;
+        }
+
+        return {
+          faceId: face.face_id,
+          personId: face.person_id,
+          leftPercent: left,
+          topPercent: top,
+          widthPercent: width,
+          heightPercent: height
+        };
+      })
+      .filter((region): region is FaceOverlayRegion => region !== null);
+  }, [detail]);
+
+  const faceRegionState = useMemo(() => {
+    if (!detail) {
+      return MISSING_VALUE;
+    }
+
+    if (detail.faces.length === 0) {
+      return "No face regions detected for this photo.";
+    }
+
+    if (faceOverlayRegions.length === 0) {
+      return "Face regions are present but could not be rendered on this preview.";
+    }
+
+    return `${faceOverlayRegions.length} face region${faceOverlayRegions.length === 1 ? "" : "s"} rendered.`;
+  }, [detail, faceOverlayRegions.length]);
+
   return (
     <section aria-labelledby="page-title" className="page detail-page">
       <div className="detail-header">
@@ -178,6 +254,66 @@ export function PhotoDetailRoutePage() {
 
       {!isLoading && !error && detail ? (
         <div className="detail-layout">
+          <article className="detail-panel">
+            <h2>Preview</h2>
+            {detail.thumbnail ? (
+              <>
+                <div className="detail-media-controls" role="group" aria-label="Preview display mode">
+                  <button
+                    type="button"
+                    className={mediaMode === "fit" ? "is-active" : undefined}
+                    onClick={() => setMediaMode("fit")}
+                  >
+                    Fit to panel
+                  </button>
+                  <button
+                    type="button"
+                    className={mediaMode === "actual" ? "is-active" : undefined}
+                    onClick={() => setMediaMode("actual")}
+                  >
+                    Actual pixels
+                  </button>
+                </div>
+                <div className="detail-media-frame" data-mode={mediaMode}>
+                  <div className="detail-media-stage">
+                    <img
+                      className="detail-media-image"
+                      src={`data:${detail.thumbnail.mime_type};base64,${detail.thumbnail.data_base64}`}
+                      width={detail.thumbnail.width}
+                      height={detail.thumbnail.height}
+                      alt={`Preview for ${detail.photo_id}`}
+                    />
+                    {faceOverlayRegions.length > 0 ? (
+                      <ol className="detail-face-overlay-list" aria-label="Detected face regions">
+                        {faceOverlayRegions.map((region, index) => (
+                          <li
+                            key={region.faceId}
+                            className="detail-face-overlay"
+                            aria-label={`Face region ${index + 1}${region.personId ? ` for ${region.personId}` : ""}`}
+                            style={{
+                              left: `${region.leftPercent}%`,
+                              top: `${region.topPercent}%`,
+                              width: `${region.widthPercent}%`,
+                              height: `${region.heightPercent}%`
+                            }}
+                          />
+                        ))}
+                      </ol>
+                    ) : null}
+                  </div>
+                </div>
+                <p className="detail-face-state">{faceRegionState}</p>
+              </>
+            ) : (
+              <>
+                <div className="browse-thumbnail browse-thumbnail-placeholder" aria-hidden="true">
+                  No preview
+                </div>
+                <p className="detail-face-state">{faceRegionState}</p>
+              </>
+            )}
+          </article>
+
           <article className="detail-panel">
             <h2>{detail.photo_id}</h2>
             <p className="detail-path">{detail.path}</p>

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -413,6 +413,83 @@ body {
   overflow-wrap: anywhere;
 }
 
+.detail-media-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.detail-media-controls button {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.3rem 0.5rem;
+  font: inherit;
+}
+
+.detail-media-controls button.is-active {
+  border-color: #1d4ed8;
+  background: #dbeafe;
+}
+
+.detail-media-frame {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.55rem;
+  background: #f8fafc;
+  padding: 0.5rem;
+}
+
+.detail-media-frame[data-mode="actual"] {
+  overflow: auto;
+}
+
+.detail-media-stage {
+  position: relative;
+  width: 100%;
+}
+
+.detail-media-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 0.35rem;
+  background: #e2e8f0;
+}
+
+.detail-media-frame[data-mode="actual"] .detail-media-stage {
+  width: fit-content;
+  max-width: none;
+}
+
+.detail-media-frame[data-mode="actual"] .detail-media-image {
+  width: auto;
+  max-width: none;
+}
+
+.detail-face-overlay-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.detail-face-overlay {
+  position: absolute;
+  border: 2px solid #f97316;
+  border-radius: 0.25rem;
+  background: rgb(249 115 22 / 15%);
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 85%);
+}
+
+.detail-face-state {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #334155;
+}
+
 .feedback-panel {
   border: 1px solid #cbd5e1;
   border-radius: 0.65rem;


### PR DESCRIPTION
## Summary
- add a photo detail preview panel that renders detected face-region overlays from `bbox_x/y/w/h` payload coordinates
- add deterministic preview-mode controls (`Fit to panel` and `Actual pixels`) while keeping overlays aligned in both modes
- add explicit no-face and non-renderable-face fallback messaging in the detail preview surface
- extend `PhotoDetailRoutePage` tests to cover overlay rendering, no-face fallback, and mode-switch coherence

## Verification
- `npm --prefix apps/ui test -- PhotoDetailRoutePage.test.tsx`
- `npm --prefix apps/ui test -- BrowseRoutePage.test.tsx PhotoDetailRoutePage.test.tsx`
- `npm --prefix apps/ui run build`

Closes #171