### PR TITLE
feat(ui): implement issue #174 tokenized search bar interactions

### DIFF
--- a/apps/ui/src/app/AppRouter.tsx
+++ b/apps/ui/src/app/AppRouter.tsx
@@ -16,6 +16,7 @@ import {
 } from "../routes/routeDefinitions";
 import { PrimaryRoutePage } from "../pages/PrimaryRoutePage";
 import { BrowseRoutePage } from "../pages/BrowseRoutePage";
+import { SearchRoutePage } from "../pages/SearchRoutePage";
 import { PhotoDetailRoutePage } from "../pages/PhotoDetailRoutePage";
 import { NotFoundPage } from "../pages/NotFoundPage";
 import {
@@ -85,6 +86,8 @@ export function AppRouteTree({ initialSessionIdentity }: AppRouteTreeProps = {})
             element={
               route.key === "browse" ? (
                 <BrowseRoutePage />
+              ) : route.key === "search" ? (
+                <SearchRoutePage />
               ) : (
                 <PrimaryRoutePage route={route} />
               )

--- a/apps/ui/src/app/AppShell.test.tsx
+++ b/apps/ui/src/app/AppShell.test.tsx
@@ -61,6 +61,10 @@ function expectShellContextText(text: string) {
   expect(shellContext).toHaveTextContent(text);
 }
 
+const ROUTES_WITH_PRIMARY_PAGE_FEEDBACK = PRIMARY_ROUTE_DEFINITIONS.filter(
+  (route) => route.key !== "search"
+);
+
 describe("App shell", () => {
   const fetchMock = vi.fn();
 
@@ -169,7 +173,7 @@ describe("App shell", () => {
     expectShellContextText("Browse");
   });
 
-  it.each(PRIMARY_ROUTE_DEFINITIONS)(
+  it.each(ROUTES_WITH_PRIMARY_PAGE_FEEDBACK)(
     "routes $title through shared loading feedback surface",
     ({ key, path }) => {
       renderAtPath(`${path}?demoState=loading`);
@@ -180,38 +184,51 @@ describe("App shell", () => {
     }
   );
 
-  it("transitions from route error to ready on retry", async () => {
+  it("transitions from route error to ready on retry for primary-placeholder routes", async () => {
     const user = userEvent.setup();
-    renderAtPath("/search?demoState=error");
+    renderAtPath("/labeling?demoState=error");
 
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
     expect(
       screen.getByRole("heading", {
-        name: "Could not load Search",
+        name: "Could not load Labeling",
         level: 2
       })
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Retry" }));
 
-    expect(screen.getByRole("heading", { name: "Search", level: 1 })).toBeInTheDocument();
-    expect(screen.getByText("Search is ready.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Labeling", level: 1 })).toBeInTheDocument();
+    expect(screen.getByText("Labeling is ready.")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Dismiss notification" }));
-    expect(screen.queryByText("Search is ready.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Labeling is ready.")).not.toBeInTheDocument();
   });
 
   it("does not reset feedback state when unrelated query params change", async () => {
     const user = userEvent.setup();
-    renderAtPathWithQueryBump("/search?demoState=error&panel=primary");
+    renderAtPathWithQueryBump("/labeling?demoState=error&panel=primary");
 
     await user.click(screen.getByRole("button", { name: "Retry" }));
-    expect(screen.getByText("Search is ready.")).toBeInTheDocument();
+    expect(screen.getByText("Labeling is ready.")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Bump query" }));
 
-    expect(screen.getByRole("heading", { name: "Search", level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Labeling", level: 1 })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
-    expect(screen.getByText("Search is ready.")).toBeInTheDocument();
+    expect(screen.getByText("Labeling is ready.")).toBeInTheDocument();
+  });
+
+  it("renders search query controls on the /search route", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ hits: { total: 0, cursor: null, items: [] }, facets: {} })
+    } as Response);
+
+    renderAtPath("/search");
+
+    expect(await screen.findByRole("heading", { name: "Search", level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Search query" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/pages/SearchRoutePage.test.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.test.tsx
@@ -1,0 +1,194 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { SearchRoutePage } from "./SearchRoutePage";
+
+interface SearchResponsePayload {
+  hits: {
+    total: number;
+    cursor: string | null;
+    items: Array<{
+      photo_id: string;
+      path: string;
+      ext: string;
+      shot_ts: string | null;
+      filesize: number;
+    }>;
+  };
+  facets: Record<string, unknown>;
+}
+
+function buildPayload(photoIds: string[], total = photoIds.length): SearchResponsePayload {
+  return {
+    hits: {
+      total,
+      cursor: null,
+      items: photoIds.map((photoId, index) => ({
+        photo_id: photoId,
+        path: `/library/${photoId}.jpg`,
+        ext: "jpg",
+        shot_ts: `2026-04-${String(index + 1).padStart(2, "0")}T12:00:00Z`,
+        filesize: 1024 + index
+      }))
+    },
+    facets: {}
+  };
+}
+
+function renderSearchAt(path = "/search") {
+  return render(
+    <MemoryRouter
+      initialEntries={[path]}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Routes>
+        <Route path="/search" element={<SearchRoutePage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("SearchRoutePage", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => buildPayload([], 0)
+    } as Response);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("submits a phrase chip with Enter and sends q using chip-order serialization", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    const input = await screen.findByRole("textbox", { name: "Search query" });
+    await user.type(input, "lake weekend{enter}");
+
+    expect(await screen.findByRole("button", { name: "Remove query lake weekend" })).toBeInTheDocument();
+
+    const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+    expect(lastCall?.[0]).toBe("/api/v1/search");
+    const body = JSON.parse(String((lastCall?.[1] as RequestInit).body));
+    expect(body.q).toBe("lake weekend");
+    expect(body.sort).toEqual({ by: "shot_ts", dir: "desc" });
+    expect(body.page).toEqual({ limit: 24, cursor: null });
+  });
+
+  it("submits with Search button and appends phrase as a new chip", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    const input = await screen.findByRole("textbox", { name: "Search query" });
+    await user.type(input, "first phrase");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await user.type(input, "second phrase");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(screen.getByRole("button", { name: "Remove query first phrase" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove query second phrase" })).toBeInTheDocument();
+
+    const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+    const body = JSON.parse(String((lastCall?.[1] as RequestInit).body));
+    expect(body.q).toBe("first phrase second phrase");
+  });
+
+  it("ignores whitespace-only submit and keeps existing chips and request count unchanged", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    const input = await screen.findByRole("textbox", { name: "Search query" });
+    await user.type(input, "coastline");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    const callsAfterFirstSubmit = fetchMock.mock.calls.length;
+
+    await user.clear(input);
+    await user.type(input, "   ");
+    await user.keyboard("{Enter}");
+
+    expect(fetchMock.mock.calls.length).toBe(callsAfterFirstSubmit);
+    expect(screen.getByRole("button", { name: "Remove query coastline" })).toBeInTheDocument();
+  });
+
+  it("removes dismissed chip and re-fetches using remaining chip order", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    const input = await screen.findByRole("textbox", { name: "Search query" });
+    await user.type(input, "alpha");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await user.type(input, "beta");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await user.click(screen.getByRole("button", { name: "Remove query alpha" }));
+
+    const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+    const body = JSON.parse(String((lastCall?.[1] as RequestInit).body));
+    expect(body.q).toBe("beta");
+    expect(screen.queryByRole("button", { name: "Remove query alpha" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove query beta" })).toBeInTheDocument();
+  });
+
+  it("renders loading status while the search request is pending", async () => {
+    let resolveResponse!: (value: Response) => void;
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveResponse = resolve;
+        })
+    );
+
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    const input = await screen.findByRole("textbox", { name: "Search query" });
+    await user.type(input, "harbor");
+    await user.keyboard("{Enter}");
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading search workflow.");
+
+    resolveResponse({
+      ok: true,
+      json: async () => buildPayload([], 0)
+    } as Response);
+
+    expect(await screen.findByText("No matching photos for the active query.")).toBeInTheDocument();
+  });
+
+  it("shows retry UI on failure and retries with active chips", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({ ok: false, status: 503 } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => buildPayload(["photo-1"], 1)
+      } as Response);
+
+    renderSearchAt();
+    const input = await screen.findByRole("textbox", { name: "Search query" });
+    await user.type(input, "storm coast");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Could not load Search",
+        level: 2
+      })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
+    const body = JSON.parse(String((lastCall?.[1] as RequestInit).body));
+    expect(body.q).toBe("storm coast");
+    expect(await screen.findByText("photo-1")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/pages/SearchRoutePage.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.tsx
@@ -1,0 +1,198 @@
+import { FormEvent, useMemo, useState } from "react";
+
+type SearchPhoto = {
+  photo_id: string;
+  path: string;
+  ext: string;
+  shot_ts: string | null;
+  filesize: number;
+};
+
+type SearchResponsePayload = {
+  hits: {
+    total: number;
+    cursor: string | null;
+    items: SearchPhoto[];
+  };
+};
+
+const DEFAULT_SORT = { by: "shot_ts", dir: "desc" } as const;
+const DEFAULT_PAGE = { limit: 24, cursor: null } as const;
+
+async function fetchSearchResults(query: string): Promise<SearchResponsePayload> {
+  const response = await fetch("/api/v1/search", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({
+      q: query,
+      sort: DEFAULT_SORT,
+      page: DEFAULT_PAGE
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Search request failed (${response.status})`);
+  }
+
+  return (await response.json()) as SearchResponsePayload;
+}
+
+export function SearchRoutePage() {
+  const [draftQuery, setDraftQuery] = useState("");
+  const [queryChips, setQueryChips] = useState<string[]>([]);
+  const [results, setResults] = useState<SearchPhoto[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasRequested, setHasRequested] = useState(false);
+
+  const serializedQuery = useMemo(() => queryChips.join(" "), [queryChips]);
+
+  async function runSearch(chips: string[]) {
+    setIsLoading(true);
+    setError(null);
+    setHasRequested(true);
+
+    try {
+      const payload = await fetchSearchResults(chips.join(" "));
+      setResults(payload.hits.items);
+      setTotalCount(payload.hits.total);
+    } catch (caughtError: unknown) {
+      const message =
+        caughtError instanceof Error
+          ? caughtError.message
+          : "Could not load search results.";
+      setError(message);
+      setResults([]);
+      setTotalCount(0);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const trimmed = draftQuery.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    const nextChips = [...queryChips, trimmed];
+    setQueryChips(nextChips);
+    setDraftQuery("");
+    void runSearch(nextChips);
+  }
+
+  function handleDismissChip(indexToRemove: number) {
+    const nextChips = queryChips.filter((_, index) => index !== indexToRemove);
+    setQueryChips(nextChips);
+    void runSearch(nextChips);
+  }
+
+  function handleRetry() {
+    void runSearch(queryChips);
+  }
+
+  const summaryLabel = useMemo(() => {
+    if (isLoading) {
+      return "Loading search workflow.";
+    }
+
+    if (error) {
+      return "Search results unavailable.";
+    }
+
+    if (!hasRequested) {
+      return "Submit a phrase to search the catalog.";
+    }
+
+    return `Showing ${results.length} of ${totalCount} photos`;
+  }, [error, hasRequested, isLoading, results.length, totalCount]);
+
+  return (
+    <section aria-labelledby="page-title" className="page search-page">
+      <div>
+        <h1 id="page-title">Search</h1>
+        <p>Tokenized phrase chips with deterministic submit and reset behavior.</p>
+      </div>
+
+      <form className="search-query-form" onSubmit={handleSubmit}>
+        <label htmlFor="search-query-input">Search query</label>
+        <div className="search-query-row">
+          <input
+            id="search-query-input"
+            type="text"
+            value={draftQuery}
+            onChange={(event) => setDraftQuery(event.target.value)}
+            aria-describedby="search-query-summary"
+          />
+          <button type="submit">Search</button>
+        </div>
+      </form>
+
+      {queryChips.length > 0 ? (
+        <ul className="search-chip-list" aria-label="Active query filters">
+          {queryChips.map((chip, index) => (
+            <li key={`${chip}-${index}`}>
+              <button
+                type="button"
+                className="search-chip"
+                aria-label={`Remove query ${chip}`}
+                onClick={() => handleDismissChip(index)}
+              >
+                {chip}
+                <span aria-hidden="true"> ×</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <p id="search-query-summary" className="search-summary" aria-live="polite">
+        {summaryLabel}
+      </p>
+
+      {isLoading ? (
+        <div className="feedback-panel feedback-panel-loading" role="status" aria-live="polite">
+          Loading search workflow.
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="feedback-panel feedback-panel-error">
+          <h2>Could not load Search</h2>
+          <p>{error}</p>
+          <button type="button" onClick={handleRetry}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {!error && !isLoading && hasRequested && results.length === 0 ? (
+        <div className="feedback-panel">
+          <p>No matching photos for the active query.</p>
+        </div>
+      ) : null}
+
+      {!error && !isLoading && results.length > 0 ? (
+        <ol className="search-results" aria-label="Search results">
+          {results.map((photo) => (
+            <li key={photo.photo_id}>
+              <h2>{photo.photo_id}</h2>
+              <p className="search-result-path" title={photo.path}>
+                {photo.path}
+              </p>
+            </li>
+          ))}
+        </ol>
+      ) : null}
+
+      <p className="search-serialized-query" aria-live="off">
+        Active query: {serializedQuery || "(none)"}
+      </p>
+    </section>
+  );
+}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -622,6 +622,96 @@ body {
   background: #fffbeb;
 }
 
+.search-page {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.search-query-form {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.search-query-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.search-query-row input {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  padding: 0.45rem 0.55rem;
+  font: inherit;
+}
+
+.search-query-row button {
+  border: 1px solid #93c5fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.45rem 0.7rem;
+  font: inherit;
+}
+
+.search-chip-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.search-chip {
+  border: 1px solid #bfdbfe;
+  background: #f8fbff;
+  color: #1e3a8a;
+  border-radius: 999px;
+  padding: 0.3rem 0.6rem;
+  font: inherit;
+}
+
+.search-summary {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.search-results {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.search-results li {
+  border: 1px solid #dbe4ee;
+  border-radius: 0.55rem;
+  background: #ffffff;
+  padding: 0.65rem 0.75rem;
+}
+
+.search-results h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.search-result-path {
+  margin: 0.35rem 0 0;
+  color: #334155;
+  word-break: break-word;
+}
+
+.search-serialized-query {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
 @media (max-width: 1024px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -699,5 +789,13 @@ body {
 
   .browse-card {
     grid-template-rows: 7.5rem 1fr;
+  }
+
+  .search-query-row {
+    flex-direction: column;
+  }
+
+  .search-query-row button {
+    width: fit-content;
   }
 }

--- a/apps/ui/tests/e2e/journeys/app-shell-journeys.spec.ts
+++ b/apps/ui/tests/e2e/journeys/app-shell-journeys.spec.ts
@@ -118,21 +118,21 @@ test("JRN-P3-search-route-deep-link @journey @smoke", async ({ page }) => {
 });
 
 test("JRN-P2-shared-feedback-surfaces @journey @smoke", async ({ page }) => {
-  await page.goto("/search?demoState=loading");
+  await page.goto("/labeling?demoState=loading");
 
-  await expect(page.getByRole("status")).toContainText(/Loading search workflow/i);
+  await expect(page.getByRole("status")).toContainText(/Loading labeling workflow/i);
 
-  await page.goto("/search?demoState=error");
+  await page.goto("/labeling?demoState=error");
 
   const retryButton = page.getByRole("button", { name: "Retry" });
   await expect(retryButton).toBeVisible();
 
   await retryButton.click();
 
-  await expect(page.getByRole("heading", { name: "Search", level: 1 })).toBeVisible();
-  await expect(page.getByText("Search is ready.")).toBeVisible();
-  await expectShellRoute(page, "search");
-  await expect(page).toHaveURL(/\/search(?:\?|$)/);
+  await expect(page.getByRole("heading", { name: "Labeling", level: 1 })).toBeVisible();
+  await expect(page.getByText("Labeling is ready.")).toBeVisible();
+  await expectShellRoute(page, "labeling");
+  await expect(page).toHaveURL(/\/labeling(?:\?|$)/);
 });
 
 test("JRN-P2-responsive-shell-layout @journey @smoke", async ({ page }) => {

--- a/docs/superpowers/specs/2026-04-29-issue-174-tokenized-search-bar-design.md
+++ b/docs/superpowers/specs/2026-04-29-issue-174-tokenized-search-bar-design.md
@@ -1,0 +1,167 @@
+# Issue #174 Tokenized Search Bar Design
+
+Date: 2026-04-29
+Issue: #174
+Epic: #160
+
+## Summary
+
+Implement the Phase 3 Search route text-query interaction model with phrase-level query chips. Users can submit text via Enter or a Search button, accumulate multiple phrase chips, clear phrases by dismissing chips, and trigger deterministic search requests against `/api/v1/search`.
+
+## Goals
+
+- deliver tokenized search input interactions for query submit and reset behavior in the `/search` route
+- represent active text query state explicitly in UI via chips
+- keep behavior deterministic across submit, clear, retry, and empty-input paths
+- stay compatible with current backend contract (`q` is a single string)
+
+## Non-Goals
+
+- URL query synchronization and deep-link restoration (tracked by #179)
+- date/person/location/facet filter controls (covered by #175-#178)
+- search-state architectural refactor shared with browse route (follow-up story)
+- backend parser/query semantics redesign
+
+## Architecture
+
+- Add a dedicated route component: `apps/ui/src/pages/SearchRoutePage.tsx`.
+- Update `apps/ui/src/app/AppRouter.tsx` so `/search` renders `SearchRoutePage`.
+- Keep `PrimaryRoutePage` for remaining placeholder routes (`/labeling`, `/suggestions`, `/operations`).
+- Keep implementation story-scoped in one page component; avoid introducing new shared abstractions in #174.
+
+## Interaction Model
+
+### Query submission
+
+- Input accepts free-form text.
+- Submission triggers from:
+  - keyboard Enter on the input
+  - clicking a `Search` button
+- On submit:
+  - `trim()` input text
+  - if empty or whitespace-only, do nothing (no chip mutation, no request)
+  - if non-empty, append one chip using the full phrase exactly as entered after trim
+  - clear input field
+  - execute a search request
+
+### Tokenized chips
+
+- One submitted phrase equals one chip.
+- Multiple submits accumulate multiple chips in insertion order.
+- Chip list order is stable and deterministic.
+
+### Reset/clear behavior
+
+- No standalone `Clear` button.
+- Clearing occurs only by dismissing a chip (`x` action).
+- On dismiss:
+  - remove selected chip
+  - re-run search using remaining chips
+
+## Request Mapping
+
+Backend currently expects one text query field `q: string | null`.
+
+For #174, map chips to backend query by joining phrase chips with single spaces in chip order:
+
+- `q = chips.join(" ")`
+
+Request body baseline for this story:
+
+- `q`: serialized chips
+- `sort`: `{ by: "shot_ts", dir: "desc" }`
+- `page`: `{ limit: 24, cursor: null }`
+
+When no chips remain after dismissing, `q` becomes empty string and request executes in default unfiltered text mode, preserving deterministic behavior.
+
+## State Model
+
+`SearchRoutePage` local state:
+
+- `draftQuery: string` — current input value
+- `queryChips: string[]` — submitted phrase chips in order
+- `results` — latest response item list
+- `totalCount: number`
+- `isLoading: boolean`
+- `error: string | null`
+- `reloadToken: number` — deterministic retry trigger
+
+Derived values:
+
+- `serializedQuery = queryChips.join(" ")`
+- request summary label for polite status updates
+
+## UI Feedback Behavior
+
+### Loading
+
+- Show route-local loading panel with `role="status"` and `aria-live="polite"`.
+- Shell and navigation remain mounted.
+
+### Error
+
+- Show route-local retry panel with retry button.
+- Retry replays request based on current chips.
+
+### Empty results
+
+- Show explicit no-match panel when request succeeds with zero items.
+
+### Success
+
+- Show result list/grid for returned photos.
+- Show concise result summary (`Showing X of Y photos`).
+- Show active query chips as visible filter context.
+
+### Empty/invalid input behavior
+
+- Whitespace-only submit is explicit no-op by design.
+- Existing chips/results remain unchanged.
+
+## Accessibility Baseline
+
+- Input and Search button are keyboard-operable.
+- Chips expose labeled dismiss buttons.
+- Loading/error status messaging uses semantic roles and polite live region where applicable.
+- Route heading remains level-1 and shell semantics remain unchanged.
+
+## Testing Strategy
+
+Add `apps/ui/src/pages/SearchRoutePage.test.tsx` covering:
+
+- Enter submit appends one phrase chip and issues request
+- Search button submit matches Enter behavior
+- whitespace-only submit is no-op (no request/chip mutation)
+- multiple submits preserve chip order and request serialization order
+- dismissing a chip updates chips and re-fetches with recomputed `q`
+- loading/error/empty/success states render deterministically
+
+Update existing shell routing tests (`apps/ui/src/app/AppShell.test.tsx`) to reflect `/search` rendering the real search page controls rather than generic placeholder text.
+
+## Follow-Up Story
+
+Create a follow-up implementation story to refactor shared browse/search concerns:
+
+- extract shared request lifecycle and feedback state handling hook(s)
+- extract shared photo-result card/list primitives where beneficial
+- centralize query/filter serialization helpers ahead of #175-#181
+
+This follow-up is intentionally out of scope for #174.
+
+## Risks And Mitigations
+
+- Risk: accidental scope overlap with #179 URL sync.
+  - Mitigation: avoid reading/writing search params for #174 state.
+- Risk: behavior drift between Enter and button submit.
+  - Mitigation: route both through one submit handler and test both paths.
+- Risk: ambiguity around empty query behavior.
+  - Mitigation: enforce no-op submit rule and test it directly.
+
+## Acceptance Criteria Mapping (Issue #174)
+
+- Text query submit and clear interactions deterministic:
+  - covered by single submit path, chip-dismiss clear path, deterministic state transitions.
+- Query state reflected consistently in UI:
+  - chips are source of truth and are always visible.
+- Invalid/empty query behavior explicit:
+  - whitespace-only submit defined and tested as no-op.


### PR DESCRIPTION
## Summary
- implement dedicated `/search` workflow page with phrase-level query chips and deterministic submit behavior (Enter + Search button)
- add chip-dismiss clear/re-query flow, whitespace-submit no-op behavior, and route-local loading/error/retry/empty/success states
- wire `/search` to `SearchRoutePage`, update shell tests for non-search placeholder routes, and add search-route UI styling
- create follow-up refactor tracking issue #220 and link it from #174

## Test Plan
- [x] `npm --prefix apps/ui run test -- src/pages/SearchRoutePage.test.tsx`
- [x] `npm --prefix apps/ui run test -- src/app/AppShell.test.tsx`
- [x] `npm --prefix apps/ui run test`
- [x] `npm --prefix apps/ui run build`

Closes #174