### PR TITLE
Implement #178 facet panel for has-faces and path-hint filters

### DIFF
--- a/apps/ui/src/pages/SearchRoutePage.test.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.test.tsx
@@ -22,7 +22,11 @@ interface SearchResponsePayload {
       filesize: number;
     }>;
   };
-  facets: Record<string, unknown>;
+  facets: {
+    has_faces?: Record<string, unknown>;
+    path_hints?: Array<{ value: string; count: number }>;
+    tags?: Array<{ value: string; count: number }>;
+  };
 }
 
 interface PersonPayload {
@@ -32,7 +36,11 @@ interface PersonPayload {
   updated_ts: string;
 }
 
-function buildPayload(photoIds: string[], total = photoIds.length): SearchResponsePayload {
+function buildPayload(
+  photoIds: string[],
+  total = photoIds.length,
+  facets: SearchResponsePayload["facets"] = {}
+): SearchResponsePayload {
   return {
     hits: {
       total,
@@ -45,7 +53,7 @@ function buildPayload(photoIds: string[], total = photoIds.length): SearchRespon
         filesize: 1024 + index
       }))
     },
-    facets: {}
+    facets
   };
 }
 
@@ -477,5 +485,77 @@ describe("SearchRoutePage", () => {
         radius_km: 12.5
       }
     });
+  });
+
+  it("renders has-faces facet counts and toggles has_faces filter deterministically", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === PEOPLE_ENDPOINT) {
+        return {
+          ok: true,
+          json: async () => PEOPLE_FIXTURE
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () =>
+          buildPayload(["photo-1"], 1, {
+            has_faces: { true: 5, false: 2 },
+            tags: [{ value: "event:lake-weekend", count: 3 }]
+          })
+      } as Response;
+    });
+
+    renderSearchAt();
+    await user.type(await screen.findByRole("textbox", { name: "Search query" }), "lake");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(await screen.findByRole("button", { name: "With faces (5)" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Without faces (2)" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "With faces (5)" }));
+    expect(lastSearchBody(fetchMock).filters).toEqual({ has_faces: true });
+
+    await user.click(screen.getByRole("button", { name: "With faces (5)" }));
+    expect(lastSearchBody(fetchMock).filters).toBeUndefined();
+  });
+
+  it("uses path-hint facet counts for toggle and clear interactions", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === PEOPLE_ENDPOINT) {
+        return {
+          ok: true,
+          json: async () => PEOPLE_FIXTURE
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () =>
+          buildPayload(["photo-1"], 1, {
+            has_faces: { true: 1, false: 0 },
+            tags: [
+              { value: "event:lake-weekend", count: 4 },
+              { value: "event:city-break", count: 2 }
+            ]
+          })
+      } as Response;
+    });
+
+    renderSearchAt();
+    await user.type(await screen.findByRole("textbox", { name: "Search query" }), "travel");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await user.click(screen.getByRole("button", { name: "path: city-break (2)" }));
+    await user.click(screen.getByRole("button", { name: "path: lake-weekend (4)" }));
+
+    expect(lastSearchBody(fetchMock).filters).toEqual({
+      path_hints: ["city-break", "lake-weekend"]
+    });
+
+    await user.click(screen.getByRole("button", { name: "Clear path hints" }));
+    expect(lastSearchBody(fetchMock).filters).toBeUndefined();
   });
 });

--- a/apps/ui/src/pages/SearchRoutePage.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.tsx
@@ -1,5 +1,13 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import { LocationRadiusPicker } from "./search/LocationRadiusPicker";
+import { FacetFilterPanel } from "./search/FacetFilterPanel";
+import {
+  normalizePathHintFilters,
+  parseHasFacesFacetCounts,
+  toPathHintFacetCounts,
+  type FacetCountEntry,
+  type SearchFacetPayload
+} from "./search/facetFilters";
 import {
   buildLocationRadiusFilter,
   formatLocationChipLabel,
@@ -22,6 +30,7 @@ type SearchResponsePayload = {
     cursor: string | null;
     items: SearchPhoto[];
   };
+  facets?: SearchFacetPayload;
 };
 
 type PersonRecord = {
@@ -87,24 +96,31 @@ function buildSearchFilters(
   fromDate: string,
   toDate: string,
   selectedPersonNames: string[],
-  locationRadius: { latitude: number; longitude: number; radius_km: number } | null
+  locationRadius: { latitude: number; longitude: number; radius_km: number } | null,
+  hasFaces: boolean | null,
+  pathHints: string[]
 ): {
   date?: { from?: string; to?: string };
   person_names?: string[];
   location_radius?: { latitude: number; longitude: number; radius_km: number };
+  has_faces?: boolean;
+  path_hints?: string[];
 } | null {
   const dateFilter = buildDateFilter(fromDate, toDate);
   const personNameFilter = selectedPersonNames.length > 0 ? selectedPersonNames : null;
   const locationFilter = locationRadius;
+  const pathHintFilter = pathHints.length > 0 ? pathHints : null;
 
-  if (!dateFilter && !personNameFilter && !locationFilter) {
+  if (!dateFilter && !personNameFilter && !locationFilter && hasFaces === null && !pathHintFilter) {
     return null;
   }
 
   return {
     ...(dateFilter ? { date: dateFilter } : {}),
     ...(personNameFilter ? { person_names: personNameFilter } : {}),
-    ...(locationFilter ? { location_radius: locationFilter } : {})
+    ...(locationFilter ? { location_radius: locationFilter } : {}),
+    ...(hasFaces === null ? {} : { has_faces: hasFaces }),
+    ...(pathHintFilter ? { path_hints: pathHintFilter } : {})
   };
 }
 
@@ -113,9 +129,18 @@ async function fetchSearchResults(
   fromDate: string,
   toDate: string,
   selectedPersonNames: string[],
-  locationRadius: { latitude: number; longitude: number; radius_km: number } | null
+  locationRadius: { latitude: number; longitude: number; radius_km: number } | null,
+  hasFaces: boolean | null,
+  pathHints: string[]
 ): Promise<SearchResponsePayload> {
-  const searchFilters = buildSearchFilters(fromDate, toDate, selectedPersonNames, locationRadius);
+  const searchFilters = buildSearchFilters(
+    fromDate,
+    toDate,
+    selectedPersonNames,
+    locationRadius,
+    hasFaces,
+    pathHints
+  );
   const response = await fetch("/api/v1/search", {
     method: "POST",
     headers: {
@@ -149,6 +174,13 @@ export function SearchRoutePage() {
   const [peopleDirectory, setPeopleDirectory] = useState<PersonRecord[]>([]);
   const [personMessage, setPersonMessage] = useState<string | null>(null);
   const [mapMessage, setMapMessage] = useState<string | null>(null);
+  const [hasFacesFilter, setHasFacesFilter] = useState<boolean | null>(null);
+  const [pathHintFilters, setPathHintFilters] = useState<string[]>([]);
+  const [facetHasFacesCounts, setFacetHasFacesCounts] = useState<{ true: number; false: number }>({
+    true: 0,
+    false: 0
+  });
+  const [facetPathHintCounts, setFacetPathHintCounts] = useState<FacetCountEntry[]>([]);
   const [results, setResults] = useState<SearchPhoto[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
@@ -169,6 +201,8 @@ export function SearchRoutePage() {
   const hasActiveDateFilter = Boolean(fromDate || toDate);
   const hasActivePersonFilter = selectedPersonNames.length > 0;
   const hasActiveLocationFilter = Boolean(locationRadiusFilter);
+  const hasActiveHasFacesFilter = hasFacesFilter !== null;
+  const hasActivePathHintFilter = pathHintFilters.length > 0;
   const matchingPeople = useMemo(() => {
     const trimmed = personDraft.trim();
     if (!trimmed) {
@@ -214,7 +248,9 @@ export function SearchRoutePage() {
     activeFromDate: string,
     activeToDate: string,
     activePersonNames: string[],
-    activeLocationRadius: { latitude: number; longitude: number; radius_km: number } | null
+    activeLocationRadius: { latitude: number; longitude: number; radius_km: number } | null,
+    activeHasFaces: boolean | null,
+    activePathHints: string[]
   ) {
     if (validateDateRange(activeFromDate, activeToDate)) {
       return;
@@ -230,10 +266,14 @@ export function SearchRoutePage() {
         activeFromDate,
         activeToDate,
         activePersonNames,
-        activeLocationRadius
+        activeLocationRadius,
+        activeHasFaces,
+        activePathHints
       );
       setResults(payload.hits.items);
       setTotalCount(payload.hits.total);
+      setFacetHasFacesCounts(parseHasFacesFacetCounts(payload.facets));
+      setFacetPathHintCounts(toPathHintFacetCounts(payload.facets, activePathHints));
     } catch (caughtError: unknown) {
       const message =
         caughtError instanceof Error
@@ -242,9 +282,36 @@ export function SearchRoutePage() {
       setError(message);
       setResults([]);
       setTotalCount(0);
+      setFacetHasFacesCounts({ true: 0, false: 0 });
+      setFacetPathHintCounts(
+        activePathHints.map((value) => ({
+          value,
+          count: 0
+        }))
+      );
     } finally {
       setIsLoading(false);
     }
+  }
+
+  function requestSearch(overrides: {
+    chips?: string[];
+    fromDate?: string;
+    toDate?: string;
+    personNames?: string[];
+    locationRadius?: { latitude: number; longitude: number; radius_km: number } | null;
+    hasFaces?: boolean | null;
+    pathHints?: string[];
+  } = {}) {
+    void runSearch(
+      overrides.chips ?? queryChips,
+      overrides.fromDate ?? fromDate,
+      overrides.toDate ?? toDate,
+      overrides.personNames ?? selectedPersonNames,
+      overrides.locationRadius === undefined ? locationRadiusFilter : overrides.locationRadius,
+      overrides.hasFaces === undefined ? hasFacesFilter : overrides.hasFaces,
+      overrides.pathHints ?? pathHintFilters
+    );
   }
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -255,7 +322,14 @@ export function SearchRoutePage() {
     }
 
     const trimmed = draftQuery.trim();
-    if (!trimmed && !hasActiveDateFilter && !hasActivePersonFilter && !hasActiveLocationFilter) {
+    if (
+      !trimmed &&
+      !hasActiveDateFilter &&
+      !hasActivePersonFilter &&
+      !hasActiveLocationFilter &&
+      !hasActiveHasFacesFilter &&
+      !hasActivePathHintFilter
+    ) {
       return;
     }
 
@@ -265,23 +339,23 @@ export function SearchRoutePage() {
       setDraftQuery("");
     }
 
-    void runSearch(nextChips, fromDate, toDate, selectedPersonNames, locationRadiusFilter);
+    requestSearch({ chips: nextChips });
   }
 
   function handleDismissChip(indexToRemove: number) {
     const nextChips = queryChips.filter((_, index) => index !== indexToRemove);
     setQueryChips(nextChips);
-    void runSearch(nextChips, fromDate, toDate, selectedPersonNames, locationRadiusFilter);
+    requestSearch({ chips: nextChips });
   }
 
   function handleClearFromDate() {
     setFromDate("");
-    void runSearch(queryChips, "", toDate, selectedPersonNames, locationRadiusFilter);
+    requestSearch({ fromDate: "" });
   }
 
   function handleClearToDate() {
     setToDate("");
-    void runSearch(queryChips, fromDate, "", selectedPersonNames, locationRadiusFilter);
+    requestSearch({ toDate: "" });
   }
 
   function handleAddPersonByName(displayName: string) {
@@ -319,7 +393,7 @@ export function SearchRoutePage() {
     const nextNames = selectedPersonNames.filter((name) => name !== displayName);
     setSelectedPersonNames(nextNames);
     setPersonMessage(null);
-    void runSearch(queryChips, fromDate, toDate, nextNames, locationRadiusFilter);
+    requestSearch({ personNames: nextNames });
   }
 
   function handleMapLocationChange(location: LocationRadiusValue) {
@@ -333,11 +407,54 @@ export function SearchRoutePage() {
     setLatitudeDraft("");
     setLongitudeDraft("");
     setRadiusDraft("");
-    void runSearch(queryChips, fromDate, toDate, selectedPersonNames, null);
+    requestSearch({ locationRadius: null });
+  }
+
+  function handleToggleHasFacesFilter(nextValue: boolean) {
+    const resolvedValue = hasFacesFilter === nextValue ? null : nextValue;
+    setHasFacesFilter(resolvedValue);
+    requestSearch({ hasFaces: resolvedValue });
+  }
+
+  function handleClearHasFacesFilter() {
+    if (hasFacesFilter === null) {
+      return;
+    }
+
+    setHasFacesFilter(null);
+    requestSearch({ hasFaces: null });
+  }
+
+  function handleTogglePathHintFilter(pathHint: string) {
+    const nextHints = pathHintFilters.includes(pathHint)
+      ? pathHintFilters.filter((hint) => hint !== pathHint)
+      : normalizePathHintFilters([...pathHintFilters, pathHint]);
+
+    setPathHintFilters(nextHints);
+    requestSearch({ pathHints: nextHints });
+  }
+
+  function handleClearPathHintFilter(pathHint: string) {
+    const nextHints = pathHintFilters.filter((hint) => hint !== pathHint);
+    if (nextHints.length === pathHintFilters.length) {
+      return;
+    }
+
+    setPathHintFilters(nextHints);
+    requestSearch({ pathHints: nextHints });
+  }
+
+  function handleClearAllPathHints() {
+    if (pathHintFilters.length === 0) {
+      return;
+    }
+
+    setPathHintFilters([]);
+    requestSearch({ pathHints: [] });
   }
 
   function handleRetry() {
-    void runSearch(queryChips, fromDate, toDate, selectedPersonNames, locationRadiusFilter);
+    requestSearch();
   }
 
   const summaryLabel = useMemo(() => {
@@ -453,6 +570,16 @@ export function SearchRoutePage() {
             onMapError={setMapMessage}
           />
         </div>
+        <FacetFilterPanel
+          hasFacesFilter={hasFacesFilter}
+          pathHintFilters={pathHintFilters}
+          hasFacesCounts={facetHasFacesCounts}
+          pathHintCounts={facetPathHintCounts}
+          onToggleHasFaces={handleToggleHasFacesFilter}
+          onClearHasFaces={handleClearHasFacesFilter}
+          onTogglePathHint={handleTogglePathHintFilter}
+          onClearAllPathHints={handleClearAllPathHints}
+        />
         {dateRangeError ? (
           <p id="search-date-validation" className="search-validation-message" role="alert">
             {dateRangeError}
@@ -490,7 +617,12 @@ export function SearchRoutePage() {
         ) : null}
       </form>
 
-      {queryChips.length > 0 || hasActiveDateFilter || hasActivePersonFilter || hasActiveLocationFilter ? (
+      {queryChips.length > 0 ||
+      hasActiveDateFilter ||
+      hasActivePersonFilter ||
+      hasActiveLocationFilter ||
+      hasActiveHasFacesFilter ||
+      hasActivePathHintFilter ? (
         <ul className="search-chip-list" aria-label="Active search filters">
           {locationRadiusFilter ? (
             <li>
@@ -522,6 +654,32 @@ export function SearchRoutePage() {
                 onClick={() => handleRemovePersonFilter(displayName)}
               >
                 person: {displayName}
+                <span aria-hidden="true"> ×</span>
+              </button>
+            </li>
+          ))}
+          {hasFacesFilter !== null ? (
+            <li>
+              <button
+                type="button"
+                className="search-chip"
+                aria-label={`Remove has faces filter ${hasFacesFilter ? "with faces" : "without faces"}`}
+                onClick={handleClearHasFacesFilter}
+              >
+                has faces: {hasFacesFilter ? "yes" : "no"}
+                <span aria-hidden="true"> ×</span>
+              </button>
+            </li>
+          ) : null}
+          {pathHintFilters.map((pathHint) => (
+            <li key={pathHint}>
+              <button
+                type="button"
+                className="search-chip"
+                aria-label={`Remove path hint ${pathHint}`}
+                onClick={() => handleClearPathHintFilter(pathHint)}
+              >
+                path hint: {pathHint}
                 <span aria-hidden="true"> ×</span>
               </button>
             </li>
@@ -616,6 +774,10 @@ export function SearchRoutePage() {
         {locationRadiusFilter
           ? `${locationRadiusFilter.latitude.toFixed(4)}, ${locationRadiusFilter.longitude.toFixed(4)} (${locationRadiusFilter.radius_km.toFixed(1)} km)`
           : "(none)"}
+        {" | Has faces: "}
+        {hasFacesFilter === null ? "(none)" : hasFacesFilter ? "true" : "false"}
+        {" | Path hints: "}
+        {pathHintFilters.length > 0 ? pathHintFilters.join(", ") : "(none)"}
       </p>
     </section>
   );

--- a/apps/ui/src/pages/search/FacetFilterPanel.tsx
+++ b/apps/ui/src/pages/search/FacetFilterPanel.tsx
@@ -1,0 +1,83 @@
+import type { FacetCountEntry, HasFacesFacetCounts } from "./facetFilters";
+
+type FacetFilterPanelProps = {
+  hasFacesFilter: boolean | null;
+  pathHintFilters: string[];
+  hasFacesCounts: HasFacesFacetCounts;
+  pathHintCounts: FacetCountEntry[];
+  onToggleHasFaces: (nextValue: boolean) => void;
+  onClearHasFaces: () => void;
+  onTogglePathHint: (pathHint: string) => void;
+  onClearAllPathHints: () => void;
+};
+
+export function FacetFilterPanel({
+  hasFacesFilter,
+  pathHintFilters,
+  hasFacesCounts,
+  pathHintCounts,
+  onToggleHasFaces,
+  onClearHasFaces,
+  onTogglePathHint,
+  onClearAllPathHints
+}: FacetFilterPanelProps) {
+  return (
+    <div className="search-facet-panel" aria-label="Facet filters">
+      <p className="search-filter-section-label">Facet filters</p>
+      <div className="search-facet-group">
+        <p className="search-facet-group-label">Has faces</p>
+        <div className="search-facet-options">
+          <button
+            type="button"
+            className={`search-facet-option${hasFacesFilter === true ? " search-facet-option-active" : ""}`}
+            aria-pressed={hasFacesFilter === true}
+            onClick={() => onToggleHasFaces(true)}
+          >
+            With faces ({hasFacesCounts.true})
+          </button>
+          <button
+            type="button"
+            className={`search-facet-option${hasFacesFilter === false ? " search-facet-option-active" : ""}`}
+            aria-pressed={hasFacesFilter === false}
+            onClick={() => onToggleHasFaces(false)}
+          >
+            Without faces ({hasFacesCounts.false})
+          </button>
+          {hasFacesFilter !== null ? (
+            <button type="button" className="search-facet-clear" onClick={onClearHasFaces}>
+              Clear has-faces
+            </button>
+          ) : null}
+        </div>
+      </div>
+      <div className="search-facet-group">
+        <p className="search-facet-group-label">Path hints</p>
+        <div className="search-facet-options">
+          {pathHintCounts.length > 0 ? (
+            pathHintCounts.map((entry) => {
+              const isActive = pathHintFilters.includes(entry.value);
+              return (
+                <button
+                  key={entry.value}
+                  type="button"
+                  className={`search-facet-option${isActive ? " search-facet-option-active" : ""}`}
+                  aria-pressed={isActive}
+                  onClick={() => onTogglePathHint(entry.value)}
+                >
+                  path: {entry.value} ({entry.count})
+                </button>
+              );
+            })
+          ) : (
+            <p className="search-facet-empty">Submit a search to load path-hint counts.</p>
+          )}
+          {pathHintFilters.length > 0 ? (
+            <button type="button" className="search-facet-clear" onClick={onClearAllPathHints}>
+              Clear path hints
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/ui/src/pages/search/facetFilters.ts
+++ b/apps/ui/src/pages/search/facetFilters.ts
@@ -1,0 +1,87 @@
+export type FacetCountEntry = {
+  value: string;
+  count: number;
+};
+
+export type SearchFacetPayload = {
+  has_faces?: Record<string, unknown>;
+  path_hints?: FacetCountEntry[];
+  tags?: FacetCountEntry[];
+};
+
+export type HasFacesFacetCounts = {
+  true: number;
+  false: number;
+};
+
+function normalizeFacetCount(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  return 0;
+}
+
+function parseFacetCountEntries(rawEntries: unknown): FacetCountEntry[] {
+  if (!Array.isArray(rawEntries)) {
+    return [];
+  }
+
+  return rawEntries.flatMap((entry) => {
+    if (!entry || typeof entry !== "object") {
+      return [];
+    }
+
+    const value = "value" in entry && typeof entry.value === "string" ? entry.value.trim() : "";
+    if (!value) {
+      return [];
+    }
+
+    const count = "count" in entry ? normalizeFacetCount(entry.count) : 0;
+    return [{ value, count }];
+  });
+}
+
+export function parseHasFacesFacetCounts(facets: SearchFacetPayload | undefined): HasFacesFacetCounts {
+  return {
+    true: normalizeFacetCount(facets?.has_faces?.true),
+    false: normalizeFacetCount(facets?.has_faces?.false)
+  };
+}
+
+export function toPathHintFacetCounts(
+  facets: SearchFacetPayload | undefined,
+  activePathHints: string[]
+): FacetCountEntry[] {
+  const directPathHintCounts = parseFacetCountEntries(facets?.path_hints);
+  const sourceCounts =
+    directPathHintCounts.length > 0
+      ? directPathHintCounts
+      : parseFacetCountEntries(facets?.tags)
+          .filter((entry) => entry.value.startsWith("event:"))
+          .map((entry) => ({ value: entry.value.slice("event:".length), count: entry.count }));
+
+  const mergedCounts = new Map<string, number>();
+  for (const entry of sourceCounts) {
+    mergedCounts.set(entry.value, (mergedCounts.get(entry.value) ?? 0) + entry.count);
+  }
+  for (const activePathHint of activePathHints) {
+    if (!mergedCounts.has(activePathHint)) {
+      mergedCounts.set(activePathHint, 0);
+    }
+  }
+
+  return [...mergedCounts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((left, right) => {
+      if (right.count !== left.count) {
+        return right.count - left.count;
+      }
+      return left.value.localeCompare(right.value);
+    });
+}
+
+export function normalizePathHintFilters(pathHints: string[]): string[] {
+  return [...new Set(pathHints.map((hint) => hint.trim()).filter((hint) => hint.length > 0))].sort(
+    (left, right) => left.localeCompare(right)
+  );
+}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -738,6 +738,58 @@ body {
   gap: 0.45rem;
 }
 
+.search-facet-panel {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.search-facet-group {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.search-facet-group-label {
+  margin: 0;
+  color: #334155;
+  font-size: 0.9rem;
+}
+
+.search-facet-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.search-facet-option {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #1e293b;
+  border-radius: 0.45rem;
+  padding: 0.35rem 0.65rem;
+  font: inherit;
+}
+
+.search-facet-option-active {
+  border-color: #93c5fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.search-facet-clear {
+  border: 1px solid #bfdbfe;
+  background: #f8fbff;
+  color: #1e3a8a;
+  border-radius: 0.45rem;
+  padding: 0.35rem 0.65rem;
+  font: inherit;
+}
+
+.search-facet-empty {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.88rem;
+}
+
 .search-location-row {
   display: grid;
   grid-template-columns: auto minmax(7rem, 1fr) auto minmax(8rem, 1fr) auto minmax(6rem, 1fr);


### PR DESCRIPTION
## Summary
- add a facet panel for `has_faces` and path-hint filters on the Search route
- keep `SearchRoutePage` orchestration-focused by extracting facet parsing/state helpers and facet UI component
- add deterministic toggle/clear behavior and active chips for facet filters
- extend Search route tests for facet counts and toggle transitions

## Verification
- `npm --prefix apps/ui test -- src/pages/SearchRoutePage.test.tsx src/app/AppShell.test.tsx`

Closes #178