### PR TITLE
[codex] Implement browse/detail focus restoration and not-found state (#173)

### DIFF
--- a/apps/ui/src/pages/BrowseRoutePage.test.tsx
+++ b/apps/ui/src/pages/BrowseRoutePage.test.tsx
@@ -253,4 +253,60 @@ describe("BrowseRoutePage", () => {
     expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Unknown").length).toBeGreaterThan(0);
   });
+
+  it("restores focus to the previously selected photo when returning from detail", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => buildPayload(["photo-a", "photo-b"], null, 2)
+    } as Response);
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: "/browse",
+            state: { restoreFocusPhotoId: "photo-b" }
+          }
+        ]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route path="/browse" element={<BrowseRoutePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const targetLink = await screen.findByRole("link", { name: "photo-b" });
+    await waitFor(() => {
+      expect(targetLink).toHaveFocus();
+    });
+  });
+
+  it("falls back to the browse heading when return-focus target is unavailable", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => buildPayload(["photo-a"], null, 1)
+    } as Response);
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: "/browse",
+            state: { restoreFocusPhotoId: "photo-missing" }
+          }
+        ]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route path="/browse" element={<BrowseRoutePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const heading = await screen.findByRole("heading", { name: "Browse", level: 1 });
+    await waitFor(() => {
+      expect(heading).toHaveFocus();
+    });
+  });
 });

--- a/apps/ui/src/pages/BrowseRoutePage.tsx
+++ b/apps/ui/src/pages/BrowseRoutePage.tsx
@@ -1,8 +1,13 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import type { NotificationEntry } from "../app/feedback/feedbackTypes";
 import { ToastStack } from "../app/feedback/ToastStack";
 import { deriveIngestStatus, INGEST_STATUS_LEGEND } from "../app/ingestStatus";
+import {
+  consumePendingBrowseFocusPhotoId,
+  resolveBrowseReturnState,
+  setPendingBrowseFocusPhotoId
+} from "./browseFocusState";
 
 type SortDirection = "asc" | "desc";
 
@@ -119,6 +124,7 @@ export function BrowseRoutePage() {
   const location = useLocation();
   const navigate = useNavigate();
   const requestedPage = parseRequestedPage(location.search);
+  const initialReturnState = resolveBrowseReturnState(location.state);
 
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const [cursorByPage, setCursorByPage] = useState<Record<number, string | null>>({ 1: null });
@@ -129,6 +135,10 @@ export function BrowseRoutePage() {
   const [error, setError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
   const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
+  const headingRef = useRef<HTMLHeadingElement | null>(null);
+  const pendingReturnFocusPhotoIdRef = useRef<string | null>(
+    initialReturnState?.restoreFocusPhotoId ?? consumePendingBrowseFocusPhotoId()
+  );
 
   const cursorForPage = cursorByPage[requestedPage];
 
@@ -216,6 +226,37 @@ export function BrowseRoutePage() {
     };
   }, [cursorForPage, reloadToken, requestedPage, sortDirection]);
 
+  useEffect(() => {
+    const pendingPhotoId = pendingReturnFocusPhotoIdRef.current;
+    if (!pendingPhotoId || isLoading) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      if (error) {
+        headingRef.current?.focus();
+        pendingReturnFocusPhotoIdRef.current = null;
+        return;
+      }
+
+      const focusTarget = document.querySelector<HTMLAnchorElement>(
+        `[data-photo-id="${pendingPhotoId}"]`
+      );
+
+      if (focusTarget) {
+        focusTarget.focus();
+      } else {
+        headingRef.current?.focus();
+      }
+
+      pendingReturnFocusPhotoIdRef.current = null;
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [error, isLoading, photos]);
+
   const canGoPrevious = requestedPage > 1 && !isLoading;
   const canGoNext = nextCursor !== null && !isLoading;
 
@@ -233,7 +274,9 @@ export function BrowseRoutePage() {
     <section aria-labelledby="page-title" className="page browse-page">
       <div className="browse-header">
         <div>
-          <h1 id="page-title">Browse</h1>
+          <h1 id="page-title" ref={headingRef} tabIndex={-1}>
+            Browse
+          </h1>
           <p>Deterministic gallery ordering with stable cursor pagination.</p>
         </div>
         <div className="browse-controls" role="group" aria-label="Browse controls">
@@ -326,46 +369,55 @@ export function BrowseRoutePage() {
                   <span className={`ingest-status-badge is-${ingestStatus.tone}`}>{ingestStatus.label}</span>
                   <span className="browse-ingest-status-detail">{ingestStatus.description}</span>
                 </p>
-              {photo.thumbnail ? (
-                <img
-                  className="browse-thumbnail"
-                  src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
-                  width={photo.thumbnail.width}
-                  height={photo.thumbnail.height}
-                  alt={`Thumbnail for ${photo.photo_id}`}
-                />
-              ) : (
-                <div className="browse-thumbnail browse-thumbnail-placeholder" aria-hidden="true">
-                  No preview
-                </div>
-              )}
+                {photo.thumbnail ? (
+                  <img
+                    className="browse-thumbnail"
+                    src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
+                    width={photo.thumbnail.width}
+                    height={photo.thumbnail.height}
+                    alt={`Thumbnail for ${photo.photo_id}`}
+                  />
+                ) : (
+                  <div className="browse-thumbnail browse-thumbnail-placeholder" aria-hidden="true">
+                    No preview
+                  </div>
+                )}
 
-              <div className="browse-card-body">
-                <h2>
-                  <Link className="browse-photo-link" to={`/browse/${photo.photo_id}`}>
-                    {photo.photo_id}
-                  </Link>
-                </h2>
-                <p className="browse-path" title={photo.path}>{photo.path}</p>
-                <dl>
-                  <div>
-                    <dt>Captured</dt>
-                    <dd>{formatShotTimestamp(photo.shot_ts)}</dd>
-                  </div>
-                  <div>
-                    <dt>Size</dt>
-                    <dd>{formatFilesize(photo.filesize)}</dd>
-                  </div>
-                  <div>
-                    <dt>People</dt>
-                    <dd>{photo.people.length}</dd>
-                  </div>
-                  <div>
-                    <dt>Original</dt>
-                    <dd>{photo.original?.availability_state ?? "unknown"}</dd>
-                  </div>
-                </dl>
-              </div>
+                <div className="browse-card-body">
+                  <h2>
+                    <Link
+                      className="browse-photo-link"
+                      data-photo-id={photo.photo_id}
+                      to={`/browse/${photo.photo_id}`}
+                      state={{
+                        returnToBrowseSearch: location.search,
+                        returnFocusPhotoId: photo.photo_id
+                      }}
+                      onClick={() => setPendingBrowseFocusPhotoId(photo.photo_id)}
+                    >
+                      {photo.photo_id}
+                    </Link>
+                  </h2>
+                  <p className="browse-path" title={photo.path}>{photo.path}</p>
+                  <dl>
+                    <div>
+                      <dt>Captured</dt>
+                      <dd>{formatShotTimestamp(photo.shot_ts)}</dd>
+                    </div>
+                    <div>
+                      <dt>Size</dt>
+                      <dd>{formatFilesize(photo.filesize)}</dd>
+                    </div>
+                    <div>
+                      <dt>People</dt>
+                      <dd>{photo.people.length}</dd>
+                    </div>
+                    <div>
+                      <dt>Original</dt>
+                      <dd>{photo.original?.availability_state ?? "unknown"}</dd>
+                    </div>
+                  </dl>
+                </div>
               </li>
             );
           })}

--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -283,4 +283,31 @@ describe("PhotoDetailRoutePage", () => {
     expect(screen.getByText("Ingest status legend")).toBeInTheDocument();
     expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
   });
+
+  it("moves keyboard focus to the detail heading when opened", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => buildPayload()
+    } as Response);
+
+    renderDetail();
+
+    const heading = await screen.findByRole("heading", { name: "Photo detail", level: 1 });
+    await waitFor(() => {
+      expect(heading).toHaveFocus();
+    });
+  });
+
+  it("renders an explicit empty state when the photo is not found", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404
+    } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByRole("heading", { name: "Photo not found", level: 2 })).toBeInTheDocument();
+    expect(screen.getByText("This photo is no longer available in the catalog.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to browse" })).toBeInTheDocument();
+  });
 });

--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -216,11 +216,11 @@ describe("PhotoDetailRoutePage", () => {
     renderDetail();
 
     expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
-    expect(screen.getByLabelText("Face region 1 for person-1")).toBeInTheDocument();
+    expect(await screen.findByLabelText("Face region 1 for person-1")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Actual pixels" }));
 
-    expect(screen.getByLabelText("Face region 1 for person-1")).toBeInTheDocument();
+    expect(await screen.findByLabelText("Face region 1 for person-1")).toBeInTheDocument();
   });
 
   it("renders deterministic loading and error transitions", async () => {

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -1,6 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link, useLocation, useParams } from "react-router-dom";
 import { deriveIngestStatus, INGEST_STATUS_LEGEND } from "../app/ingestStatus";
+import {
+  resolveDetailReturnState,
+  setPendingBrowseFocusPhotoId
+} from "./browseFocusState";
 
 type PhotoDetailPayload = {
   photo_id: string;
@@ -62,6 +66,16 @@ type FaceOverlayRegion = {
   heightPercent: number;
 };
 
+class PhotoDetailRequestError extends Error {
+  status: number;
+
+  constructor(status: number) {
+    super(`Photo detail request failed (${status})`);
+    this.status = status;
+    this.name = "PhotoDetailRequestError";
+  }
+}
+
 function formatTimestamp(value: string | null): string {
   if (!value) {
     return MISSING_VALUE;
@@ -112,22 +126,31 @@ function clamp(value: number, min: number, max: number): number {
 async function fetchPhotoDetail(photoId: string): Promise<PhotoDetailPayload> {
   const response = await fetch(`/api/v1/photos/${photoId}`);
   if (!response.ok) {
-    throw new Error(`Photo detail request failed (${response.status})`);
+    throw new PhotoDetailRequestError(response.status);
   }
   return (await response.json()) as PhotoDetailPayload;
 }
 
 export function PhotoDetailRoutePage() {
+  const location = useLocation();
   const { photoId } = useParams<{ photoId: string }>();
+  const returnState = resolveDetailReturnState(location.state);
+  const headingRef = useRef<HTMLHeadingElement | null>(null);
   const [detail, setDetail] = useState<PhotoDetailPayload | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isNotFound, setIsNotFound] = useState(false);
   const [reloadToken, setReloadToken] = useState(0);
   const [mediaMode, setMediaMode] = useState<MediaPresentationMode>("fit");
 
   useEffect(() => {
+    headingRef.current?.focus();
+  }, [photoId]);
+
+  useEffect(() => {
     if (!photoId) {
       setError("Photo identifier is missing.");
+      setIsNotFound(false);
       setIsLoading(false);
       return;
     }
@@ -135,12 +158,14 @@ export function PhotoDetailRoutePage() {
     const controller = new AbortController();
     setIsLoading(true);
     setError(null);
+    setIsNotFound(false);
 
     fetchPhotoDetail(photoId)
       .then((payload) => {
         if (controller.signal.aborted) {
           return;
         }
+        setIsNotFound(false);
         setDetail(payload);
         setIsLoading(false);
       })
@@ -148,7 +173,17 @@ export function PhotoDetailRoutePage() {
         if (controller.signal.aborted) {
           return;
         }
+
+        if (caughtError instanceof PhotoDetailRequestError && caughtError.status === 404) {
+          setDetail(null);
+          setError(null);
+          setIsNotFound(true);
+          setIsLoading(false);
+          return;
+        }
+
         setError(caughtError instanceof Error ? caughtError.message : "Could not load photo detail.");
+        setIsNotFound(false);
         setIsLoading(false);
       });
 
@@ -239,14 +274,30 @@ export function PhotoDetailRoutePage() {
     });
   }, [detail]);
 
+  const backLinkFocusPhotoId = detail?.photo_id ?? returnState.returnFocusPhotoId ?? photoId ?? null;
+
   return (
     <section aria-labelledby="page-title" className="page detail-page">
       <div className="detail-header">
         <div>
-          <h1 id="page-title">Photo detail</h1>
+          <h1 id="page-title" ref={headingRef} tabIndex={-1}>
+            Photo detail
+          </h1>
           <p>Inspect canonical metadata and availability fields for a single photo.</p>
         </div>
-        <Link className="detail-back-link" to="/browse">
+        <Link
+          className="detail-back-link"
+          to={{
+            pathname: "/browse",
+            search: returnState.returnToBrowseSearch ?? ""
+          }}
+          state={backLinkFocusPhotoId ? { restoreFocusPhotoId: backLinkFocusPhotoId } : undefined}
+          onClick={() => {
+            if (backLinkFocusPhotoId) {
+              setPendingBrowseFocusPhotoId(backLinkFocusPhotoId);
+            }
+          }}
+        >
           Back to browse
         </Link>
       </div>
@@ -450,6 +501,13 @@ export function PhotoDetailRoutePage() {
             </dl>
           </article>
         </div>
+      ) : null}
+
+      {!isLoading && !error && isNotFound ? (
+        <section className="feedback-panel" aria-labelledby="photo-not-found-title">
+          <h2 id="photo-not-found-title">Photo not found</h2>
+          <p>This photo is no longer available in the catalog.</p>
+        </section>
       ) : null}
     </section>
   );

--- a/apps/ui/src/pages/browseFocusState.ts
+++ b/apps/ui/src/pages/browseFocusState.ts
@@ -1,0 +1,53 @@
+export interface BrowseReturnState {
+  restoreFocusPhotoId?: string;
+}
+
+export interface DetailReturnState {
+  returnToBrowseSearch?: string;
+  returnFocusPhotoId?: string;
+}
+
+let pendingBrowseFocusPhotoId: string | null = null;
+
+export function setPendingBrowseFocusPhotoId(photoId: string): void {
+  pendingBrowseFocusPhotoId = photoId;
+}
+
+export function consumePendingBrowseFocusPhotoId(): string | null {
+  const photoId = pendingBrowseFocusPhotoId;
+  pendingBrowseFocusPhotoId = null;
+  return photoId;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function resolveBrowseReturnState(state: unknown): BrowseReturnState | null {
+  if (!isRecord(state)) {
+    return null;
+  }
+
+  const restoreFocusPhotoId = state.restoreFocusPhotoId;
+  if (typeof restoreFocusPhotoId !== "string" || restoreFocusPhotoId.length === 0) {
+    return null;
+  }
+
+  return { restoreFocusPhotoId };
+}
+
+export function resolveDetailReturnState(state: unknown): DetailReturnState {
+  if (!isRecord(state)) {
+    return {};
+  }
+
+  const returnState: DetailReturnState = {};
+  if (typeof state.returnToBrowseSearch === "string") {
+    returnState.returnToBrowseSearch = state.returnToBrowseSearch;
+  }
+  if (typeof state.returnFocusPhotoId === "string" && state.returnFocusPhotoId.length > 0) {
+    returnState.returnFocusPhotoId = state.returnFocusPhotoId;
+  }
+
+  return returnState;
+}


### PR DESCRIPTION
## Summary
- implement deterministic keyboard focus behavior between browse and photo detail views
- restore focus to the originating browse card when navigating back from detail, with fallback to the browse heading when the target is unavailable
- move focus to the detail page heading on detail entry for keyboard users
- add explicit photo-detail empty state handling for `404 Not Found` responses while preserving existing loading/error states

## Why
Issue #173 requires predictable empty/loading/error handling and keyboard focus transfer across browse/detail transitions so users remain oriented and can continue navigation after transitions or recoveries.

## Validation
- `npm --prefix apps/ui test -- src/pages/BrowseRoutePage.test.tsx src/pages/PhotoDetailRoutePage.test.tsx`
- `npm --prefix apps/ui test -- src/pages`

## Notes
- introduces `browseFocusState.ts` to carry return-focus context across route transitions
- keeps PR as draft for review