### PR TITLE
Implement stable sort and deterministic pagination behavior for Search

### DIFF
--- a/apps/ui/src/pages/SearchRoutePage.test.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.test.tsx
@@ -39,12 +39,13 @@ interface PersonPayload {
 function buildPayload(
   photoIds: string[],
   total = photoIds.length,
-  facets: SearchResponsePayload["facets"] = {}
+  facets: SearchResponsePayload["facets"] = {},
+  cursor: string | null = null
 ): SearchResponsePayload {
   return {
     hits: {
       total,
-      cursor: null,
+      cursor,
       items: photoIds.map((photoId, index) => ({
         photo_id: photoId,
         path: `/library/${photoId}.jpg`,
@@ -297,6 +298,160 @@ describe("SearchRoutePage", () => {
     } as Response);
 
     expect(await screen.findByText("No matching photos for the active query.")).toBeInTheDocument();
+  });
+
+  it("maps sort control selections to deterministic backend sort modes", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    await user.selectOptions(screen.getByLabelText("Sort order"), "asc");
+    await user.type(await screen.findByRole("textbox", { name: "Search query" }), "lake");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    const body = lastSearchBody(fetchMock);
+    expect(body.sort).toEqual({ by: "shot_ts", dir: "asc" });
+    expect(body.page).toEqual({ limit: 24, cursor: null });
+  });
+
+  it("advances and returns pages using deterministic cursor boundaries", async () => {
+    const user = userEvent.setup();
+    let searchRequestCount = 0;
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === PEOPLE_ENDPOINT) {
+        return {
+          ok: true,
+          json: async () => PEOPLE_FIXTURE
+        } as Response;
+      }
+
+      searchRequestCount += 1;
+      if (searchRequestCount === 1) {
+        return {
+          ok: true,
+          json: async () => buildPayload(["photo-1"], 3, {}, "cursor-page-2")
+        } as Response;
+      }
+
+      if (searchRequestCount === 2) {
+        return {
+          ok: true,
+          json: async () => buildPayload(["photo-2"], 3, {}, "cursor-page-3")
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-1"], 3, {}, "cursor-page-2")
+      } as Response;
+    });
+
+    renderSearchAt();
+    await user.type(await screen.findByRole("textbox", { name: "Search query" }), "trip");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    expect(await screen.findByText("photo-1")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+    expect(await screen.findByText("photo-2")).toBeInTheDocument();
+    expect(screen.getByText("Page 2")).toBeInTheDocument();
+
+    const secondRequest = searchCalls(fetchMock)[1]?.[1] as RequestInit;
+    expect(JSON.parse(String(secondRequest.body)).page).toEqual({
+      limit: 24,
+      cursor: "cursor-page-2"
+    });
+
+    await user.click(screen.getByRole("button", { name: "Previous page" }));
+    expect(await screen.findByText("photo-1")).toBeInTheDocument();
+    expect(screen.getByText("Page 1")).toBeInTheDocument();
+  });
+
+  it("resets pagination to page one when filter state changes", async () => {
+    const user = userEvent.setup();
+    let searchRequestCount = 0;
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === PEOPLE_ENDPOINT) {
+        return {
+          ok: true,
+          json: async () => PEOPLE_FIXTURE
+        } as Response;
+      }
+
+      searchRequestCount += 1;
+      if (searchRequestCount === 1) {
+        return {
+          ok: true,
+          json: async () =>
+            buildPayload(["photo-1"], 3, { has_faces: { true: 2, false: 1 } }, "cursor-page-2")
+        } as Response;
+      }
+      if (searchRequestCount === 2) {
+        return {
+          ok: true,
+          json: async () =>
+            buildPayload(["photo-2"], 3, { has_faces: { true: 2, false: 1 } }, "cursor-page-3")
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-3"], 2, { has_faces: { true: 1, false: 1 } }, null)
+      } as Response;
+    });
+
+    renderSearchAt();
+    await user.type(await screen.findByRole("textbox", { name: "Search query" }), "lake");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+    expect(await screen.findByText("photo-2")).toBeInTheDocument();
+    expect(screen.getByText("Page 2")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "With faces (2)" }));
+    expect(await screen.findByText("photo-3")).toBeInTheDocument();
+    expect(screen.getByText("Page 1")).toBeInTheDocument();
+
+    const filterChangeRequest = searchCalls(fetchMock)[2]?.[1] as RequestInit;
+    expect(JSON.parse(String(filterChangeRequest.body)).page).toEqual({ limit: 24, cursor: null });
+  });
+
+  it("deterministically falls back to page one when a page boundary is invalid", async () => {
+    const user = userEvent.setup();
+    let searchRequestCount = 0;
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === PEOPLE_ENDPOINT) {
+        return {
+          ok: true,
+          json: async () => PEOPLE_FIXTURE
+        } as Response;
+      }
+
+      searchRequestCount += 1;
+      if (searchRequestCount === 1) {
+        return {
+          ok: true,
+          json: async () => buildPayload(["photo-1"], 1, {}, "cursor-page-2")
+        } as Response;
+      }
+      if (searchRequestCount === 2) {
+        return {
+          ok: true,
+          json: async () => buildPayload([], 1, {}, null)
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-1"], 1, {}, "cursor-page-2")
+      } as Response;
+    });
+
+    renderSearchAt();
+    await user.type(await screen.findByRole("textbox", { name: "Search query" }), "lake");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(await screen.findByText("Reset to page 1 because that page position is unavailable.")).toBeInTheDocument();
+    expect(screen.getByText("Page 1")).toBeInTheDocument();
+
+    const fallbackRequest = searchCalls(fetchMock)[2]?.[1] as RequestInit;
+    expect(JSON.parse(String(fallbackRequest.body)).page).toEqual({ limit: 24, cursor: null });
   });
 
   it("shows retry UI on failure and retries with active chips", async () => {

--- a/apps/ui/src/pages/SearchRoutePage.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.tsx
@@ -39,8 +39,11 @@ type PersonRecord = {
   display_name: string;
 };
 
-const DEFAULT_SORT = { by: "shot_ts", dir: "desc" } as const;
-const DEFAULT_PAGE = { limit: 24, cursor: null } as const;
+type SortDirection = "asc" | "desc";
+
+const DEFAULT_SORT_DIRECTION: SortDirection = "desc";
+const PAGE_LIMIT = 24;
+const INVALID_PAGE_MESSAGE = "Reset to page 1 because that page position is unavailable.";
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 type SearchUrlState = {
@@ -268,7 +271,9 @@ async function fetchSearchResults(
   selectedPersonNames: string[],
   locationRadius: { latitude: number; longitude: number; radius_km: number } | null,
   hasFaces: boolean | null,
-  pathHints: string[]
+  pathHints: string[],
+  sortDirection: SortDirection,
+  cursor: string | null
 ): Promise<SearchResponsePayload> {
   const searchFilters = buildSearchFilters(
     fromDate,
@@ -286,8 +291,14 @@ async function fetchSearchResults(
     body: JSON.stringify({
       q: query,
       ...(searchFilters ? { filters: searchFilters } : {}),
-      sort: DEFAULT_SORT,
-      page: DEFAULT_PAGE
+      sort: {
+        by: "shot_ts",
+        dir: sortDirection
+      },
+      page: {
+        limit: PAGE_LIMIT,
+        cursor
+      }
     })
   });
 
@@ -325,6 +336,11 @@ export function SearchRoutePage() {
   const [facetPathHintCounts, setFacetPathHintCounts] = useState<FacetCountEntry[]>([]);
   const [results, setResults] = useState<SearchPhoto[]>([]);
   const [totalCount, setTotalCount] = useState(0);
+  const [sortDirection, setSortDirection] = useState<SortDirection>(DEFAULT_SORT_DIRECTION);
+  const [page, setPage] = useState(1);
+  const [cursorByPage, setCursorByPage] = useState<Record<number, string | null>>({ 1: null });
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [paginationMessage, setPaginationMessage] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasRequested, setHasRequested] = useState(false);
@@ -410,6 +426,11 @@ export function SearchRoutePage() {
     setIsLoading(false);
     setError(null);
     setHasRequested(false);
+    setSortDirection(DEFAULT_SORT_DIRECTION);
+    setPage(1);
+    setCursorByPage({ 1: null });
+    setNextCursor(null);
+    setPaginationMessage(null);
     setResults([]);
     setTotalCount(0);
     setFacetHasFacesCounts({ true: 0, false: 0 });
@@ -472,7 +493,10 @@ export function SearchRoutePage() {
     activePersonNames: string[],
     activeLocationRadius: { latitude: number; longitude: number; radius_km: number } | null,
     activeHasFaces: boolean | null,
-    activePathHints: string[]
+    activePathHints: string[],
+    activeSortDirection: SortDirection,
+    activePage: number,
+    activeCursorByPage: Record<number, string | null>
   ) {
     if (validateDateRange(activeFromDate, activeToDate)) {
       return;
@@ -481,8 +505,35 @@ export function SearchRoutePage() {
     setIsLoading(true);
     setError(null);
     setHasRequested(true);
+    setPaginationMessage(null);
 
     try {
+      const cursor = activeCursorByPage[activePage];
+      if (activePage > 1 && cursor === undefined) {
+        setPaginationMessage(INVALID_PAGE_MESSAGE);
+        const resetCursors = { 1: null };
+        setPage(1);
+        setCursorByPage(resetCursors);
+        const resetPayload = await fetchSearchResults(
+          chips.join(" "),
+          activeFromDate,
+          activeToDate,
+          activePersonNames,
+          activeLocationRadius,
+          activeHasFaces,
+          activePathHints,
+          activeSortDirection,
+          null
+        );
+        setResults(resetPayload.hits.items);
+        setTotalCount(resetPayload.hits.total);
+        setNextCursor(resetPayload.hits.cursor);
+        setFacetHasFacesCounts(parseHasFacesFacetCounts(resetPayload.facets));
+        setFacetPathHintCounts(toPathHintFacetCounts(resetPayload.facets, activePathHints));
+        setCursorByPage({ 1: null, ...(resetPayload.hits.cursor ? { 2: resetPayload.hits.cursor } : {}) });
+        return;
+      }
+
       const payload = await fetchSearchResults(
         chips.join(" "),
         activeFromDate,
@@ -490,12 +541,50 @@ export function SearchRoutePage() {
         activePersonNames,
         activeLocationRadius,
         activeHasFaces,
-        activePathHints
+        activePathHints,
+        activeSortDirection,
+        cursor ?? null
       );
+      if (activePage > 1 && payload.hits.items.length === 0) {
+        setPaginationMessage(INVALID_PAGE_MESSAGE);
+        const resetCursors = { 1: null };
+        setPage(1);
+        setCursorByPage(resetCursors);
+        const resetPayload = await fetchSearchResults(
+          chips.join(" "),
+          activeFromDate,
+          activeToDate,
+          activePersonNames,
+          activeLocationRadius,
+          activeHasFaces,
+          activePathHints,
+          activeSortDirection,
+          null
+        );
+        setResults(resetPayload.hits.items);
+        setTotalCount(resetPayload.hits.total);
+        setNextCursor(resetPayload.hits.cursor);
+        setFacetHasFacesCounts(parseHasFacesFacetCounts(resetPayload.facets));
+        setFacetPathHintCounts(toPathHintFacetCounts(resetPayload.facets, activePathHints));
+        setCursorByPage({ 1: null, ...(resetPayload.hits.cursor ? { 2: resetPayload.hits.cursor } : {}) });
+        return;
+      }
       setResults(payload.hits.items);
       setTotalCount(payload.hits.total);
+      setPage(activePage);
+      setNextCursor(payload.hits.cursor);
       setFacetHasFacesCounts(parseHasFacesFacetCounts(payload.facets));
       setFacetPathHintCounts(toPathHintFacetCounts(payload.facets, activePathHints));
+      setCursorByPage((current) => {
+        const pageCursor = activeCursorByPage[activePage];
+        const next = { ...current, ...activeCursorByPage, [activePage]: pageCursor ?? null };
+        if (payload.hits.cursor === null) {
+          delete next[activePage + 1];
+        } else {
+          next[activePage + 1] = payload.hits.cursor;
+        }
+        return next;
+      });
     } catch (caughtError: unknown) {
       const message =
         caughtError instanceof Error
@@ -504,6 +593,7 @@ export function SearchRoutePage() {
       setError(message);
       setResults([]);
       setTotalCount(0);
+      setNextCursor(null);
       setFacetHasFacesCounts({ true: 0, false: 0 });
       setFacetPathHintCounts(
         activePathHints.map((value) => ({
@@ -524,7 +614,23 @@ export function SearchRoutePage() {
     locationRadius?: { latitude: number; longitude: number; radius_km: number } | null;
     hasFaces?: boolean | null;
     pathHints?: string[];
+    sortDirection?: SortDirection;
+    page?: number;
+    cursorByPage?: Record<number, string | null>;
+    resetToFirstPage?: boolean;
   } = {}) {
+    const shouldResetToFirstPage = overrides.resetToFirstPage ?? false;
+    const resolvedPage = shouldResetToFirstPage ? 1 : (overrides.page ?? page);
+    const resolvedCursorByPage = shouldResetToFirstPage
+      ? { 1: null }
+      : (overrides.cursorByPage ?? cursorByPage);
+
+    if (shouldResetToFirstPage) {
+      setPage(1);
+      setCursorByPage({ 1: null });
+      setNextCursor(null);
+    }
+
     void runSearch(
       overrides.chips ?? queryChips,
       overrides.fromDate ?? fromDate,
@@ -532,7 +638,10 @@ export function SearchRoutePage() {
       overrides.personNames ?? selectedPersonNames,
       overrides.locationRadius === undefined ? locationRadiusFilter : overrides.locationRadius,
       overrides.hasFaces === undefined ? hasFacesFilter : overrides.hasFaces,
-      overrides.pathHints ?? pathHintFilters
+      overrides.pathHints ?? pathHintFilters,
+      overrides.sortDirection ?? sortDirection,
+      resolvedPage,
+      resolvedCursorByPage
     );
   }
 
@@ -561,23 +670,23 @@ export function SearchRoutePage() {
       setDraftQuery("");
     }
 
-    requestSearch({ chips: nextChips });
+    requestSearch({ chips: nextChips, resetToFirstPage: true });
   }
 
   function handleDismissChip(indexToRemove: number) {
     const nextChips = queryChips.filter((_, index) => index !== indexToRemove);
     setQueryChips(nextChips);
-    requestSearch({ chips: nextChips });
+    requestSearch({ chips: nextChips, resetToFirstPage: true });
   }
 
   function handleClearFromDate() {
     setFromDate("");
-    requestSearch({ fromDate: "" });
+    requestSearch({ fromDate: "", resetToFirstPage: true });
   }
 
   function handleClearToDate() {
     setToDate("");
-    requestSearch({ toDate: "" });
+    requestSearch({ toDate: "", resetToFirstPage: true });
   }
 
   function handleAddPersonByName(displayName: string) {
@@ -615,7 +724,7 @@ export function SearchRoutePage() {
     const nextNames = selectedPersonNames.filter((name) => name !== displayName);
     setSelectedPersonNames(nextNames);
     setPersonMessage(null);
-    requestSearch({ personNames: nextNames });
+    requestSearch({ personNames: nextNames, resetToFirstPage: true });
   }
 
   function handleMapLocationChange(location: LocationRadiusValue) {
@@ -629,13 +738,13 @@ export function SearchRoutePage() {
     setLatitudeDraft("");
     setLongitudeDraft("");
     setRadiusDraft("");
-    requestSearch({ locationRadius: null });
+    requestSearch({ locationRadius: null, resetToFirstPage: true });
   }
 
   function handleToggleHasFacesFilter(nextValue: boolean) {
     const resolvedValue = hasFacesFilter === nextValue ? null : nextValue;
     setHasFacesFilter(resolvedValue);
-    requestSearch({ hasFaces: resolvedValue });
+    requestSearch({ hasFaces: resolvedValue, resetToFirstPage: true });
   }
 
   function handleClearHasFacesFilter() {
@@ -644,7 +753,7 @@ export function SearchRoutePage() {
     }
 
     setHasFacesFilter(null);
-    requestSearch({ hasFaces: null });
+    requestSearch({ hasFaces: null, resetToFirstPage: true });
   }
 
   function handleTogglePathHintFilter(pathHint: string) {
@@ -653,7 +762,7 @@ export function SearchRoutePage() {
       : normalizePathHintFilters([...pathHintFilters, pathHint]);
 
     setPathHintFilters(nextHints);
-    requestSearch({ pathHints: nextHints });
+    requestSearch({ pathHints: nextHints, resetToFirstPage: true });
   }
 
   function handleClearPathHintFilter(pathHint: string) {
@@ -663,7 +772,7 @@ export function SearchRoutePage() {
     }
 
     setPathHintFilters(nextHints);
-    requestSearch({ pathHints: nextHints });
+    requestSearch({ pathHints: nextHints, resetToFirstPage: true });
   }
 
   function handleClearAllPathHints() {
@@ -672,7 +781,44 @@ export function SearchRoutePage() {
     }
 
     setPathHintFilters([]);
-    requestSearch({ pathHints: [] });
+    requestSearch({ pathHints: [], resetToFirstPage: true });
+  }
+
+  function handleSortDirectionChange(nextDirection: SortDirection) {
+    setSortDirection(nextDirection);
+    if (!hasRequested) {
+      return;
+    }
+
+    requestSearch({
+      sortDirection: nextDirection,
+      resetToFirstPage: true
+    });
+  }
+
+  function handlePreviousPage() {
+    if (isLoading || page <= 1) {
+      return;
+    }
+
+    requestSearch({
+      page: page - 1
+    });
+  }
+
+  function handleNextPage() {
+    if (isLoading || nextCursor === null) {
+      return;
+    }
+
+    const nextPage = page + 1;
+    requestSearch({
+      page: nextPage,
+      cursorByPage: {
+        ...cursorByPage,
+        [nextPage]: nextCursor
+      }
+    });
   }
 
   function handleRetry() {
@@ -681,7 +827,7 @@ export function SearchRoutePage() {
 
   const summaryLabel = useMemo(() => {
     if (isLoading) {
-      return "Loading search workflow.";
+      return `Loading page ${page}…`;
     }
 
     if (error) {
@@ -695,11 +841,50 @@ export function SearchRoutePage() {
     return `Showing ${results.length} of ${totalCount} photos`;
   }, [error, hasRequested, isLoading, results.length, totalCount]);
 
+  const canGoPrevious = hasRequested && page > 1 && !isLoading;
+  const canGoNext = hasRequested && nextCursor !== null && !isLoading;
+
   return (
     <section aria-labelledby="page-title" className="page search-page">
-      <div>
-        <h1 id="page-title">Search</h1>
-        <p>Tokenized phrase chips and inclusive date range filters with deterministic request state.</p>
+      <div className="search-header">
+        <div>
+          <h1 id="page-title">Search</h1>
+          <p>Tokenized phrase chips and inclusive date range filters with deterministic request state.</p>
+        </div>
+        <div className="search-controls" role="group" aria-label="Search controls">
+          <label className="search-sort-control">
+            Sort order
+            <select
+              aria-label="Sort order"
+              value={sortDirection}
+              onChange={(event) =>
+                handleSortDirectionChange(event.target.value === "asc" ? "asc" : "desc")
+              }
+            >
+              <option value="desc">Newest first</option>
+              <option value="asc">Oldest first</option>
+            </select>
+          </label>
+          <div className="search-pagination" aria-label="Pagination controls">
+            <button
+              type="button"
+              onClick={handlePreviousPage}
+              disabled={!canGoPrevious}
+              aria-label="Previous page"
+            >
+              Previous
+            </button>
+            <p className="search-page-indicator">Page {page}</p>
+            <button
+              type="button"
+              onClick={handleNextPage}
+              disabled={!canGoNext}
+              aria-label="Next page"
+            >
+              Next
+            </button>
+          </div>
+        </div>
       </div>
 
       <form className="search-query-form" onSubmit={handleSubmit}>
@@ -951,6 +1136,11 @@ export function SearchRoutePage() {
       <p id="search-query-summary" className="search-summary" aria-live="polite">
         {summaryLabel}
       </p>
+      {paginationMessage ? (
+        <p className="search-pagination-message" role="status">
+          {paginationMessage}
+        </p>
+      ) : null}
 
       {isLoading ? (
         <div className="feedback-panel feedback-panel-loading" role="status" aria-live="polite">

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -627,6 +627,62 @@ body {
   gap: 0.9rem;
 }
 
+.search-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.search-controls {
+  display: grid;
+  gap: 0.6rem;
+  justify-items: end;
+}
+
+.search-sort-control {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: #1e293b;
+}
+
+.search-sort-control select {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  padding: 0.3rem 0.4rem;
+  background: #ffffff;
+  color: #0f172a;
+  font: inherit;
+}
+
+.search-pagination {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.search-pagination button {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.35rem 0.55rem;
+  font: inherit;
+}
+
+.search-pagination button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.search-page-indicator {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #1e293b;
+}
+
 .search-query-form {
   display: grid;
   gap: 0.35rem;
@@ -861,6 +917,12 @@ body {
   color: #475569;
 }
 
+.search-pagination-message {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #92400e;
+}
+
 .search-results {
   margin: 0;
   padding: 0;
@@ -965,6 +1027,10 @@ body {
   }
 
   .browse-controls {
+    justify-items: start;
+  }
+
+  .search-controls {
     justify-items: start;
   }
 


### PR DESCRIPTION
## Summary
- add deterministic sort control for Search (`Newest first` / `Oldest first`) mapped to backend `shot_ts` direction
- add cursor-based Search pagination controls with stable page/cursor state
- reset Search pagination to page 1 when query/filter/sort state changes
- handle invalid-page outcomes deterministically by falling back to page 1 with explicit user feedback
- add and update SearchRoutePage tests for sort mapping, cursor boundaries, reset behavior, and invalid-page fallback

## Verification
- `npm --prefix apps/ui test -- src/pages/SearchRoutePage.test.tsx`

Closes #180