### PR TITLE
feat(ui): add map-based location radius search filter (#177)

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "photo-org-ui",
       "version": "0.1.0",
       "dependencies": {
+        "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.1"
@@ -17,6 +18,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/leaflet": "^1.9.21",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.4.1",
@@ -1357,6 +1359,21 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -2331,6 +2348,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
     },
     "node_modules/local-pkg": {
       "version": "0.5.1",

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -17,6 +17,7 @@
     "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
+    "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.30.1"
@@ -26,6 +27,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/leaflet": "^1.9.21",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.4.1",

--- a/apps/ui/src/pages/SearchRoutePage.test.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.test.tsx
@@ -3,6 +3,10 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { SearchRoutePage } from "./SearchRoutePage";
 
+vi.mock("./search/LocationRadiusPicker", () => ({
+  LocationRadiusPicker: () => <div data-testid="location-radius-picker" />
+}));
+
 const SEARCH_ENDPOINT = "/api/v1/search";
 const PEOPLE_ENDPOINT = "/api/v1/people";
 
@@ -381,5 +385,97 @@ describe("SearchRoutePage", () => {
     await user.click(screen.getByRole("button", { name: "Remove person Inez Alvarez" }));
     const body = lastSearchBody(fetchMock);
     expect(body.filters).toBeUndefined();
+  });
+
+  it("submits valid location filter as filters.location_radius", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    await user.type(await screen.findByLabelText("Latitude"), "37.7749");
+    await user.type(screen.getByLabelText("Longitude"), "-122.4194");
+    await user.type(screen.getByLabelText("Radius (km)"), "12.5");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    const body = lastSearchBody(fetchMock);
+    expect(body.filters).toEqual({
+      location_radius: {
+        latitude: 37.7749,
+        longitude: -122.4194,
+        radius_km: 12.5
+      }
+    });
+  });
+
+  it("blocks submit when location values are invalid", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    await user.type(await screen.findByLabelText("Latitude"), "91");
+    await user.type(screen.getByLabelText("Longitude"), "-122.4194");
+    await user.type(screen.getByLabelText("Radius (km)"), "12");
+    await user.type(screen.getByRole("textbox", { name: "Search query" }), "coast");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(searchCalls(fetchMock)).toHaveLength(0);
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Latitude must be between -90 and 90."
+    );
+  });
+
+  it("removes location chip and re-fetches without location_radius filters", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    await user.type(await screen.findByLabelText("Latitude"), "37.7749");
+    await user.type(screen.getByLabelText("Longitude"), "-122.4194");
+    await user.type(screen.getByLabelText("Radius (km)"), "12.5");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await user.click(
+      screen.getByRole("button", { name: "Remove location: 37.7749, -122.4194 (12.5 km)" })
+    );
+
+    const body = lastSearchBody(fetchMock);
+    expect(body.filters).toBeUndefined();
+  });
+
+  it("does not auto-search when location fields change", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    await user.type(await screen.findByLabelText("Latitude"), "37.7749");
+    await user.type(screen.getByLabelText("Longitude"), "-122.4194");
+    await user.type(screen.getByLabelText("Radius (km)"), "12.5");
+
+    expect(searchCalls(fetchMock)).toHaveLength(0);
+  });
+
+  it("combines location, person, and date filters in one deterministic request payload", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    await user.type(await screen.findByLabelText("Latitude"), "37.7749");
+    await user.type(screen.getByLabelText("Longitude"), "-122.4194");
+    await user.type(screen.getByLabelText("Radius (km)"), "12.5");
+    await user.type(screen.getByLabelText("From date"), "2026-04-01");
+
+    const personInput = screen.getByLabelText("Person filter");
+    await user.type(personInput, "inez");
+    await user.click(screen.getByRole("button", { name: "Add person filter" }));
+
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    const body = lastSearchBody(fetchMock);
+    expect(body.filters).toEqual({
+      date: {
+        from: "2026-04-01"
+      },
+      person_names: ["Inez Alvarez"],
+      location_radius: {
+        latitude: 37.7749,
+        longitude: -122.4194,
+        radius_km: 12.5
+      }
+    });
   });
 });

--- a/apps/ui/src/pages/SearchRoutePage.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.tsx
@@ -1,4 +1,12 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
+import { LocationRadiusPicker } from "./search/LocationRadiusPicker";
+import {
+  buildLocationRadiusFilter,
+  formatLocationChipLabel,
+  parseLocationDraft,
+  validateLocationDraft
+} from "./search/locationFilter";
+import type { LocationRadiusValue } from "./search/types";
 
 type SearchPhoto = {
   photo_id: string;
@@ -78,18 +86,25 @@ function isFuzzyNameMatch(query: string, candidate: string): boolean {
 function buildSearchFilters(
   fromDate: string,
   toDate: string,
-  selectedPersonNames: string[]
-): { date?: { from?: string; to?: string }; person_names?: string[] } | null {
+  selectedPersonNames: string[],
+  locationRadius: { latitude: number; longitude: number; radius_km: number } | null
+): {
+  date?: { from?: string; to?: string };
+  person_names?: string[];
+  location_radius?: { latitude: number; longitude: number; radius_km: number };
+} | null {
   const dateFilter = buildDateFilter(fromDate, toDate);
   const personNameFilter = selectedPersonNames.length > 0 ? selectedPersonNames : null;
+  const locationFilter = locationRadius;
 
-  if (!dateFilter && !personNameFilter) {
+  if (!dateFilter && !personNameFilter && !locationFilter) {
     return null;
   }
 
   return {
     ...(dateFilter ? { date: dateFilter } : {}),
-    ...(personNameFilter ? { person_names: personNameFilter } : {})
+    ...(personNameFilter ? { person_names: personNameFilter } : {}),
+    ...(locationFilter ? { location_radius: locationFilter } : {})
   };
 }
 
@@ -97,9 +112,10 @@ async function fetchSearchResults(
   query: string,
   fromDate: string,
   toDate: string,
-  selectedPersonNames: string[]
+  selectedPersonNames: string[],
+  locationRadius: { latitude: number; longitude: number; radius_km: number } | null
 ): Promise<SearchResponsePayload> {
-  const searchFilters = buildSearchFilters(fromDate, toDate, selectedPersonNames);
+  const searchFilters = buildSearchFilters(fromDate, toDate, selectedPersonNames, locationRadius);
   const response = await fetch("/api/v1/search", {
     method: "POST",
     headers: {
@@ -127,8 +143,12 @@ export function SearchRoutePage() {
   const [toDate, setToDate] = useState("");
   const [personDraft, setPersonDraft] = useState("");
   const [selectedPersonNames, setSelectedPersonNames] = useState<string[]>([]);
+  const [latitudeDraft, setLatitudeDraft] = useState("");
+  const [longitudeDraft, setLongitudeDraft] = useState("");
+  const [radiusDraft, setRadiusDraft] = useState("");
   const [peopleDirectory, setPeopleDirectory] = useState<PersonRecord[]>([]);
   const [personMessage, setPersonMessage] = useState<string | null>(null);
+  const [mapMessage, setMapMessage] = useState<string | null>(null);
   const [results, setResults] = useState<SearchPhoto[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
@@ -137,8 +157,18 @@ export function SearchRoutePage() {
 
   const serializedQuery = useMemo(() => queryChips.join(" "), [queryChips]);
   const dateRangeError = useMemo(() => validateDateRange(fromDate, toDate), [fromDate, toDate]);
+  const parsedLocation = useMemo(
+    () => parseLocationDraft(latitudeDraft, longitudeDraft, radiusDraft),
+    [latitudeDraft, longitudeDraft, radiusDraft]
+  );
+  const locationError = useMemo(() => validateLocationDraft(parsedLocation), [parsedLocation]);
+  const locationRadiusFilter = useMemo(
+    () => buildLocationRadiusFilter(parsedLocation),
+    [parsedLocation]
+  );
   const hasActiveDateFilter = Boolean(fromDate || toDate);
   const hasActivePersonFilter = selectedPersonNames.length > 0;
+  const hasActiveLocationFilter = Boolean(locationRadiusFilter);
   const matchingPeople = useMemo(() => {
     const trimmed = personDraft.trim();
     if (!trimmed) {
@@ -183,7 +213,8 @@ export function SearchRoutePage() {
     chips: string[],
     activeFromDate: string,
     activeToDate: string,
-    activePersonNames: string[]
+    activePersonNames: string[],
+    activeLocationRadius: { latitude: number; longitude: number; radius_km: number } | null
   ) {
     if (validateDateRange(activeFromDate, activeToDate)) {
       return;
@@ -198,7 +229,8 @@ export function SearchRoutePage() {
         chips.join(" "),
         activeFromDate,
         activeToDate,
-        activePersonNames
+        activePersonNames,
+        activeLocationRadius
       );
       setResults(payload.hits.items);
       setTotalCount(payload.hits.total);
@@ -218,12 +250,12 @@ export function SearchRoutePage() {
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
-    if (dateRangeError) {
+    if (dateRangeError || locationError) {
       return;
     }
 
     const trimmed = draftQuery.trim();
-    if (!trimmed && !hasActiveDateFilter && !hasActivePersonFilter) {
+    if (!trimmed && !hasActiveDateFilter && !hasActivePersonFilter && !hasActiveLocationFilter) {
       return;
     }
 
@@ -233,23 +265,23 @@ export function SearchRoutePage() {
       setDraftQuery("");
     }
 
-    void runSearch(nextChips, fromDate, toDate, selectedPersonNames);
+    void runSearch(nextChips, fromDate, toDate, selectedPersonNames, locationRadiusFilter);
   }
 
   function handleDismissChip(indexToRemove: number) {
     const nextChips = queryChips.filter((_, index) => index !== indexToRemove);
     setQueryChips(nextChips);
-    void runSearch(nextChips, fromDate, toDate, selectedPersonNames);
+    void runSearch(nextChips, fromDate, toDate, selectedPersonNames, locationRadiusFilter);
   }
 
   function handleClearFromDate() {
     setFromDate("");
-    void runSearch(queryChips, "", toDate, selectedPersonNames);
+    void runSearch(queryChips, "", toDate, selectedPersonNames, locationRadiusFilter);
   }
 
   function handleClearToDate() {
     setToDate("");
-    void runSearch(queryChips, fromDate, "", selectedPersonNames);
+    void runSearch(queryChips, fromDate, "", selectedPersonNames, locationRadiusFilter);
   }
 
   function handleAddPersonByName(displayName: string) {
@@ -287,11 +319,25 @@ export function SearchRoutePage() {
     const nextNames = selectedPersonNames.filter((name) => name !== displayName);
     setSelectedPersonNames(nextNames);
     setPersonMessage(null);
-    void runSearch(queryChips, fromDate, toDate, nextNames);
+    void runSearch(queryChips, fromDate, toDate, nextNames, locationRadiusFilter);
+  }
+
+  function handleMapLocationChange(location: LocationRadiusValue) {
+    setLatitudeDraft(String(location.latitude));
+    setLongitudeDraft(String(location.longitude));
+    setRadiusDraft(String(Number(location.radiusKm.toFixed(3))));
+    setMapMessage(null);
+  }
+
+  function handleClearLocationFilter() {
+    setLatitudeDraft("");
+    setLongitudeDraft("");
+    setRadiusDraft("");
+    void runSearch(queryChips, fromDate, toDate, selectedPersonNames, null);
   }
 
   function handleRetry() {
-    void runSearch(queryChips, fromDate, toDate, selectedPersonNames);
+    void runSearch(queryChips, fromDate, toDate, selectedPersonNames, locationRadiusFilter);
   }
 
   const summaryLabel = useMemo(() => {
@@ -362,14 +408,69 @@ export function SearchRoutePage() {
             </button>
           </div>
         </div>
+        <div className="search-location-panel">
+          <p className="search-filter-section-label">Location radius</p>
+          <div className="search-location-row">
+            <label htmlFor="search-location-latitude">Latitude</label>
+            <input
+              id="search-location-latitude"
+              type="text"
+              inputMode="decimal"
+              value={latitudeDraft}
+              onChange={(event) => setLatitudeDraft(event.target.value)}
+              aria-describedby="search-query-summary search-location-validation"
+            />
+            <label htmlFor="search-location-longitude">Longitude</label>
+            <input
+              id="search-location-longitude"
+              type="text"
+              inputMode="decimal"
+              value={longitudeDraft}
+              onChange={(event) => setLongitudeDraft(event.target.value)}
+              aria-describedby="search-query-summary search-location-validation"
+            />
+            <label htmlFor="search-location-radius">Radius (km)</label>
+            <input
+              id="search-location-radius"
+              type="text"
+              inputMode="decimal"
+              value={radiusDraft}
+              onChange={(event) => setRadiusDraft(event.target.value)}
+              aria-describedby="search-query-summary search-location-validation"
+            />
+          </div>
+          <LocationRadiusPicker
+            value={
+              locationRadiusFilter
+                ? {
+                    latitude: locationRadiusFilter.latitude,
+                    longitude: locationRadiusFilter.longitude,
+                    radiusKm: locationRadiusFilter.radius_km
+                  }
+                : null
+            }
+            onChange={handleMapLocationChange}
+            onMapError={setMapMessage}
+          />
+        </div>
         {dateRangeError ? (
           <p id="search-date-validation" className="search-validation-message" role="alert">
             {dateRangeError}
           </p>
         ) : null}
+        {locationError ? (
+          <p id="search-location-validation" className="search-validation-message" role="alert">
+            {locationError}
+          </p>
+        ) : null}
         {personMessage ? (
           <p id="search-person-validation" className="search-validation-message" role="status">
             {personMessage}
+          </p>
+        ) : null}
+        {mapMessage ? (
+          <p className="search-map-message" role="status">
+            {mapMessage}
           </p>
         ) : null}
         {personMessage?.startsWith("Multiple people match") && matchingPeople.length > 0 ? (
@@ -389,8 +490,29 @@ export function SearchRoutePage() {
         ) : null}
       </form>
 
-      {queryChips.length > 0 || hasActiveDateFilter || hasActivePersonFilter ? (
+      {queryChips.length > 0 || hasActiveDateFilter || hasActivePersonFilter || hasActiveLocationFilter ? (
         <ul className="search-chip-list" aria-label="Active search filters">
+          {locationRadiusFilter ? (
+            <li>
+              <button
+                type="button"
+                className="search-chip"
+                aria-label={`Remove ${formatLocationChipLabel({
+                  latitude: locationRadiusFilter.latitude,
+                  longitude: locationRadiusFilter.longitude,
+                  radiusKm: locationRadiusFilter.radius_km
+                })}`}
+                onClick={handleClearLocationFilter}
+              >
+                {formatLocationChipLabel({
+                  latitude: locationRadiusFilter.latitude,
+                  longitude: locationRadiusFilter.longitude,
+                  radiusKm: locationRadiusFilter.radius_km
+                })}
+                <span aria-hidden="true"> ×</span>
+              </button>
+            </li>
+          ) : null}
           {selectedPersonNames.map((displayName) => (
             <li key={displayName}>
               <button
@@ -490,6 +612,10 @@ export function SearchRoutePage() {
         {fromDate || toDate ? `${fromDate || "(open)"} to ${toDate || "(open)"}` : "(none)"}
         {" | People: "}
         {selectedPersonNames.length > 0 ? selectedPersonNames.join(", ") : "(none)"}
+        {" | Location: "}
+        {locationRadiusFilter
+          ? `${locationRadiusFilter.latitude.toFixed(4)}, ${locationRadiusFilter.longitude.toFixed(4)} (${locationRadiusFilter.radius_km.toFixed(1)} km)`
+          : "(none)"}
       </p>
     </section>
   );

--- a/apps/ui/src/pages/search/LocationRadiusPicker.tsx
+++ b/apps/ui/src/pages/search/LocationRadiusPicker.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef } from "react";
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import type { LocationRadiusValue } from "./types";
+
+const DEFAULT_RADIUS_KM = 50;
+const EARTH_RADIUS_KM = 6371.0088;
+
+export type LocationRadiusPickerProps = {
+  value: LocationRadiusValue | null;
+  onChange: (value: LocationRadiusValue) => void;
+  onMapError?: (message: string) => void;
+};
+
+function toHandlePosition(center: LocationRadiusValue): L.LatLng {
+  const latitudeRadians = (center.latitude * Math.PI) / 180;
+  const angularDistance = center.radiusKm / EARTH_RADIUS_KM;
+  const cosLatitude = Math.cos(latitudeRadians);
+  const longitudeOffsetRadians =
+    Math.abs(cosLatitude) < 1e-8 ? 0 : angularDistance / cosLatitude;
+  const longitudeOffsetDegrees = (longitudeOffsetRadians * 180) / Math.PI;
+
+  return L.latLng(center.latitude, center.longitude + longitudeOffsetDegrees);
+}
+
+function toCircleStyle() {
+  return {
+    color: "#2563eb",
+    fillColor: "#60a5fa",
+    fillOpacity: 0.15,
+    weight: 2
+  };
+}
+
+export function LocationRadiusPicker({ value, onChange, onMapError }: LocationRadiusPickerProps) {
+  const mapElementRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<L.Map | null>(null);
+  const centerMarkerRef = useRef<L.CircleMarker | null>(null);
+  const radiusCircleRef = useRef<L.Circle | null>(null);
+  const radiusHandleRef = useRef<L.Marker | null>(null);
+
+  useEffect(() => {
+    if (!mapElementRef.current || mapRef.current) {
+      return;
+    }
+
+    const map = L.map(mapElementRef.current).setView([20, 0], 2);
+    mapRef.current = map;
+
+    const tiles = L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      maxZoom: 19,
+      attribution: "&copy; OpenStreetMap contributors"
+    });
+    tiles.on("tileerror", () => {
+      onMapError?.("Map tiles failed to load. You can still use manual coordinate inputs.");
+    });
+    tiles.addTo(map);
+
+    map.on("click", (event: L.LeafletMouseEvent) => {
+      onChange({
+        latitude: event.latlng.lat,
+        longitude: event.latlng.lng,
+        radiusKm: value?.radiusKm ?? DEFAULT_RADIUS_KM
+      });
+    });
+
+    return () => {
+      map.remove();
+      mapRef.current = null;
+      centerMarkerRef.current = null;
+      radiusCircleRef.current = null;
+      radiusHandleRef.current = null;
+    };
+  }, [onChange, onMapError, value?.radiusKm]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) {
+      return;
+    }
+
+    centerMarkerRef.current?.remove();
+    radiusCircleRef.current?.remove();
+    radiusHandleRef.current?.remove();
+    centerMarkerRef.current = null;
+    radiusCircleRef.current = null;
+    radiusHandleRef.current = null;
+
+    if (!value) {
+      return;
+    }
+
+    const center = L.latLng(value.latitude, value.longitude);
+    const handle = toHandlePosition(value);
+
+    const centerMarker = L.circleMarker(center, {
+      radius: 5,
+      color: "#1d4ed8",
+      fillColor: "#2563eb",
+      fillOpacity: 1,
+      weight: 1
+    }).addTo(map);
+    centerMarkerRef.current = centerMarker;
+
+    const radiusCircle = L.circle(center, {
+      radius: value.radiusKm * 1000,
+      ...toCircleStyle()
+    }).addTo(map);
+    radiusCircleRef.current = radiusCircle;
+
+    const radiusHandle = L.marker(handle, {
+      draggable: true,
+      icon: L.divIcon({
+        className: "search-location-radius-handle",
+        iconSize: [14, 14]
+      })
+    }).addTo(map);
+    radiusHandleRef.current = radiusHandle;
+
+    radiusHandle.on("drag", (event: L.LeafletEvent) => {
+      const marker = event.target as L.Marker;
+      const markerPosition = marker.getLatLng();
+      const nextRadiusKm = Math.max(map.distance(center, markerPosition) / 1000, 0.1);
+      radiusCircle.setRadius(nextRadiusKm * 1000);
+      onChange({
+        latitude: value.latitude,
+        longitude: value.longitude,
+        radiusKm: nextRadiusKm
+      });
+    });
+
+    map.setView(center, Math.max(map.getZoom(), 8));
+  }, [onChange, value]);
+
+  return <div className="search-location-map" ref={mapElementRef} aria-label="Location radius map" />;
+}

--- a/apps/ui/src/pages/search/locationFilter.test.ts
+++ b/apps/ui/src/pages/search/locationFilter.test.ts
@@ -1,0 +1,40 @@
+import {
+  buildLocationRadiusFilter,
+  formatLocationChipLabel,
+  parseLocationDraft,
+  validateLocationDraft
+} from "./locationFilter";
+
+describe("locationFilter helpers", () => {
+  it("parses valid drafts to numeric location state", () => {
+    expect(parseLocationDraft("37.7749", "-122.4194", "12.5")).toEqual({
+      latitude: 37.7749,
+      longitude: -122.4194,
+      radiusKm: 12.5
+    });
+  });
+
+  it("returns validation error for out-of-range latitude", () => {
+    const parsed = parseLocationDraft("91", "0", "10");
+    expect(validateLocationDraft(parsed)).toBe("Latitude must be between -90 and 90.");
+  });
+
+  it("builds location_radius payload only when state is valid", () => {
+    const valid = parseLocationDraft("37.7749", "-122.4194", "10");
+    expect(buildLocationRadiusFilter(valid)).toEqual({
+      latitude: 37.7749,
+      longitude: -122.4194,
+      radius_km: 10
+    });
+  });
+
+  it("formats deterministic location chip label", () => {
+    expect(
+      formatLocationChipLabel({
+        latitude: 37.774912,
+        longitude: -122.419488,
+        radiusKm: 12.54
+      })
+    ).toBe("location: 37.7749, -122.4195 (12.5 km)");
+  });
+});

--- a/apps/ui/src/pages/search/locationFilter.ts
+++ b/apps/ui/src/pages/search/locationFilter.ts
@@ -1,0 +1,103 @@
+import type { LocationRadiusValue } from "./types";
+
+export type ParsedLocationDraft = {
+  latitude: number | null;
+  longitude: number | null;
+  radiusKm: number | null;
+};
+
+function parseNumericDraft(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+function hasAnyLocationValue(parsed: ParsedLocationDraft): boolean {
+  return parsed.latitude !== null || parsed.longitude !== null || parsed.radiusKm !== null;
+}
+
+export function parseLocationDraft(
+  latitudeDraft: string,
+  longitudeDraft: string,
+  radiusDraft: string
+): ParsedLocationDraft {
+  return {
+    latitude: parseNumericDraft(latitudeDraft),
+    longitude: parseNumericDraft(longitudeDraft),
+    radiusKm: parseNumericDraft(radiusDraft)
+  };
+}
+
+export function validateLocationDraft(parsed: ParsedLocationDraft): string | null {
+  if (!hasAnyLocationValue(parsed)) {
+    return null;
+  }
+
+  if (parsed.latitude === null) {
+    return "Latitude is required.";
+  }
+
+  if (!Number.isFinite(parsed.latitude)) {
+    return "Latitude must be a number.";
+  }
+
+  if (parsed.latitude < -90 || parsed.latitude > 90) {
+    return "Latitude must be between -90 and 90.";
+  }
+
+  if (parsed.longitude === null) {
+    return "Longitude is required.";
+  }
+
+  if (!Number.isFinite(parsed.longitude)) {
+    return "Longitude must be a number.";
+  }
+
+  if (parsed.longitude < -180 || parsed.longitude > 180) {
+    return "Longitude must be between -180 and 180.";
+  }
+
+  if (parsed.radiusKm === null) {
+    return "Radius (km) is required.";
+  }
+
+  if (!Number.isFinite(parsed.radiusKm)) {
+    return "Radius (km) must be a number.";
+  }
+
+  if (parsed.radiusKm <= 0) {
+    return "Radius (km) must be greater than 0.";
+  }
+
+  return null;
+}
+
+export function buildLocationRadiusFilter(
+  parsed: ParsedLocationDraft
+): { latitude: number; longitude: number; radius_km: number } | null {
+  if (validateLocationDraft(parsed)) {
+    return null;
+  }
+
+  if (
+    parsed.latitude === null ||
+    parsed.longitude === null ||
+    parsed.radiusKm === null
+  ) {
+    return null;
+  }
+
+  return {
+    latitude: parsed.latitude,
+    longitude: parsed.longitude,
+    radius_km: parsed.radiusKm
+  };
+}
+
+export function formatLocationChipLabel(location: LocationRadiusValue): string {
+  return `location: ${location.latitude.toFixed(4)}, ${location.longitude.toFixed(4)} (${location.radiusKm.toFixed(1)} km)`;
+}

--- a/apps/ui/src/pages/search/types.ts
+++ b/apps/ui/src/pages/search/types.ts
@@ -1,0 +1,5 @@
+export type LocationRadiusValue = {
+  latitude: number;
+  longitude: number;
+  radiusKm: number;
+};

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -727,6 +727,58 @@ body {
   font: inherit;
 }
 
+.search-filter-section-label {
+  margin: 0;
+  color: #334155;
+  font-size: 0.9rem;
+}
+
+.search-location-panel {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.search-location-row {
+  display: grid;
+  grid-template-columns: auto minmax(7rem, 1fr) auto minmax(8rem, 1fr) auto minmax(6rem, 1fr);
+  gap: 0.45rem 0.6rem;
+  align-items: center;
+}
+
+.search-location-row label {
+  color: #334155;
+  font-size: 0.9rem;
+}
+
+.search-location-row input {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  padding: 0.4rem 0.5rem;
+  font: inherit;
+}
+
+.search-location-map {
+  height: 16rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.55rem;
+  overflow: hidden;
+}
+
+.search-map-message {
+  margin: 0;
+  color: #1e3a8a;
+  font-size: 0.85rem;
+}
+
+.search-location-radius-handle {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  border: 2px solid #1d4ed8;
+  background: #ffffff;
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.08);
+}
+
 .search-validation-message {
   margin: 0;
   color: #b91c1c;
@@ -886,5 +938,9 @@ body {
 
   .search-date-row {
     grid-template-columns: 1fr;
+  }
+
+  .search-location-row {
+    grid-template-columns: auto minmax(8rem, 1fr);
   }
 }

--- a/docs/superpowers/plans/2026-04-30-issue-177-location-radius-map-picker.md
+++ b/docs/superpowers/plans/2026-04-30-issue-177-location-radius-map-picker.md
@@ -1,0 +1,223 @@
+# Issue #177 Location Radius Map Picker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a free map-based location-radius picker to Search that supports click-center + drag-radius, validates latitude/longitude/radius before submit, shows removable active filter state, and serializes deterministic `filters.location_radius` requests.
+
+**Architecture:** Keep `SearchRoutePage.tsx` as an orchestrator and extract location logic into SRP modules. Use a Leaflet-backed `LocationRadiusPicker` component for map interactions and a pure `locationFilter` helper module for parsing/validation/payload/chip formatting. Extend existing Search route tests with location-specific behaviors while mocking the map component for deterministic unit tests.
+
+**Tech Stack:** React 18, TypeScript, Vite/Vitest, Testing Library, Leaflet + OpenStreetMap tiles
+
+---
+
+### Task 1: Add failing location filter helper tests (TDD Red)
+
+**Files:**
+- Create: `apps/ui/src/pages/search/locationFilter.test.ts`
+- Create: `apps/ui/src/pages/search/locationFilter.ts`
+
+- [ ] **Step 1: Write failing tests for parsing, validation, payload, and chip formatting**
+
+```ts
+import {
+  buildLocationRadiusFilter,
+  formatLocationChipLabel,
+  parseLocationDraft,
+  validateLocationDraft
+} from "./locationFilter";
+
+it("parses valid drafts to numeric location state", () => {
+  expect(parseLocationDraft("37.7749", "-122.4194", "12.5")).toEqual({
+    latitude: 37.7749,
+    longitude: -122.4194,
+    radiusKm: 12.5
+  });
+});
+
+it("returns validation error for out-of-range latitude", () => {
+  const parsed = parseLocationDraft("91", "0", "10");
+  expect(validateLocationDraft(parsed)).toBe("Latitude must be between -90 and 90.");
+});
+
+it("builds location_radius payload only when state is valid", () => {
+  const valid = parseLocationDraft("37.7749", "-122.4194", "10");
+  expect(buildLocationRadiusFilter(valid)).toEqual({
+    latitude: 37.7749,
+    longitude: -122.4194,
+    radius_km: 10
+  });
+});
+
+it("formats deterministic location chip label", () => {
+  expect(formatLocationChipLabel({ latitude: 37.774912, longitude: -122.419488, radiusKm: 12.54 })).toBe(
+    "location: 37.7749, -122.4195 (12.5 km)"
+  );
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run: `npm --prefix apps/ui test -- src/pages/search/locationFilter.test.ts`
+Expected: FAIL because helper module functions are not implemented.
+
+### Task 2: Implement location helper module (TDD Green)
+
+**Files:**
+- Modify: `apps/ui/src/pages/search/locationFilter.ts`
+- Test: `apps/ui/src/pages/search/locationFilter.test.ts`
+
+- [ ] **Step 1: Implement minimal helper module to satisfy tests**
+
+```ts
+export type ParsedLocationDraft = {
+  latitude: number | null;
+  longitude: number | null;
+  radiusKm: number | null;
+};
+
+export function parseLocationDraft(latitudeDraft: string, longitudeDraft: string, radiusDraft: string): ParsedLocationDraft {
+  // parse trimmed numeric drafts; return null for empty/non-finite
+}
+
+export function validateLocationDraft(parsed: ParsedLocationDraft): string | null {
+  // enforce finite + range checks for latitude/longitude/radius
+}
+
+export function buildLocationRadiusFilter(parsed: ParsedLocationDraft): { latitude: number; longitude: number; radius_km: number } | null {
+  // return payload only when valid
+}
+
+export function formatLocationChipLabel(location: { latitude: number; longitude: number; radiusKm: number }): string {
+  // round lat/lon to 4, radius to 1
+}
+```
+
+- [ ] **Step 2: Re-run helper tests and verify pass**
+
+Run: `npm --prefix apps/ui test -- src/pages/search/locationFilter.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit helper module and tests**
+
+```bash
+git add apps/ui/src/pages/search/locationFilter.ts apps/ui/src/pages/search/locationFilter.test.ts
+git commit -m "feat(ui): add location filter parsing and validation helpers"
+```
+
+### Task 3: Add failing SearchRoutePage tests for location filter semantics (TDD Red)
+
+**Files:**
+- Modify: `apps/ui/src/pages/SearchRoutePage.test.tsx`
+
+- [ ] **Step 1: Add failing tests for location payload, validation, clear behavior, and no auto-search**
+
+```ts
+it("submits valid location filter as filters.location_radius", async () => {
+  // set latitude, longitude, radius and submit
+  expect(body.filters.location_radius).toEqual({
+    latitude: 37.7749,
+    longitude: -122.4194,
+    radius_km: 12.5
+  });
+});
+
+it("blocks submit when location values are invalid", async () => {
+  // set invalid latitude and submit
+  expect(searchCalls(fetchMock)).toHaveLength(0);
+  expect(await screen.findByRole("alert")).toHaveTextContent("Latitude must be between -90 and 90.");
+});
+
+it("removes location chip and re-fetches without location_radius", async () => {
+  // submit with location, remove chip, verify payload no longer contains location_radius
+});
+
+it("does not auto-search when location fields change", async () => {
+  // type location values only
+  expect(searchCalls(fetchMock)).toHaveLength(0);
+});
+```
+
+- [ ] **Step 2: Run tests and verify failure**
+
+Run: `npm --prefix apps/ui test -- src/pages/SearchRoutePage.test.tsx`
+Expected: FAIL because location controls/behavior are not implemented.
+
+### Task 4: Implement SRP location picker component and route integration (TDD Green)
+
+**Files:**
+- Create: `apps/ui/src/pages/search/LocationRadiusPicker.tsx`
+- Create: `apps/ui/src/pages/search/types.ts`
+- Modify: `apps/ui/src/pages/SearchRoutePage.tsx`
+- Modify: `apps/ui/src/styles/app-shell.css`
+- Modify: `apps/ui/package.json`
+
+- [ ] **Step 1: Add map dependencies**
+
+Run: `npm --prefix apps/ui install leaflet`
+Run: `npm --prefix apps/ui install -D @types/leaflet`
+
+- [ ] **Step 2: Implement `LocationRadiusPicker` with click-center and draggable-radius behavior**
+
+```tsx
+export function LocationRadiusPicker({
+  value,
+  onChange,
+  onMapError
+}: LocationRadiusPickerProps) {
+  // create map + OSM tile layer
+  // click map sets center and default radius when empty
+  // draw circle + edge handle marker
+  // drag handle recomputes radiusKm and calls onChange
+}
+```
+
+- [ ] **Step 3: Integrate location drafts + helper module into `SearchRoutePage`**
+
+```tsx
+const [latitudeDraft, setLatitudeDraft] = useState("");
+const [longitudeDraft, setLongitudeDraft] = useState("");
+const [radiusDraft, setRadiusDraft] = useState("");
+
+const parsedLocation = useMemo(
+  () => parseLocationDraft(latitudeDraft, longitudeDraft, radiusDraft),
+  [latitudeDraft, longitudeDraft, radiusDraft]
+);
+const locationError = useMemo(() => validateLocationDraft(parsedLocation), [parsedLocation]);
+```
+
+Include `location_radius` through `buildLocationRadiusFilter(parsedLocation)` and show removable location chip.
+
+- [ ] **Step 4: Add responsive styling for location panel and map container**
+
+```css
+.search-location-panel { display: grid; gap: 0.45rem; }
+.search-location-map { height: 16rem; border: 1px solid #cbd5e1; border-radius: 0.55rem; }
+```
+
+- [ ] **Step 5: Re-run SearchRoutePage test file and verify pass**
+
+Run: `npm --prefix apps/ui test -- src/pages/SearchRoutePage.test.tsx`
+Expected: PASS.
+
+### Task 5: Run broader verification and finalize
+
+**Files:**
+- Modify (if needed): `apps/ui/src/pages/SearchRoutePage.test.tsx`
+- Modify (if needed): `apps/ui/src/pages/search/LocationRadiusPicker.tsx`
+
+- [ ] **Step 1: Run targeted UI test suite for touched units**
+
+Run: `npm --prefix apps/ui test -- src/pages/search/locationFilter.test.ts src/pages/SearchRoutePage.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 2: Run full UI unit suite**
+
+Run: `npm --prefix apps/ui test`
+Expected: PASS.
+
+- [ ] **Step 3: Commit feature changes**
+
+```bash
+git add apps/ui/package.json apps/ui/package-lock.json apps/ui/src/pages/SearchRoutePage.tsx apps/ui/src/pages/SearchRoutePage.test.tsx apps/ui/src/pages/search/locationFilter.ts apps/ui/src/pages/search/locationFilter.test.ts apps/ui/src/pages/search/types.ts apps/ui/src/pages/search/LocationRadiusPicker.tsx apps/ui/src/styles/app-shell.css
+git commit -m "feat(ui): add map-based location radius filter for search"
+```

--- a/docs/superpowers/specs/2026-04-30-issue-177-location-radius-map-picker-design.md
+++ b/docs/superpowers/specs/2026-04-30-issue-177-location-radius-map-picker-design.md
@@ -1,0 +1,161 @@
+# Issue #177 Location Radius Map Picker Design
+
+Date: 2026-04-30
+Issue: #177
+Epic: #160
+
+## Summary
+
+Implement Search route location-radius filtering with a free, navigable map picker that lets users set center coordinates and radius via direct map interaction. The UX adds click-to-set-center plus drag-to-resize-circle behavior, keeps typed latitude/longitude/radius inputs synchronized, validates ranges before submit, and serializes deterministic `filters.location_radius` payloads only when valid.
+
+## Goals
+
+- deliver a map-driven location filter UX for `/search` without requiring provider credentials
+- allow users to set location center and radius directly from map interaction
+- keep location filter state explicit and removable through active chips
+- block invalid location submissions with clear validation feedback
+- preserve deterministic request semantics when location filters combine with date/person/text filters
+
+## Non-Goals
+
+- place-name search, geocoding, or reverse-geocoding
+- automatic search execution while dragging map controls
+- URL/deep-link synchronization for location state (tracked separately)
+- backend contract changes for `location_radius`
+
+## Existing Context
+
+- backend already supports typed `filters.location_radius` with schema-level validation and radius defaults from issue #37
+- search UI currently supports tokenized text chips (#174), date filters (#175), and person filters (#176) with one deterministic submit path
+- current search behavior runs only on explicit submit or chip-removal actions; this issue keeps that execution model
+
+## Chosen Approach
+
+Use `leaflet` with OpenStreetMap tiles and a custom editable circle interaction in `SearchRoutePage`.
+
+Why this approach:
+
+- satisfies the required UX exactly: click map to set center, drag handle to set radius
+- avoids API keys and paid providers
+- avoids heavy plugin toolbars while keeping interaction logic local and testable
+
+## Interaction Model
+
+### Map creation and editing
+
+- Show a `Location radius` section inside the existing search form.
+- Render a Leaflet map initialized to neutral/global view.
+- First click on map sets center and creates:
+  - center marker
+  - radius circle
+  - draggable radius handle placed on circle edge
+- initial radius defaults to `50` km when no prior radius value exists
+- Dragging the radius handle updates `radius_km` continuously.
+- Additional map click resets center to clicked location while preserving current radius when valid.
+
+### Input synchronization
+
+- Keep manual `latitude`, `longitude`, and `radius_km` inputs visible and editable.
+- Map updates inputs immediately after click/drag interactions.
+- Valid manual input updates map overlays immediately.
+- Invalid manual input does not trigger request execution and surfaces validation messaging.
+
+### Submit and clear behavior
+
+- Map edits update filter state only; no automatic search execution.
+- Search executes only when user presses `Search`, consistent with existing behavior.
+- Active location filter appears as a removable chip:
+  - `location: <lat>, <lon> (<radius_km> km)` with stable display rounding (`lat/lon` to 4 decimals, `radius_km` to 1 decimal)
+- Removing the location chip:
+  - clears location inputs
+  - removes map circle/marker/handle
+  - omits `filters.location_radius` from subsequent request payloads
+
+## Validation Rules
+
+Client-side validation gates submit for location state:
+
+- latitude must be finite and between `-90` and `90`
+- longitude must be finite and between `-180` and `180`
+- radius must be finite and greater than `0`
+
+When validation fails:
+
+- submission is blocked
+- a clear location validation message is shown near location controls
+- existing results and other active filter state remain unchanged
+
+Location filter is considered active only when all three location values are present and valid.
+
+## Request Semantics
+
+On submit, include location filter only when active:
+
+```json
+{
+  "q": "<serialized query chips>",
+  "filters": {
+    "date": { "...": "..." },
+    "person_names": ["..."],
+    "location_radius": {
+      "latitude": 37.7749,
+      "longitude": -122.4194,
+      "radius_km": 12.5
+    }
+  },
+  "sort": { "by": "shot_ts", "dir": "desc" },
+  "page": { "limit": 24, "cursor": null }
+}
+```
+
+- `filters.location_radius` composes with date/person filters under existing deterministic merge behavior.
+- clearing location state removes only `location_radius`; other active filters stay intact.
+
+## Technical Design
+
+- Add dependencies:
+  - `leaflet` in `apps/ui/package.json`
+  - `@types/leaflet` in `apps/ui/package.json` dev dependencies
+- Extend `apps/ui/src/pages/SearchRoutePage.tsx`:
+  - add location draft and parsed state
+  - add location validation helper(s)
+  - extend `buildSearchFilters(...)` and request builder for `location_radius`
+  - integrate a small map/editor subcomponent colocated in this file for issue scope
+- Extend `apps/ui/src/styles/app-shell.css` with location panel/map/handle styling and responsive behavior.
+
+## Accessibility And Failure Handling
+
+- keep manual numeric inputs as first-class controls so location filtering still works if tiles fail
+- map interactions remain additive, not exclusive; typed input is always available
+- if tile layer fails, show non-blocking helper text and keep manual location filtering available
+
+## Testing Strategy
+
+Update `apps/ui/src/pages/SearchRoutePage.test.tsx` with focused tests:
+
+- submits valid location filter as `filters.location_radius`
+- blocks submit when latitude/longitude/radius are invalid and shows validation message
+- removes location chip and submits without `location_radius` afterwards
+- combines location filter with existing date/person filters deterministically
+- preserves no-auto-search behavior when location fields change before submit
+
+For unit tests, mock map-layer/event surfaces enough to verify state and payload semantics.
+Do not require pixel-level drag simulation in this issue’s unit scope.
+
+## Risks And Mitigations
+
+- Risk: map interaction complexity introduces flaky tests.
+  - Mitigation: test deterministic state/payload effects; keep pointer-precision behavior outside unit scope.
+- Risk: map provider availability or tile load issues.
+  - Mitigation: treat map as enhancement and preserve manual input path.
+- Risk: UX confusion from mixed input and map editing.
+  - Mitigation: keep synchronized values visible and surface one clear active location chip.
+
+## Acceptance Criteria Mapping (Issue #177)
+
+- location-radius inputs validate and prevent invalid submissions:
+  - covered by explicit range validation and submit gating.
+- active location filter state is visible and removable:
+  - covered by location chip plus clear behavior resetting map/input state.
+- valid inputs generate deterministic request payload semantics:
+  - covered by typed `filters.location_radius` inclusion only for valid active location state.

--- a/docs/superpowers/specs/2026-04-30-issue-177-location-radius-map-picker-design.md
+++ b/docs/superpowers/specs/2026-04-30-issue-177-location-radius-map-picker-design.md
@@ -116,11 +116,13 @@ On submit, include location filter only when active:
 - Add dependencies:
   - `leaflet` in `apps/ui/package.json`
   - `@types/leaflet` in `apps/ui/package.json` dev dependencies
-- Extend `apps/ui/src/pages/SearchRoutePage.tsx`:
-  - add location draft and parsed state
-  - add location validation helper(s)
-  - extend `buildSearchFilters(...)` and request builder for `location_radius`
-  - integrate a small map/editor subcomponent colocated in this file for issue scope
+- Keep `apps/ui/src/pages/SearchRoutePage.tsx` focused on route orchestration only (submit flow, high-level state wiring).
+- Extract location-specific logic into SRP-aligned modules so this story does not bloat one TSX file:
+  - `apps/ui/src/pages/search/locationFilter.ts` for location parsing, validation, chip label formatting, and payload-shape helpers
+  - `apps/ui/src/pages/search/LocationRadiusPicker.tsx` for Leaflet map + circle/handle interaction UI
+  - `apps/ui/src/pages/search/types.ts` (or equivalent) for local filter/state types when needed
+- Update `SearchRoutePage.tsx` to compose these modules instead of accumulating map math/validation/event code inline.
+- Extend `buildSearchFilters(...)` and request builder to include `location_radius` via extracted helper(s).
 - Extend `apps/ui/src/styles/app-shell.css` with location panel/map/handle styling and responsive behavior.
 
 ## Accessibility And Failure Handling


### PR DESCRIPTION
## Summary
- implement location-radius filtering UX on `/search` with manual latitude/longitude/radius inputs
- add free OpenStreetMap/Leaflet picker with click-to-set center and drag-handle radius editing
- keep `SearchRoutePage.tsx` orchestration-focused by extracting SRP helpers/components under `src/pages/search/`
- add active/removable location chip with deterministic rounding and clear behavior
- include `filters.location_radius` only when location state is valid, and block invalid submissions with explicit messages

## Implementation details
- added `src/pages/search/locationFilter.ts` for parsing, validation, payload serialization, and chip formatting
- added `src/pages/search/LocationRadiusPicker.tsx` for map interaction logic
- added `src/pages/search/types.ts` for shared location type
- integrated location state + filter composition into `SearchRoutePage.tsx`
- added styling for location panel, map container, and draggable radius handle

## Verification
- `npm --prefix apps/ui test -- src/pages/search/locationFilter.test.ts`
- `npm --prefix apps/ui test -- src/pages/SearchRoutePage.test.tsx src/pages/search/locationFilter.test.ts`
- `npm --prefix apps/ui test`
- `npm --prefix apps/ui run build`

Closes #177