### PR TITLE
[codex] Implement ingest-status visibility in gallery and detail contexts

### DIFF
--- a/apps/ui/src/app/ingestStatus.test.ts
+++ b/apps/ui/src/app/ingestStatus.test.ts
@@ -1,0 +1,58 @@
+import { deriveIngestStatus } from "./ingestStatus";
+
+describe("deriveIngestStatus", () => {
+  it("returns complete for active and hydrated items", () => {
+    const status = deriveIngestStatus({
+      availabilityState: "active",
+      isAvailable: true,
+      hasThumbnail: true
+    });
+
+    expect(status.label).toBe("Complete");
+    expect(status.tone).toBe("complete");
+  });
+
+  it("returns pending when thumbnail is missing", () => {
+    const status = deriveIngestStatus({
+      availabilityState: "active",
+      hasThumbnail: false
+    });
+
+    expect(status.label).toBe("Pending");
+    expect(status.tone).toBe("pending");
+  });
+
+  it("returns pending when detail face-detection timestamp is missing", () => {
+    const status = deriveIngestStatus({
+      availabilityState: "active",
+      hasThumbnail: true,
+      includeFaceDetection: true,
+      facesDetectedTs: null
+    });
+
+    expect(status.label).toBe("Pending");
+    expect(status.tone).toBe("pending");
+  });
+
+  it("returns failed when an explicit failure reason is present", () => {
+    const status = deriveIngestStatus({
+      availabilityState: "active",
+      hasThumbnail: true,
+      lastFailureReason: "folder_unmounted"
+    });
+
+    expect(status.label).toBe("Failed");
+    expect(status.tone).toBe("failed");
+  });
+
+  it("returns unknown when the API returns an unrecognized availability state", () => {
+    const status = deriveIngestStatus({
+      availabilityState: "mystery-state",
+      hasThumbnail: true
+    });
+
+    expect(status.label).toBe("Unknown");
+    expect(status.tone).toBe("unknown");
+    expect(status.description).toContain("mystery-state");
+  });
+});

--- a/apps/ui/src/app/ingestStatus.ts
+++ b/apps/ui/src/app/ingestStatus.ts
@@ -1,0 +1,103 @@
+export type IngestStatusTone = "complete" | "pending" | "failed" | "unknown";
+
+export type IngestStatusViewModel = {
+  tone: IngestStatusTone;
+  label: string;
+  description: string;
+};
+
+type IngestStatusInput = {
+  availabilityState?: string | null;
+  isAvailable?: boolean | null;
+  lastFailureReason?: string | null;
+  hasThumbnail?: boolean | null;
+  facesDetectedTs?: string | null;
+  includeFaceDetection?: boolean;
+};
+
+const FAILED_AVAILABILITY_STATES = new Set(["unreachable", "disabled", "error", "failed"]);
+const ACTIVE_AVAILABILITY_STATE = "active";
+
+function normalizeAvailabilityState(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  return value.trim().toLowerCase();
+}
+
+export function deriveIngestStatus(input: IngestStatusInput): IngestStatusViewModel {
+  const availabilityState = normalizeAvailabilityState(input.availabilityState);
+  const hasFailureReason = Boolean(input.lastFailureReason && input.lastFailureReason.trim());
+  const checkFaces = input.includeFaceDetection === true;
+  const facesPending = checkFaces && input.facesDetectedTs === null;
+  const thumbnailPending = input.hasThumbnail === false;
+
+  if (hasFailureReason || availabilityState !== null && FAILED_AVAILABILITY_STATES.has(availabilityState)) {
+    return {
+      tone: "failed",
+      label: "Failed",
+      description: "Ingest reported a failure for this photo or source."
+    };
+  }
+
+  if (availabilityState !== null && availabilityState !== ACTIVE_AVAILABILITY_STATE) {
+    return {
+      tone: "unknown",
+      label: "Unknown",
+      description: `Ingest returned an unrecognized state (${availabilityState}).`
+    };
+  }
+
+  if (facesPending || thumbnailPending) {
+    return {
+      tone: "pending",
+      label: "Pending",
+      description: "Ingest is still processing required assets for this photo."
+    };
+  }
+
+  if (availabilityState === ACTIVE_AVAILABILITY_STATE || input.isAvailable === true || input.hasThumbnail === true) {
+    return {
+      tone: "complete",
+      label: "Complete",
+      description: "Ingest completed enough work for browse and detail rendering."
+    };
+  }
+
+  if (input.isAvailable === false) {
+    return {
+      tone: "failed",
+      label: "Failed",
+      description: "Ingest reported a failure for this photo or source."
+    };
+  }
+
+  return {
+    tone: "unknown",
+    label: "Unknown",
+    description: "Ingest status is missing from this response."
+  };
+}
+
+export const INGEST_STATUS_LEGEND: Array<{ tone: IngestStatusTone; label: string; description: string }> = [
+  {
+    tone: "complete",
+    label: "Complete",
+    description: "Assets are ready for normal browse/detail viewing."
+  },
+  {
+    tone: "pending",
+    label: "Pending",
+    description: "Background ingest is still processing this item."
+  },
+  {
+    tone: "failed",
+    label: "Failed",
+    description: "Ingest encountered a failure for this item or source."
+  },
+  {
+    tone: "unknown",
+    label: "Unknown",
+    description: "Status was absent or not recognized in the API payload."
+  }
+];

--- a/apps/ui/src/pages/BrowseRoutePage.test.tsx
+++ b/apps/ui/src/pages/BrowseRoutePage.test.tsx
@@ -18,7 +18,12 @@ interface SearchResponsePayload {
       tags: string[];
       people: string[];
       faces: Array<{ person_id: string | null }>;
-      thumbnail: null;
+      thumbnail: {
+        mime_type: string;
+        width: number;
+        height: number;
+        data_base64: string;
+      } | null;
       original: {
         is_available: boolean;
         availability_state: string;
@@ -189,5 +194,63 @@ describe("BrowseRoutePage", () => {
 
     expect(screen.getByText("Reset to page 1 because that page position is unavailable.")).toBeInTheDocument();
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders ingest status badges and legend entries", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        hits: {
+          total: 3,
+          cursor: null,
+          items: [
+            {
+              ...buildPayload(["photo-complete"], null).hits.items[0],
+              photo_id: "photo-complete",
+              thumbnail: {
+                mime_type: "image/jpeg",
+                width: 10,
+                height: 10,
+                data_base64: "dGh1bWI="
+              },
+              original: {
+                is_available: true,
+                availability_state: "active",
+                last_failure_reason: null
+              }
+            },
+            {
+              ...buildPayload(["photo-pending"], null).hits.items[0],
+              photo_id: "photo-pending",
+              thumbnail: null,
+              original: {
+                is_available: true,
+                availability_state: "active",
+                last_failure_reason: null
+              }
+            },
+            {
+              ...buildPayload(["photo-unknown"], null).hits.items[0],
+              photo_id: "photo-unknown",
+              thumbnail: null,
+              original: {
+                is_available: true,
+                availability_state: "mystery",
+                last_failure_reason: null
+              }
+            }
+          ]
+        },
+        facets: {}
+      })
+    } as Response);
+
+    renderBrowseAt("/browse");
+
+    expect(await screen.findByText("photo-complete")).toBeInTheDocument();
+    expect(screen.getByText("Ingest status legend")).toBeInTheDocument();
+    expect(screen.getAllByText("Complete").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Unknown").length).toBeGreaterThan(0);
   });
 });

--- a/apps/ui/src/pages/BrowseRoutePage.tsx
+++ b/apps/ui/src/pages/BrowseRoutePage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import type { NotificationEntry } from "../app/feedback/feedbackTypes";
 import { ToastStack } from "../app/feedback/ToastStack";
+import { deriveIngestStatus, INGEST_STATUS_LEGEND } from "../app/ingestStatus";
 
 type SortDirection = "asc" | "desc";
 
@@ -275,6 +276,17 @@ export function BrowseRoutePage() {
       </div>
 
       <p className="browse-summary" aria-live="polite">{summaryLabel}</p>
+      <section className="status-legend" aria-label="Ingest status legend">
+        <h2>Ingest status legend</h2>
+        <ul>
+          {INGEST_STATUS_LEGEND.map((entry) => (
+            <li key={entry.tone}>
+              <span className={`ingest-status-badge is-${entry.tone}`}>{entry.label}</span>
+              <span>{entry.description}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
 
       {error ? (
         <div className="feedback-panel feedback-panel-error">
@@ -300,8 +312,20 @@ export function BrowseRoutePage() {
 
       {!error && !isLoading && photos.length > 0 ? (
         <ol className="browse-grid" aria-label="Photo gallery">
-          {photos.map((photo) => (
-            <li key={photo.photo_id} className="browse-card">
+          {photos.map((photo) => {
+            const ingestStatus = deriveIngestStatus({
+              availabilityState: photo.original?.availability_state ?? null,
+              isAvailable: photo.original?.is_available ?? null,
+              lastFailureReason: photo.original?.last_failure_reason ?? null,
+              hasThumbnail: Boolean(photo.thumbnail)
+            });
+
+            return (
+              <li key={photo.photo_id} className="browse-card">
+                <p className="browse-ingest-status">
+                  <span className={`ingest-status-badge is-${ingestStatus.tone}`}>{ingestStatus.label}</span>
+                  <span className="browse-ingest-status-detail">{ingestStatus.description}</span>
+                </p>
               {photo.thumbnail ? (
                 <img
                   className="browse-thumbnail"
@@ -342,8 +366,9 @@ export function BrowseRoutePage() {
                   </div>
                 </dl>
               </div>
-            </li>
-          ))}
+              </li>
+            );
+          })}
         </ol>
       ) : null}
 

--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -182,6 +182,7 @@ describe("PhotoDetailRoutePage", () => {
     expect(screen.getByText("No tags")).toBeInTheDocument();
     expect(screen.getByText("No recognized people")).toBeInTheDocument();
     expect(screen.getByText("Unknown availability")).toBeInTheDocument();
+    expect(screen.getAllByText("Unknown").length).toBeGreaterThan(0);
   });
 
   it("shows explicit no-face state when no face regions are present", async () => {
@@ -257,5 +258,29 @@ describe("PhotoDetailRoutePage", () => {
       expect(screen.getByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders pending ingest status when face detection is still in progress", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () =>
+        buildPayload({
+          original: {
+            is_available: true,
+            availability_state: "active",
+            last_failure_reason: null
+          },
+          metadata: {
+            ...buildPayload().metadata,
+            faces_detected_ts: null
+          }
+        })
+    } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
+    expect(screen.getByText("Ingest status legend")).toBeInTheDocument();
+    expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
   });
 });

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { deriveIngestStatus, INGEST_STATUS_LEGEND } from "../app/ingestStatus";
 
 type PhotoDetailPayload = {
   photo_id: string;
@@ -224,6 +225,20 @@ export function PhotoDetailRoutePage() {
     return `${faceOverlayRegions.length} face region${faceOverlayRegions.length === 1 ? "" : "s"} rendered.`;
   }, [detail, faceOverlayRegions.length]);
 
+  const ingestStatus = useMemo(() => {
+    if (!detail) {
+      return null;
+    }
+    return deriveIngestStatus({
+      availabilityState: detail.original?.availability_state ?? null,
+      isAvailable: detail.original?.is_available ?? null,
+      lastFailureReason: detail.original?.last_failure_reason ?? null,
+      hasThumbnail: Boolean(detail.thumbnail),
+      includeFaceDetection: true,
+      facesDetectedTs: detail.metadata.faces_detected_ts
+    });
+  }, [detail]);
+
   return (
     <section aria-labelledby="page-title" className="page detail-page">
       <div className="detail-header">
@@ -235,6 +250,17 @@ export function PhotoDetailRoutePage() {
           Back to browse
         </Link>
       </div>
+      <section className="status-legend" aria-label="Ingest status legend">
+        <h2>Ingest status legend</h2>
+        <ul>
+          {INGEST_STATUS_LEGEND.map((entry) => (
+            <li key={entry.tone}>
+              <span className={`ingest-status-badge is-${entry.tone}`}>{entry.label}</span>
+              <span>{entry.description}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
 
       {isLoading ? (
         <div className="feedback-panel feedback-panel-loading" role="status" aria-live="polite">
@@ -338,7 +364,18 @@ export function PhotoDetailRoutePage() {
                 <dt>Availability</dt>
                 <dd>{detail.original?.availability_state ?? "Unknown availability"}</dd>
               </div>
+              <div>
+                <dt>Ingest status</dt>
+                <dd>
+                  {ingestStatus ? (
+                    <span className={`ingest-status-badge is-${ingestStatus.tone}`}>{ingestStatus.label}</span>
+                  ) : (
+                    "Unknown"
+                  )}
+                </dd>
+              </div>
             </dl>
+            {ingestStatus ? <p className="detail-ingest-status-detail">{ingestStatus.description}</p> : null}
           </article>
 
           <article className="detail-panel">

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -252,6 +252,37 @@ body {
   color: #475569;
 }
 
+.status-legend {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.65rem;
+  background: #ffffff;
+  padding: 0.7rem 0.8rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.status-legend h2 {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #0f172a;
+}
+
+.status-legend ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.status-legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #334155;
+  font-size: 0.8rem;
+}
+
 .browse-grid {
   margin: 0;
   padding: 0;
@@ -267,7 +298,20 @@ body {
   background: #ffffff;
   overflow: hidden;
   display: grid;
-  grid-template-rows: 9rem 1fr;
+  grid-template-rows: auto 9rem 1fr;
+}
+
+.browse-ingest-status {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.75rem 0.2rem;
+}
+
+.browse-ingest-status-detail {
+  color: #334155;
+  font-size: 0.75rem;
 }
 
 .browse-thumbnail {
@@ -488,6 +532,46 @@ body {
   margin: 0;
   font-size: 0.82rem;
   color: #334155;
+}
+
+.ingest-status-badge {
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.72rem;
+  padding: 0.1rem 0.5rem;
+  font-weight: 600;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.ingest-status-badge.is-complete {
+  border-color: #86efac;
+  background: #f0fdf4;
+  color: #166534;
+}
+
+.ingest-status-badge.is-pending {
+  border-color: #fcd34d;
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.ingest-status-badge.is-failed {
+  border-color: #fca5a5;
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.ingest-status-badge.is-unknown {
+  border-color: #cbd5e1;
+  background: #f8fafc;
+  color: #334155;
+}
+
+.detail-ingest-status-detail {
+  margin: 0;
+  color: #334155;
+  font-size: 0.8rem;
 }
 
 .feedback-panel {


### PR DESCRIPTION
## Summary
- add a shared ingest-status derivation utility for UI payloads with deterministic `complete`, `pending`, `failed`, and `unknown` outcomes
- show ingest-status badges and a status legend in both browse gallery cards and photo detail metadata surfaces
- extend UI coverage with new status-derivation unit tests and browse/detail rendering assertions for pending/unknown handling

## Why
Issue #172 requires ingest-status visibility in browse and detail contexts so users can distinguish ready items from still-processing, failed-like, or unknown states.

## Validation
- `make ui-test`
- `make ui-build`

Closes #172