### PR TITLE
Implement person filter picker with fuzzy-name matching behavior (#176)

### DIFF
--- a/apps/ui/src/pages/SearchRoutePage.test.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.test.tsx
@@ -3,6 +3,9 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { SearchRoutePage } from "./SearchRoutePage";
 
+const SEARCH_ENDPOINT = "/api/v1/search";
+const PEOPLE_ENDPOINT = "/api/v1/people";
+
 interface SearchResponsePayload {
   hits: {
     total: number;
@@ -16,6 +19,13 @@ interface SearchResponsePayload {
     }>;
   };
   facets: Record<string, unknown>;
+}
+
+interface PersonPayload {
+  person_id: string;
+  display_name: string;
+  created_ts: string;
+  updated_ts: string;
 }
 
 function buildPayload(photoIds: string[], total = photoIds.length): SearchResponsePayload {
@@ -35,6 +45,27 @@ function buildPayload(photoIds: string[], total = photoIds.length): SearchRespon
   };
 }
 
+const PEOPLE_FIXTURE: PersonPayload[] = [
+  {
+    person_id: "person-inez",
+    display_name: "Inez Alvarez",
+    created_ts: "2026-04-10T12:00:00Z",
+    updated_ts: "2026-04-11T12:00:00Z"
+  },
+  {
+    person_id: "person-ana",
+    display_name: "Ana Morales",
+    created_ts: "2026-04-10T12:00:00Z",
+    updated_ts: "2026-04-11T12:00:00Z"
+  },
+  {
+    person_id: "person-andy",
+    display_name: "Andy Morgan",
+    created_ts: "2026-04-10T12:00:00Z",
+    updated_ts: "2026-04-11T12:00:00Z"
+  }
+];
+
 function renderSearchAt(path = "/search") {
   return render(
     <MemoryRouter
@@ -48,16 +79,37 @@ function renderSearchAt(path = "/search") {
   );
 }
 
+function searchCalls(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.filter(
+    ([url]) => typeof url === "string" && url === SEARCH_ENDPOINT
+  );
+}
+
+function lastSearchBody(fetchMock: ReturnType<typeof vi.fn>) {
+  const calls = searchCalls(fetchMock);
+  const lastCall = calls[calls.length - 1];
+  return JSON.parse(String((lastCall?.[1] as RequestInit).body));
+}
+
 describe("SearchRoutePage", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
     fetchMock.mockReset();
     vi.stubGlobal("fetch", fetchMock);
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: async () => buildPayload([], 0)
-    } as Response);
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === PEOPLE_ENDPOINT) {
+        return {
+          ok: true,
+          json: async () => PEOPLE_FIXTURE
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => buildPayload([], 0)
+      } as Response;
+    });
   });
 
   afterEach(() => {
@@ -73,8 +125,8 @@ describe("SearchRoutePage", () => {
 
     expect(await screen.findByRole("button", { name: "Remove query lake weekend" })).toBeInTheDocument();
 
-    const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
-    expect(lastCall?.[0]).toBe("/api/v1/search");
+    const lastCall = searchCalls(fetchMock)[searchCalls(fetchMock).length - 1];
+    expect(lastCall?.[0]).toBe(SEARCH_ENDPOINT);
     const body = JSON.parse(String((lastCall?.[1] as RequestInit).body));
     expect(body.q).toBe("lake weekend");
     expect(body.sort).toEqual({ by: "shot_ts", dir: "desc" });
@@ -95,8 +147,7 @@ describe("SearchRoutePage", () => {
     expect(screen.getByRole("button", { name: "Remove query first phrase" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Remove query second phrase" })).toBeInTheDocument();
 
-    const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
-    const body = JSON.parse(String((lastCall?.[1] as RequestInit).body));
+    const body = lastSearchBody(fetchMock);
     expect(body.q).toBe("first phrase second phrase");
   });
 
@@ -108,8 +159,7 @@ describe("SearchRoutePage", () => {
     await user.type(screen.getByLabelText("To date"), "2026-04-30");
     await user.click(screen.getByRole("button", { name: "Search" }));
 
-    const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
-    const body = JSON.parse(String((lastCall?.[1] as RequestInit).body));
+    const body = lastSearchBody(fetchMock);
     expect(body.q).toBe("");
     expect(body.filters).toEqual({
       date: {
@@ -126,13 +176,13 @@ describe("SearchRoutePage", () => {
     const input = await screen.findByRole("textbox", { name: "Search query" });
     await user.type(input, "coastline");
     await user.click(screen.getByRole("button", { name: "Search" }));
-    const callsAfterFirstSubmit = fetchMock.mock.calls.length;
+    const callsAfterFirstSubmit = searchCalls(fetchMock).length;
 
     await user.clear(input);
     await user.type(input, "   ");
     await user.keyboard("{Enter}");
 
-    expect(fetchMock.mock.calls.length).toBe(callsAfterFirstSubmit);
+    expect(searchCalls(fetchMock).length).toBe(callsAfterFirstSubmit);
     expect(screen.getByRole("button", { name: "Remove query coastline" })).toBeInTheDocument();
   });
 
@@ -148,8 +198,7 @@ describe("SearchRoutePage", () => {
 
     await user.click(screen.getByRole("button", { name: "Remove query alpha" }));
 
-    const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
-    const body = JSON.parse(String((lastCall?.[1] as RequestInit).body));
+    const body = lastSearchBody(fetchMock);
     expect(body.q).toBe("beta");
     expect(screen.queryByRole("button", { name: "Remove query alpha" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Remove query beta" })).toBeInTheDocument();
@@ -164,7 +213,7 @@ describe("SearchRoutePage", () => {
     await user.type(screen.getByRole("textbox", { name: "Search query" }), "lake");
     await user.click(screen.getByRole("button", { name: "Search" }));
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(searchCalls(fetchMock)).toHaveLength(0);
     expect(await screen.findByRole("alert")).toHaveTextContent(
       "From date must be on or before To date."
     );
@@ -181,8 +230,7 @@ describe("SearchRoutePage", () => {
 
     await user.click(screen.getByRole("button", { name: "Remove from date 2026-04-01" }));
 
-    const afterFromClear = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
-    const fromClearedBody = JSON.parse(String((afterFromClear?.[1] as RequestInit).body));
+    const fromClearedBody = lastSearchBody(fetchMock);
     expect(fromClearedBody.filters).toEqual({
       date: {
         to: "2026-04-30"
@@ -190,19 +238,24 @@ describe("SearchRoutePage", () => {
     });
 
     await user.click(screen.getByRole("button", { name: "Remove to date 2026-04-30" }));
-    const afterToClear = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
-    const toClearedBody = JSON.parse(String((afterToClear?.[1] as RequestInit).body));
+    const toClearedBody = lastSearchBody(fetchMock);
     expect(toClearedBody.filters).toBeUndefined();
   });
 
   it("renders loading status while the search request is pending", async () => {
     let resolveResponse!: (value: Response) => void;
-    fetchMock.mockImplementationOnce(
-      () =>
-        new Promise<Response>((resolve) => {
-          resolveResponse = resolve;
-        })
-    );
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === PEOPLE_ENDPOINT) {
+        return {
+          ok: true,
+          json: async () => PEOPLE_FIXTURE
+        } as Response;
+      }
+
+      return await new Promise<Response>((resolve) => {
+        resolveResponse = resolve;
+      });
+    });
 
     const user = userEvent.setup();
     renderSearchAt();
@@ -224,12 +277,25 @@ describe("SearchRoutePage", () => {
   it("shows retry UI on failure and retries with active chips", async () => {
     const user = userEvent.setup();
 
-    fetchMock
-      .mockResolvedValueOnce({ ok: false, status: 503 } as Response)
-      .mockResolvedValueOnce({
+    let searchRequestCount = 0;
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === PEOPLE_ENDPOINT) {
+        return {
+          ok: true,
+          json: async () => PEOPLE_FIXTURE
+        } as Response;
+      }
+
+      searchRequestCount += 1;
+      if (searchRequestCount === 1) {
+        return { ok: false, status: 503 } as Response;
+      }
+
+      return {
         ok: true,
         json: async () => buildPayload(["photo-1"], 1)
-      } as Response);
+      } as Response;
+    });
 
     renderSearchAt();
     const input = await screen.findByRole("textbox", { name: "Search query" });
@@ -245,9 +311,75 @@ describe("SearchRoutePage", () => {
 
     await user.click(screen.getByRole("button", { name: "Retry" }));
 
-    const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1];
-    const body = JSON.parse(String((lastCall?.[1] as RequestInit).body));
+    const body = lastSearchBody(fetchMock);
     expect(body.q).toBe("storm coast");
     expect(await screen.findByText("photo-1")).toBeInTheDocument();
+  });
+
+  it("adds a fuzzy-matched person filter and submits it as filters.person_names", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    const personInput = await screen.findByLabelText("Person filter");
+    await user.type(personInput, "inz");
+    await user.click(screen.getByRole("button", { name: "Add person filter" }));
+
+    expect(screen.getByRole("button", { name: "Remove person Inez Alvarez" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    const body = lastSearchBody(fetchMock);
+    expect(body.filters).toEqual({
+      person_names: ["Inez Alvarez"]
+    });
+  });
+
+  it("surfaces ambiguous fuzzy matches and allows selecting a specific person suggestion", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    const personInput = await screen.findByLabelText("Person filter");
+    await user.type(personInput, "an");
+    await user.click(screen.getByRole("button", { name: "Add person filter" }));
+
+    expect(
+      await screen.findByText('Multiple people match "an". Select one from suggestions.')
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Ana Morales" }));
+    expect(screen.getByRole("button", { name: "Remove person Ana Morales" })).toBeInTheDocument();
+  });
+
+  it("shows explicit no-match feedback without blocking other search submission", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    const personInput = await screen.findByLabelText("Person filter");
+    await user.type(personInput, "zzzz");
+    await user.click(screen.getByRole("button", { name: "Add person filter" }));
+
+    expect(
+      await screen.findByText('No people match "zzzz". Search still works without this filter.')
+    ).toBeInTheDocument();
+
+    await user.type(screen.getByRole("textbox", { name: "Search query" }), "coast");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    const body = lastSearchBody(fetchMock);
+    expect(body.q).toBe("coast");
+    expect(body.filters).toBeUndefined();
+  });
+
+  it("removes selected person chips and re-fetches without person_names filters", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    const personInput = await screen.findByLabelText("Person filter");
+    await user.type(personInput, "inez");
+    await user.click(screen.getByRole("button", { name: "Add person filter" }));
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await user.click(screen.getByRole("button", { name: "Remove person Inez Alvarez" }));
+    const body = lastSearchBody(fetchMock);
+    expect(body.filters).toBeUndefined();
   });
 });

--- a/apps/ui/src/pages/SearchRoutePage.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 
 type SearchPhoto = {
   photo_id: string;
@@ -14,6 +14,11 @@ type SearchResponsePayload = {
     cursor: string | null;
     items: SearchPhoto[];
   };
+};
+
+type PersonRecord = {
+  person_id: string;
+  display_name: string;
 };
 
 const DEFAULT_SORT = { by: "shot_ts", dir: "desc" } as const;
@@ -41,12 +46,60 @@ function validateDateRange(from: string, to: string): string | null {
   return null;
 }
 
+function normalizeForFuzzyMatch(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function isFuzzyNameMatch(query: string, candidate: string): boolean {
+  const normalizedQuery = normalizeForFuzzyMatch(query);
+  const normalizedCandidate = normalizeForFuzzyMatch(candidate);
+
+  if (!normalizedQuery || !normalizedCandidate) {
+    return false;
+  }
+
+  if (normalizedCandidate.includes(normalizedQuery)) {
+    return true;
+  }
+
+  let queryIndex = 0;
+  for (const character of normalizedCandidate) {
+    if (character === normalizedQuery[queryIndex]) {
+      queryIndex += 1;
+      if (queryIndex === normalizedQuery.length) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+function buildSearchFilters(
+  fromDate: string,
+  toDate: string,
+  selectedPersonNames: string[]
+): { date?: { from?: string; to?: string }; person_names?: string[] } | null {
+  const dateFilter = buildDateFilter(fromDate, toDate);
+  const personNameFilter = selectedPersonNames.length > 0 ? selectedPersonNames : null;
+
+  if (!dateFilter && !personNameFilter) {
+    return null;
+  }
+
+  return {
+    ...(dateFilter ? { date: dateFilter } : {}),
+    ...(personNameFilter ? { person_names: personNameFilter } : {})
+  };
+}
+
 async function fetchSearchResults(
   query: string,
   fromDate: string,
-  toDate: string
+  toDate: string,
+  selectedPersonNames: string[]
 ): Promise<SearchResponsePayload> {
-  const dateFilter = buildDateFilter(fromDate, toDate);
+  const searchFilters = buildSearchFilters(fromDate, toDate, selectedPersonNames);
   const response = await fetch("/api/v1/search", {
     method: "POST",
     headers: {
@@ -54,7 +107,7 @@ async function fetchSearchResults(
     },
     body: JSON.stringify({
       q: query,
-      ...(dateFilter ? { filters: { date: dateFilter } } : {}),
+      ...(searchFilters ? { filters: searchFilters } : {}),
       sort: DEFAULT_SORT,
       page: DEFAULT_PAGE
     })
@@ -72,6 +125,10 @@ export function SearchRoutePage() {
   const [queryChips, setQueryChips] = useState<string[]>([]);
   const [fromDate, setFromDate] = useState("");
   const [toDate, setToDate] = useState("");
+  const [personDraft, setPersonDraft] = useState("");
+  const [selectedPersonNames, setSelectedPersonNames] = useState<string[]>([]);
+  const [peopleDirectory, setPeopleDirectory] = useState<PersonRecord[]>([]);
+  const [personMessage, setPersonMessage] = useState<string | null>(null);
   const [results, setResults] = useState<SearchPhoto[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
@@ -81,8 +138,53 @@ export function SearchRoutePage() {
   const serializedQuery = useMemo(() => queryChips.join(" "), [queryChips]);
   const dateRangeError = useMemo(() => validateDateRange(fromDate, toDate), [fromDate, toDate]);
   const hasActiveDateFilter = Boolean(fromDate || toDate);
+  const hasActivePersonFilter = selectedPersonNames.length > 0;
+  const matchingPeople = useMemo(() => {
+    const trimmed = personDraft.trim();
+    if (!trimmed) {
+      return [] as PersonRecord[];
+    }
 
-  async function runSearch(chips: string[], activeFromDate: string, activeToDate: string) {
+    return peopleDirectory.filter(
+      (person) =>
+        !selectedPersonNames.includes(person.display_name) &&
+        isFuzzyNameMatch(trimmed, person.display_name)
+    );
+  }, [peopleDirectory, personDraft, selectedPersonNames]);
+
+  useEffect(() => {
+    let isCanceled = false;
+
+    async function loadPeopleDirectory() {
+      try {
+        const response = await fetch("/api/v1/people");
+        if (!response.ok) {
+          throw new Error();
+        }
+        const payload = (await response.json()) as PersonRecord[];
+        if (!isCanceled) {
+          setPeopleDirectory(payload);
+        }
+      } catch {
+        if (!isCanceled) {
+          setPersonMessage("People lookup is unavailable. Search can continue without person filters.");
+        }
+      }
+    }
+
+    void loadPeopleDirectory();
+
+    return () => {
+      isCanceled = true;
+    };
+  }, []);
+
+  async function runSearch(
+    chips: string[],
+    activeFromDate: string,
+    activeToDate: string,
+    activePersonNames: string[]
+  ) {
     if (validateDateRange(activeFromDate, activeToDate)) {
       return;
     }
@@ -92,7 +194,12 @@ export function SearchRoutePage() {
     setHasRequested(true);
 
     try {
-      const payload = await fetchSearchResults(chips.join(" "), activeFromDate, activeToDate);
+      const payload = await fetchSearchResults(
+        chips.join(" "),
+        activeFromDate,
+        activeToDate,
+        activePersonNames
+      );
       setResults(payload.hits.items);
       setTotalCount(payload.hits.total);
     } catch (caughtError: unknown) {
@@ -116,7 +223,7 @@ export function SearchRoutePage() {
     }
 
     const trimmed = draftQuery.trim();
-    if (!trimmed && !hasActiveDateFilter) {
+    if (!trimmed && !hasActiveDateFilter && !hasActivePersonFilter) {
       return;
     }
 
@@ -126,27 +233,65 @@ export function SearchRoutePage() {
       setDraftQuery("");
     }
 
-    void runSearch(nextChips, fromDate, toDate);
+    void runSearch(nextChips, fromDate, toDate, selectedPersonNames);
   }
 
   function handleDismissChip(indexToRemove: number) {
     const nextChips = queryChips.filter((_, index) => index !== indexToRemove);
     setQueryChips(nextChips);
-    void runSearch(nextChips, fromDate, toDate);
+    void runSearch(nextChips, fromDate, toDate, selectedPersonNames);
   }
 
   function handleClearFromDate() {
     setFromDate("");
-    void runSearch(queryChips, "", toDate);
+    void runSearch(queryChips, "", toDate, selectedPersonNames);
   }
 
   function handleClearToDate() {
     setToDate("");
-    void runSearch(queryChips, fromDate, "");
+    void runSearch(queryChips, fromDate, "", selectedPersonNames);
+  }
+
+  function handleAddPersonByName(displayName: string) {
+    if (selectedPersonNames.includes(displayName)) {
+      setPersonDraft("");
+      setPersonMessage(null);
+      return;
+    }
+
+    setSelectedPersonNames((current) => [...current, displayName]);
+    setPersonDraft("");
+    setPersonMessage(null);
+  }
+
+  function handleAddPersonFilter() {
+    const trimmed = personDraft.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    if (matchingPeople.length === 0) {
+      setPersonMessage(`No people match "${trimmed}". Search still works without this filter.`);
+      return;
+    }
+
+    if (matchingPeople.length > 1) {
+      setPersonMessage(`Multiple people match "${trimmed}". Select one from suggestions.`);
+      return;
+    }
+
+    handleAddPersonByName(matchingPeople[0].display_name);
+  }
+
+  function handleRemovePersonFilter(displayName: string) {
+    const nextNames = selectedPersonNames.filter((name) => name !== displayName);
+    setSelectedPersonNames(nextNames);
+    setPersonMessage(null);
+    void runSearch(queryChips, fromDate, toDate, nextNames);
   }
 
   function handleRetry() {
-    void runSearch(queryChips, fromDate, toDate);
+    void runSearch(queryChips, fromDate, toDate, selectedPersonNames);
   }
 
   const summaryLabel = useMemo(() => {
@@ -202,15 +347,63 @@ export function SearchRoutePage() {
             aria-describedby="search-query-summary search-date-validation"
           />
         </div>
+        <div className="search-person-row">
+          <label htmlFor="search-person-input">Person filter</label>
+          <div className="search-person-input-row">
+            <input
+              id="search-person-input"
+              type="text"
+              value={personDraft}
+              onChange={(event) => setPersonDraft(event.target.value)}
+              aria-describedby="search-query-summary search-person-validation"
+            />
+            <button type="button" onClick={handleAddPersonFilter}>
+              Add person filter
+            </button>
+          </div>
+        </div>
         {dateRangeError ? (
           <p id="search-date-validation" className="search-validation-message" role="alert">
             {dateRangeError}
           </p>
         ) : null}
+        {personMessage ? (
+          <p id="search-person-validation" className="search-validation-message" role="status">
+            {personMessage}
+          </p>
+        ) : null}
+        {personMessage?.startsWith("Multiple people match") && matchingPeople.length > 0 ? (
+          <ul className="search-person-suggestion-list" aria-label="Person suggestions">
+            {matchingPeople.map((person) => (
+              <li key={person.person_id}>
+                <button
+                  type="button"
+                  className="search-person-suggestion"
+                  onClick={() => handleAddPersonByName(person.display_name)}
+                >
+                  {person.display_name}
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : null}
       </form>
 
-      {queryChips.length > 0 || hasActiveDateFilter ? (
+      {queryChips.length > 0 || hasActiveDateFilter || hasActivePersonFilter ? (
         <ul className="search-chip-list" aria-label="Active search filters">
+          {selectedPersonNames.map((displayName) => (
+            <li key={displayName}>
+              <button
+                type="button"
+                className="search-chip"
+                aria-label={`Remove person ${displayName}`}
+                onClick={() => handleRemovePersonFilter(displayName)}
+              >
+                person: {displayName}
+                <span aria-hidden="true"> ×</span>
+              </button>
+            </li>
+          ))}
           {fromDate ? (
             <li>
               <button
@@ -295,6 +488,8 @@ export function SearchRoutePage() {
       <p className="search-serialized-query" aria-live="off">
         Active query: {serializedQuery || "(none)"} | Date range:{" "}
         {fromDate || toDate ? `${fromDate || "(open)"} to ${toDate || "(open)"}` : "(none)"}
+        {" | People: "}
+        {selectedPersonNames.length > 0 ? selectedPersonNames.join(", ") : "(none)"}
       </p>
     </section>
   );

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -675,6 +675,58 @@ body {
   font: inherit;
 }
 
+.search-person-row {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.search-person-row label {
+  color: #334155;
+  font-size: 0.9rem;
+}
+
+.search-person-input-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.search-person-input-row input {
+  flex: 1 1 16rem;
+  min-width: 12rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  padding: 0.45rem 0.55rem;
+  font: inherit;
+}
+
+.search-person-input-row button {
+  border: 1px solid #93c5fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.45rem 0.7rem;
+  font: inherit;
+}
+
+.search-person-suggestion-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.search-person-suggestion {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #1e293b;
+  border-radius: 0.45rem;
+  padding: 0.3rem 0.6rem;
+  font: inherit;
+}
+
 .search-validation-message {
   margin: 0;
   color: #b91c1c;
@@ -821,6 +873,14 @@ body {
   }
 
   .search-query-row button {
+    width: fit-content;
+  }
+
+  .search-person-input-row {
+    flex-direction: column;
+  }
+
+  .search-person-input-row button {
     width: fit-content;
   }
 


### PR DESCRIPTION
## Summary
- add a person filter picker to Search with fuzzy-name matching against `/api/v1/people`
- support explicit ambiguous-input handling via selectable suggestions
- support explicit no-match handling without blocking search submission
- include selected person filters in active chips and make them removable
- send selected person names to backend as `filters.person_names` and preserve existing date/query behavior

## Verification
- `npm --prefix apps/ui run test -- src/pages/SearchRoutePage.test.tsx`
- `npm --prefix apps/ui run test`
- `npm --prefix apps/ui run build`
- `make pre-push`

Closes #176