### PR TITLE
feat(ui): implement URL-synced search state restoration for #179

### DIFF
--- a/apps/ui/src/pages/SearchRoutePage.test.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { SearchRoutePage } from "./SearchRoutePage";
 
 vi.mock("./search/LocationRadiusPicker", () => ({
@@ -79,13 +79,26 @@ const PEOPLE_FIXTURE: PersonPayload[] = [
 ];
 
 function renderSearchAt(path = "/search") {
+  function SearchLocationProbe() {
+    const location = useLocation();
+    return <p data-testid="search-location-probe">{location.search}</p>;
+  }
+
   return render(
     <MemoryRouter
       initialEntries={[path]}
       future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
     >
       <Routes>
-        <Route path="/search" element={<SearchRoutePage />} />
+        <Route
+          path="/search"
+          element={
+            <>
+              <SearchRoutePage />
+              <SearchLocationProbe />
+            </>
+          }
+        />
       </Routes>
     </MemoryRouter>
   );
@@ -557,5 +570,78 @@ describe("SearchRoutePage", () => {
 
     await user.click(screen.getByRole("button", { name: "Clear path hints" }));
     expect(lastSearchBody(fetchMock).filters).toBeUndefined();
+  });
+
+  it("restores active query and filter state from URL params", async () => {
+    renderSearchAt(
+      "/search?query=lake%20weekend&query=sunset&from=2026-04-01&to=2026-04-30&person=Inez%20Alvarez&lat=37.7749&lng=-122.4194&radiusKm=12.5&hasFaces=true&pathHint=city-break&pathHint=lake-weekend"
+    );
+
+    expect(await screen.findByRole("button", { name: "Remove query lake weekend" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove query sunset" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove from date 2026-04-01" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove to date 2026-04-30" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove person Inez Alvarez" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remove location: 37.7749, -122.4194 (12.5 km)" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remove has faces filter with faces" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove path hint city-break" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove path hint lake-weekend" })).toBeInTheDocument();
+    expect(searchCalls(fetchMock)).toHaveLength(0);
+  });
+
+  it("drops malformed URL params and keeps only deterministic valid filter state", async () => {
+    renderSearchAt(
+      "/search?query=%20%20&from=2026-04-99&to=bad-date&person=%20&lat=999&lng=nope&radiusKm=0&hasFaces=maybe&pathHint=&pathHint=lake-weekend"
+    );
+
+    expect(await screen.findByRole("button", { name: "Remove path hint lake-weekend" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Remove has faces filter with faces" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Remove has faces filter without faces" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Remove from date/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Remove to date/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Remove location/i })).not.toBeInTheDocument();
+    expect(searchCalls(fetchMock)).toHaveLength(0);
+    expect(screen.getByTestId("search-location-probe")).toHaveTextContent("?pathHint=lake-weekend");
+  });
+
+  it("writes active state back to URL deterministically when query and facet filters change", async () => {
+    const user = userEvent.setup();
+    renderSearchAt("/search");
+
+    await user.type(await screen.findByRole("textbox", { name: "Search query" }), "harbor");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await user.click(screen.getByRole("button", { name: "With faces (0)" }));
+
+    expect(screen.getByTestId("search-location-probe")).toHaveTextContent(
+      "?query=harbor&hasFaces=true"
+    );
+  });
+
+  it("restores URL state without auto-requesting search on load", async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === PEOPLE_ENDPOINT) {
+        return {
+          ok: true,
+          json: async () => PEOPLE_FIXTURE
+        } as Response;
+      }
+
+      throw new TypeError("Failed to fetch");
+    });
+
+    renderSearchAt("/search?query=lake&from=2026-04-01&hasFaces=true");
+
+    expect(await screen.findByRole("button", { name: "Remove query lake" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove from date 2026-04-01" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remove has faces filter with faces" })
+    ).toBeInTheDocument();
+    expect(searchCalls(fetchMock)).toHaveLength(0);
+    expect(screen.queryByRole("heading", { name: "Could not load Search" })).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/pages/SearchRoutePage.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.tsx
@@ -1,4 +1,5 @@
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { LocationRadiusPicker } from "./search/LocationRadiusPicker";
 import { FacetFilterPanel } from "./search/FacetFilterPanel";
 import {
@@ -40,6 +41,142 @@ type PersonRecord = {
 
 const DEFAULT_SORT = { by: "shot_ts", dir: "desc" } as const;
 const DEFAULT_PAGE = { limit: 24, cursor: null } as const;
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+type SearchUrlState = {
+  queryChips: string[];
+  fromDate: string;
+  toDate: string;
+  selectedPersonNames: string[];
+  latitudeDraft: string;
+  longitudeDraft: string;
+  radiusDraft: string;
+  locationRadius: { latitude: number; longitude: number; radius_km: number } | null;
+  hasFacesFilter: boolean | null;
+  pathHintFilters: string[];
+};
+
+function dedupeTrimmedValues(values: string[]): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    deduped.push(trimmed);
+  }
+
+  return deduped;
+}
+
+function isValidIsoDate(value: string): boolean {
+  if (!DATE_PATTERN.test(value)) {
+    return false;
+  }
+
+  const [yearRaw, monthRaw, dayRaw] = value.split("-");
+  const year = Number(yearRaw);
+  const month = Number(monthRaw);
+  const day = Number(dayRaw);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+    return false;
+  }
+
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return (
+    parsed.getUTCFullYear() === year &&
+    parsed.getUTCMonth() === month - 1 &&
+    parsed.getUTCDate() === day
+  );
+}
+
+function parseSearchUrlState(search: string): SearchUrlState {
+  const params = new URLSearchParams(search);
+  const queryChips = dedupeTrimmedValues(params.getAll("query"));
+
+  const fromCandidate = (params.get("from") ?? "").trim();
+  const toCandidate = (params.get("to") ?? "").trim();
+  const fromDate = isValidIsoDate(fromCandidate) ? fromCandidate : "";
+  const toDate = isValidIsoDate(toCandidate) ? toCandidate : "";
+
+  const selectedPersonNames = dedupeTrimmedValues(params.getAll("person"));
+  const pathHintFilters = normalizePathHintFilters(params.getAll("pathHint"));
+
+  const rawHasFaces = (params.get("hasFaces") ?? "").trim();
+  const hasFacesFilter =
+    rawHasFaces === "true" ? true : rawHasFaces === "false" ? false : null;
+
+  const latitudeCandidate = (params.get("lat") ?? "").trim();
+  const longitudeCandidate = (params.get("lng") ?? "").trim();
+  const radiusCandidate = (params.get("radiusKm") ?? "").trim();
+  const parsedLocation = parseLocationDraft(
+    latitudeCandidate,
+    longitudeCandidate,
+    radiusCandidate
+  );
+  const locationRadius = buildLocationRadiusFilter(parsedLocation);
+  const locationDrafts = locationRadius
+    ? {
+        latitudeDraft: String(locationRadius.latitude),
+        longitudeDraft: String(locationRadius.longitude),
+        radiusDraft: String(locationRadius.radius_km)
+      }
+    : { latitudeDraft: "", longitudeDraft: "", radiusDraft: "" };
+
+  return {
+    queryChips,
+    fromDate,
+    toDate,
+    selectedPersonNames,
+    latitudeDraft: locationDrafts.latitudeDraft,
+    longitudeDraft: locationDrafts.longitudeDraft,
+    radiusDraft: locationDrafts.radiusDraft,
+    locationRadius,
+    hasFacesFilter,
+    pathHintFilters
+  };
+}
+
+function buildSearchUrlQuery(state: {
+  queryChips: string[];
+  fromDate: string;
+  toDate: string;
+  selectedPersonNames: string[];
+  locationRadius: { latitude: number; longitude: number; radius_km: number } | null;
+  hasFacesFilter: boolean | null;
+  pathHintFilters: string[];
+}): string {
+  const params = new URLSearchParams();
+
+  for (const chip of state.queryChips) {
+    params.append("query", chip);
+  }
+  if (state.fromDate) {
+    params.set("from", state.fromDate);
+  }
+  if (state.toDate) {
+    params.set("to", state.toDate);
+  }
+  for (const personName of state.selectedPersonNames) {
+    params.append("person", personName);
+  }
+  if (state.locationRadius) {
+    params.set("lat", String(state.locationRadius.latitude));
+    params.set("lng", String(state.locationRadius.longitude));
+    params.set("radiusKm", String(state.locationRadius.radius_km));
+  }
+  if (state.hasFacesFilter !== null) {
+    params.set("hasFaces", state.hasFacesFilter ? "true" : "false");
+  }
+  for (const pathHint of state.pathHintFilters) {
+    params.append("pathHint", pathHint);
+  }
+
+  return params.toString();
+}
 
 function buildDateFilter(from: string, to: string): { from?: string; to?: string } | null {
   const trimmedFrom = from.trim();
@@ -162,6 +299,11 @@ async function fetchSearchResults(
 }
 
 export function SearchRoutePage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const suppressNextUrlStateSyncRef = useRef(false);
+  const applyingParsedUrlStateRef = useRef(false);
+
   const [draftQuery, setDraftQuery] = useState("");
   const [queryChips, setQueryChips] = useState<string[]>([]);
   const [fromDate, setFromDate] = useState("");
@@ -186,6 +328,7 @@ export function SearchRoutePage() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasRequested, setHasRequested] = useState(false);
+  const parsedUrlState = useMemo(() => parseSearchUrlState(location.search), [location.search]);
 
   const serializedQuery = useMemo(() => queryChips.join(" "), [queryChips]);
   const dateRangeError = useMemo(() => validateDateRange(fromDate, toDate), [fromDate, toDate]);
@@ -242,6 +385,85 @@ export function SearchRoutePage() {
       isCanceled = true;
     };
   }, []);
+
+  useEffect(() => {
+    if (suppressNextUrlStateSyncRef.current) {
+      suppressNextUrlStateSyncRef.current = false;
+      return;
+    }
+
+    applyingParsedUrlStateRef.current = true;
+    setQueryChips(parsedUrlState.queryChips);
+    setDraftQuery("");
+    setFromDate(parsedUrlState.fromDate);
+    setToDate(parsedUrlState.toDate);
+    setSelectedPersonNames(parsedUrlState.selectedPersonNames);
+    setPersonDraft("");
+    setPersonMessage(null);
+    setLatitudeDraft(parsedUrlState.latitudeDraft);
+    setLongitudeDraft(parsedUrlState.longitudeDraft);
+    setRadiusDraft(parsedUrlState.radiusDraft);
+    setMapMessage(null);
+    setHasFacesFilter(parsedUrlState.hasFacesFilter);
+    setPathHintFilters(parsedUrlState.pathHintFilters);
+
+    setIsLoading(false);
+    setError(null);
+    setHasRequested(false);
+    setResults([]);
+    setTotalCount(0);
+    setFacetHasFacesCounts({ true: 0, false: 0 });
+    setFacetPathHintCounts(
+      parsedUrlState.pathHintFilters.map((value) => ({
+        value,
+        count: 0
+      }))
+    );
+  }, [parsedUrlState]);
+
+  useEffect(() => {
+    if (applyingParsedUrlStateRef.current) {
+      applyingParsedUrlStateRef.current = false;
+      return;
+    }
+
+    const nextQuery = buildSearchUrlQuery({
+      queryChips,
+      fromDate,
+      toDate,
+      selectedPersonNames,
+      locationRadius: locationRadiusFilter,
+      hasFacesFilter,
+      pathHintFilters
+    });
+    const currentQuery = location.search.startsWith("?")
+      ? location.search.slice(1)
+      : location.search;
+
+    if (nextQuery === currentQuery) {
+      return;
+    }
+
+    suppressNextUrlStateSyncRef.current = true;
+    navigate(
+      {
+        pathname: location.pathname,
+        search: nextQuery ? `?${nextQuery}` : ""
+      },
+      { replace: true }
+    );
+  }, [
+    fromDate,
+    hasFacesFilter,
+    location.pathname,
+    location.search,
+    locationRadiusFilter,
+    navigate,
+    pathHintFilters,
+    queryChips,
+    selectedPersonNames,
+    toDate
+  ]);
 
   async function runSearch(
     chips: string[],


### PR DESCRIPTION
## Summary
- implement URL parsing and canonical URL serialization for `/search` state (`query`, date range, people, location radius, has-faces, path hints)
- restore filter/query UI state from deep links while safely dropping malformed/partial URL values
- prevent automatic search requests during URL hydration so deep links do not show `Failed to fetch` on initial load when backend is unavailable
- add regression coverage for URL restore, malformed fallback, deterministic write-back, and no-auto-request hydration behavior

## Testing
- `npm --prefix apps/ui run test -- src/pages/SearchRoutePage.test.tsx`
- `npm --prefix apps/ui run test -- src/app/AppShell.test.tsx src/pages/SearchRoutePage.test.tsx src/pages/search/locationFilter.test.ts`
- `npm --prefix apps/ui run build`
- `npm --prefix apps/ui run test:e2e -- tests/e2e/journeys/app-shell-journeys.spec.ts tests/e2e/technical/navigation-state.spec.ts --grep "JRN-P3-search-route-deep-link|technical: deep-link query state renders expected route shell"`

Closes #179