### PR TITLE
feat(ui): implement issue #181 search result state messaging

### DIFF
--- a/apps/ui/src/pages/SearchRoutePage.test.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.test.tsx
@@ -496,6 +496,46 @@ describe("SearchRoutePage", () => {
     expect(await screen.findByText("photo-1")).toBeInTheDocument();
   });
 
+  it("retries with the exact last failed request payload even after draft edits", async () => {
+    const user = userEvent.setup();
+    let searchRequestCount = 0;
+
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === PEOPLE_ENDPOINT) {
+        return {
+          ok: true,
+          json: async () => PEOPLE_FIXTURE
+        } as Response;
+      }
+
+      searchRequestCount += 1;
+      if (searchRequestCount === 1) {
+        return { ok: false, status: 503 } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-1"], 1)
+      } as Response;
+    });
+
+    renderSearchAt();
+
+    const queryInput = await screen.findByRole("textbox", { name: "Search query" });
+    await user.type(queryInput, "storm coast");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await screen.findByRole("heading", { name: "Could not load Search", level: 2 });
+
+    await user.type(queryInput, " replacement draft");
+    await user.type(screen.getByLabelText("From date"), "2026-04-01");
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    const body = lastSearchBody(fetchMock);
+    expect(body.q).toBe("storm coast");
+    expect(body.filters).toBeUndefined();
+  });
+
   it("adds a fuzzy-matched person filter and submits it as filters.person_names", async () => {
     const user = userEvent.setup();
     renderSearchAt();
@@ -547,6 +587,19 @@ describe("SearchRoutePage", () => {
     const body = lastSearchBody(fetchMock);
     expect(body.q).toBe("coast");
     expect(body.filters).toBeUndefined();
+  });
+
+  it("renders baseline empty state when zero hits are returned without active query filters", async () => {
+    const user = userEvent.setup();
+    renderSearchAt();
+
+    const input = await screen.findByRole("textbox", { name: "Search query" });
+    await user.type(input, "lake");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+    await user.click(screen.getByRole("button", { name: "Remove query lake" }));
+
+    expect(await screen.findByText("No photos are available in the catalog yet.")).toBeInTheDocument();
+    expect(screen.queryByText("No matching photos for the active query.")).not.toBeInTheDocument();
   });
 
   it("removes selected person chips and re-fetches without person_names filters", async () => {

--- a/apps/ui/src/pages/SearchRoutePage.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.tsx
@@ -59,6 +59,30 @@ type SearchUrlState = {
   pathHintFilters: string[];
 };
 
+type SearchRequestSnapshot = {
+  chips: string[];
+  fromDate: string;
+  toDate: string;
+  personNames: string[];
+  locationRadius: { latitude: number; longitude: number; radius_km: number } | null;
+  hasFaces: boolean | null;
+  pathHints: string[];
+  sortDirection: SortDirection;
+  page: number;
+  cursorByPage: Record<number, string | null>;
+};
+
+function hasActiveSearchCriteria(snapshot: SearchRequestSnapshot): boolean {
+  return (
+    snapshot.chips.length > 0 ||
+    Boolean(snapshot.fromDate || snapshot.toDate) ||
+    snapshot.personNames.length > 0 ||
+    snapshot.locationRadius !== null ||
+    snapshot.hasFaces !== null ||
+    snapshot.pathHints.length > 0
+  );
+}
+
 function dedupeTrimmedValues(values: string[]): string[] {
   const seen = new Set<string>();
   const deduped: string[] = [];
@@ -344,6 +368,8 @@ export function SearchRoutePage() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasRequested, setHasRequested] = useState(false);
+  const [lastFailedRequest, setLastFailedRequest] = useState<SearchRequestSnapshot | null>(null);
+  const [lastSuccessfulHadCriteria, setLastSuccessfulHadCriteria] = useState(false);
   const parsedUrlState = useMemo(() => parseSearchUrlState(location.search), [location.search]);
 
   const serializedQuery = useMemo(() => queryChips.join(" "), [queryChips]);
@@ -426,6 +452,8 @@ export function SearchRoutePage() {
     setIsLoading(false);
     setError(null);
     setHasRequested(false);
+    setLastFailedRequest(null);
+    setLastSuccessfulHadCriteria(false);
     setSortDirection(DEFAULT_SORT_DIRECTION);
     setPage(1);
     setCursorByPage({ 1: null });
@@ -486,19 +514,23 @@ export function SearchRoutePage() {
     toDate
   ]);
 
-  async function runSearch(
-    chips: string[],
-    activeFromDate: string,
-    activeToDate: string,
-    activePersonNames: string[],
-    activeLocationRadius: { latitude: number; longitude: number; radius_km: number } | null,
-    activeHasFaces: boolean | null,
-    activePathHints: string[],
-    activeSortDirection: SortDirection,
-    activePage: number,
-    activeCursorByPage: Record<number, string | null>
-  ) {
-    if (validateDateRange(activeFromDate, activeToDate)) {
+  function createSearchSnapshot(snapshot: SearchRequestSnapshot): SearchRequestSnapshot {
+    return {
+      chips: [...snapshot.chips],
+      fromDate: snapshot.fromDate,
+      toDate: snapshot.toDate,
+      personNames: [...snapshot.personNames],
+      locationRadius: snapshot.locationRadius ? { ...snapshot.locationRadius } : null,
+      hasFaces: snapshot.hasFaces,
+      pathHints: [...snapshot.pathHints],
+      sortDirection: snapshot.sortDirection,
+      page: snapshot.page,
+      cursorByPage: { ...snapshot.cursorByPage }
+    };
+  }
+
+  async function runSearch(snapshot: SearchRequestSnapshot) {
+    if (validateDateRange(snapshot.fromDate, snapshot.toDate)) {
       return;
     }
 
@@ -508,80 +540,95 @@ export function SearchRoutePage() {
     setPaginationMessage(null);
 
     try {
-      const cursor = activeCursorByPage[activePage];
-      if (activePage > 1 && cursor === undefined) {
+      const hadCriteria = hasActiveSearchCriteria(snapshot);
+      const cursor = snapshot.cursorByPage[snapshot.page];
+      if (snapshot.page > 1 && cursor === undefined) {
         setPaginationMessage(INVALID_PAGE_MESSAGE);
-        const resetCursors = { 1: null };
+        const resetSnapshot = createSearchSnapshot({
+          ...snapshot,
+          page: 1,
+          cursorByPage: { 1: null }
+        });
         setPage(1);
-        setCursorByPage(resetCursors);
+        setCursorByPage(resetSnapshot.cursorByPage);
         const resetPayload = await fetchSearchResults(
-          chips.join(" "),
-          activeFromDate,
-          activeToDate,
-          activePersonNames,
-          activeLocationRadius,
-          activeHasFaces,
-          activePathHints,
-          activeSortDirection,
+          resetSnapshot.chips.join(" "),
+          resetSnapshot.fromDate,
+          resetSnapshot.toDate,
+          resetSnapshot.personNames,
+          resetSnapshot.locationRadius,
+          resetSnapshot.hasFaces,
+          resetSnapshot.pathHints,
+          resetSnapshot.sortDirection,
           null
         );
         setResults(resetPayload.hits.items);
         setTotalCount(resetPayload.hits.total);
         setNextCursor(resetPayload.hits.cursor);
+        setLastFailedRequest(null);
+        setLastSuccessfulHadCriteria(hasActiveSearchCriteria(resetSnapshot));
         setFacetHasFacesCounts(parseHasFacesFacetCounts(resetPayload.facets));
-        setFacetPathHintCounts(toPathHintFacetCounts(resetPayload.facets, activePathHints));
+        setFacetPathHintCounts(toPathHintFacetCounts(resetPayload.facets, resetSnapshot.pathHints));
         setCursorByPage({ 1: null, ...(resetPayload.hits.cursor ? { 2: resetPayload.hits.cursor } : {}) });
         return;
       }
 
       const payload = await fetchSearchResults(
-        chips.join(" "),
-        activeFromDate,
-        activeToDate,
-        activePersonNames,
-        activeLocationRadius,
-        activeHasFaces,
-        activePathHints,
-        activeSortDirection,
+        snapshot.chips.join(" "),
+        snapshot.fromDate,
+        snapshot.toDate,
+        snapshot.personNames,
+        snapshot.locationRadius,
+        snapshot.hasFaces,
+        snapshot.pathHints,
+        snapshot.sortDirection,
         cursor ?? null
       );
-      if (activePage > 1 && payload.hits.items.length === 0) {
+      if (snapshot.page > 1 && payload.hits.items.length === 0) {
         setPaginationMessage(INVALID_PAGE_MESSAGE);
-        const resetCursors = { 1: null };
+        const resetSnapshot = createSearchSnapshot({
+          ...snapshot,
+          page: 1,
+          cursorByPage: { 1: null }
+        });
         setPage(1);
-        setCursorByPage(resetCursors);
+        setCursorByPage(resetSnapshot.cursorByPage);
         const resetPayload = await fetchSearchResults(
-          chips.join(" "),
-          activeFromDate,
-          activeToDate,
-          activePersonNames,
-          activeLocationRadius,
-          activeHasFaces,
-          activePathHints,
-          activeSortDirection,
+          resetSnapshot.chips.join(" "),
+          resetSnapshot.fromDate,
+          resetSnapshot.toDate,
+          resetSnapshot.personNames,
+          resetSnapshot.locationRadius,
+          resetSnapshot.hasFaces,
+          resetSnapshot.pathHints,
+          resetSnapshot.sortDirection,
           null
         );
         setResults(resetPayload.hits.items);
         setTotalCount(resetPayload.hits.total);
         setNextCursor(resetPayload.hits.cursor);
+        setLastFailedRequest(null);
+        setLastSuccessfulHadCriteria(hasActiveSearchCriteria(resetSnapshot));
         setFacetHasFacesCounts(parseHasFacesFacetCounts(resetPayload.facets));
-        setFacetPathHintCounts(toPathHintFacetCounts(resetPayload.facets, activePathHints));
+        setFacetPathHintCounts(toPathHintFacetCounts(resetPayload.facets, resetSnapshot.pathHints));
         setCursorByPage({ 1: null, ...(resetPayload.hits.cursor ? { 2: resetPayload.hits.cursor } : {}) });
         return;
       }
       setResults(payload.hits.items);
       setTotalCount(payload.hits.total);
-      setPage(activePage);
+      setPage(snapshot.page);
       setNextCursor(payload.hits.cursor);
+      setLastFailedRequest(null);
+      setLastSuccessfulHadCriteria(hadCriteria);
       setFacetHasFacesCounts(parseHasFacesFacetCounts(payload.facets));
-      setFacetPathHintCounts(toPathHintFacetCounts(payload.facets, activePathHints));
+      setFacetPathHintCounts(toPathHintFacetCounts(payload.facets, snapshot.pathHints));
       setCursorByPage((current) => {
-        const pageCursor = activeCursorByPage[activePage];
-        const next = { ...current, ...activeCursorByPage, [activePage]: pageCursor ?? null };
+        const pageCursor = snapshot.cursorByPage[snapshot.page];
+        const next = { ...current, ...snapshot.cursorByPage, [snapshot.page]: pageCursor ?? null };
         if (payload.hits.cursor === null) {
-          delete next[activePage + 1];
+          delete next[snapshot.page + 1];
         } else {
-          next[activePage + 1] = payload.hits.cursor;
+          next[snapshot.page + 1] = payload.hits.cursor;
         }
         return next;
       });
@@ -591,12 +638,13 @@ export function SearchRoutePage() {
           ? caughtError.message
           : "Could not load search results.";
       setError(message);
+      setLastFailedRequest(createSearchSnapshot(snapshot));
       setResults([]);
       setTotalCount(0);
       setNextCursor(null);
       setFacetHasFacesCounts({ true: 0, false: 0 });
       setFacetPathHintCounts(
-        activePathHints.map((value) => ({
+        snapshot.pathHints.map((value) => ({
           value,
           count: 0
         }))
@@ -631,18 +679,21 @@ export function SearchRoutePage() {
       setNextCursor(null);
     }
 
-    void runSearch(
-      overrides.chips ?? queryChips,
-      overrides.fromDate ?? fromDate,
-      overrides.toDate ?? toDate,
-      overrides.personNames ?? selectedPersonNames,
-      overrides.locationRadius === undefined ? locationRadiusFilter : overrides.locationRadius,
-      overrides.hasFaces === undefined ? hasFacesFilter : overrides.hasFaces,
-      overrides.pathHints ?? pathHintFilters,
-      overrides.sortDirection ?? sortDirection,
-      resolvedPage,
-      resolvedCursorByPage
-    );
+    const snapshot = createSearchSnapshot({
+      chips: overrides.chips ?? queryChips,
+      fromDate: overrides.fromDate ?? fromDate,
+      toDate: overrides.toDate ?? toDate,
+      personNames: overrides.personNames ?? selectedPersonNames,
+      locationRadius:
+        overrides.locationRadius === undefined ? locationRadiusFilter : overrides.locationRadius,
+      hasFaces: overrides.hasFaces === undefined ? hasFacesFilter : overrides.hasFaces,
+      pathHints: overrides.pathHints ?? pathHintFilters,
+      sortDirection: overrides.sortDirection ?? sortDirection,
+      page: resolvedPage,
+      cursorByPage: resolvedCursorByPage
+    });
+
+    void runSearch(snapshot);
   }
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -822,8 +873,28 @@ export function SearchRoutePage() {
   }
 
   function handleRetry() {
+    if (lastFailedRequest) {
+      void runSearch(lastFailedRequest);
+      return;
+    }
     requestSearch();
   }
+
+  const resultViewState = useMemo(() => {
+    if (isLoading) {
+      return "loading";
+    }
+    if (error) {
+      return "error";
+    }
+    if (!hasRequested) {
+      return "idle";
+    }
+    if (results.length > 0) {
+      return "results";
+    }
+    return lastSuccessfulHadCriteria ? "no_match" : "empty";
+  }, [error, hasRequested, isLoading, lastSuccessfulHadCriteria, results.length]);
 
   const summaryLabel = useMemo(() => {
     if (isLoading) {
@@ -1142,13 +1213,13 @@ export function SearchRoutePage() {
         </p>
       ) : null}
 
-      {isLoading ? (
+      {resultViewState === "loading" ? (
         <div className="feedback-panel feedback-panel-loading" role="status" aria-live="polite">
           Loading search workflow.
         </div>
       ) : null}
 
-      {error ? (
+      {resultViewState === "error" ? (
         <div className="feedback-panel feedback-panel-error">
           <h2>Could not load Search</h2>
           <p>{error}</p>
@@ -1158,13 +1229,19 @@ export function SearchRoutePage() {
         </div>
       ) : null}
 
-      {!error && !isLoading && hasRequested && results.length === 0 ? (
+      {resultViewState === "empty" ? (
+        <div className="feedback-panel">
+          <p>No photos are available in the catalog yet.</p>
+        </div>
+      ) : null}
+
+      {resultViewState === "no_match" ? (
         <div className="feedback-panel">
           <p>No matching photos for the active query.</p>
         </div>
       ) : null}
 
-      {!error && !isLoading && results.length > 0 ? (
+      {resultViewState === "results" ? (
         <ol className="search-results" aria-label="Search results">
           {results.map((photo) => (
             <li key={photo.photo_id}>

--- a/docs/superpowers/plans/2026-04-30-issue-181-search-result-state-messaging.md
+++ b/docs/superpowers/plans/2026-04-30-issue-181-search-result-state-messaging.md
@@ -1,0 +1,219 @@
+# Issue #181 Search Result State Messaging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement explicit `/search` empty vs no-match vs error messaging with deterministic retry replay and preserved filter context.
+
+**Architecture:** Keep behavior local to `SearchRoutePage` by introducing derived result-state classification and immutable request snapshots for retry replay. Avoid backend/schema changes and keep existing query/filter URL sync model unchanged.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library
+
+---
+
+### Task 1: Lock issue #181 behavior with failing UI tests
+
+**Files:**
+- Modify: `apps/ui/src/pages/SearchRoutePage.test.tsx`
+
+- [ ] **Step 1: Add failing test for baseline empty state distinct from no-match**
+
+```tsx
+it("renders baseline empty state when zero hits are returned without active query filters", async () => {
+  const user = userEvent.setup();
+  let searchRequestCount = 0;
+
+  fetchMock.mockImplementation(async (input: string) => {
+    if (input === PEOPLE_ENDPOINT) {
+      return { ok: true, json: async () => PEOPLE_FIXTURE } as Response;
+    }
+    searchRequestCount += 1;
+    return {
+      ok: true,
+      json: async () => buildPayload([], 0)
+    } as Response;
+  });
+
+  renderSearchAt();
+
+  const input = await screen.findByRole("textbox", { name: "Search query" });
+  await user.type(input, "lake");
+  await user.click(screen.getByRole("button", { name: "Search" }));
+  await user.click(screen.getByRole("button", { name: "Remove query lake" }));
+
+  expect(await screen.findByText("No photos are available in the catalog yet.")).toBeInTheDocument();
+  expect(screen.queryByText("No matching photos for the active query.")).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Add failing test that Retry replays exact failed payload snapshot**
+
+```tsx
+it("retries with the exact last failed request payload even after draft edits", async () => {
+  const user = userEvent.setup();
+  let searchRequestCount = 0;
+
+  fetchMock.mockImplementation(async (input: string) => {
+    if (input === PEOPLE_ENDPOINT) {
+      return { ok: true, json: async () => PEOPLE_FIXTURE } as Response;
+    }
+
+    searchRequestCount += 1;
+    if (searchRequestCount === 1) {
+      return { ok: false, status: 503 } as Response;
+    }
+
+    return {
+      ok: true,
+      json: async () => buildPayload(["photo-1"], 1)
+    } as Response;
+  });
+
+  renderSearchAt();
+
+  const queryInput = await screen.findByRole("textbox", { name: "Search query" });
+  await user.type(queryInput, "storm coast");
+  await user.click(screen.getByRole("button", { name: "Search" }));
+  await screen.findByRole("heading", { name: "Could not load Search", level: 2 });
+
+  await user.type(queryInput, " replacement draft");
+  await user.type(screen.getByLabelText("From date"), "2026-04-01");
+
+  await user.click(screen.getByRole("button", { name: "Retry" }));
+
+  const body = lastSearchBody(fetchMock);
+  expect(body.q).toBe("storm coast");
+  expect(body.filters).toBeUndefined();
+});
+```
+
+- [ ] **Step 3: Run focused tests and verify they fail for expected reason**
+
+Run: `npm --prefix apps/ui test -- src/pages/SearchRoutePage.test.tsx -t "baseline empty state|exact last failed request payload"`
+
+Expected: FAIL because current component has one generic zero-result message and retry reads live current state rather than frozen failed snapshot.
+
+- [ ] **Step 4: Commit failing test changes**
+
+```bash
+git add apps/ui/src/pages/SearchRoutePage.test.tsx
+git commit -m "test(ui): lock search result state messaging and retry replay behavior"
+```
+
+### Task 2: Implement result-state classification and deterministic retry snapshot
+
+**Files:**
+- Modify: `apps/ui/src/pages/SearchRoutePage.tsx`
+- Test: `apps/ui/src/pages/SearchRoutePage.test.tsx`
+
+- [ ] **Step 1: Add request snapshot and active-criteria helpers in SearchRoutePage**
+
+```tsx
+type SearchRequestSnapshot = {
+  chips: string[];
+  fromDate: string;
+  toDate: string;
+  personNames: string[];
+  locationRadius: { latitude: number; longitude: number; radius_km: number } | null;
+  hasFaces: boolean | null;
+  pathHints: string[];
+  sortDirection: SortDirection;
+  page: number;
+  cursorByPage: Record<number, string | null>;
+};
+
+function hasActiveSearchCriteria(snapshot: SearchRequestSnapshot): boolean {
+  return (
+    snapshot.chips.length > 0 ||
+    Boolean(snapshot.fromDate || snapshot.toDate) ||
+    snapshot.personNames.length > 0 ||
+    snapshot.locationRadius !== null ||
+    snapshot.hasFaces !== null ||
+    snapshot.pathHints.length > 0
+  );
+}
+```
+
+- [ ] **Step 2: Refactor request execution to run from immutable snapshot and store failed snapshot**
+
+```tsx
+const [lastFailedRequest, setLastFailedRequest] = useState<SearchRequestSnapshot | null>(null);
+const [lastSuccessfulHadCriteria, setLastSuccessfulHadCriteria] = useState(false);
+
+function handleRetry() {
+  if (lastFailedRequest) {
+    void runSearch(lastFailedRequest);
+    return;
+  }
+  requestSearch();
+}
+```
+
+- [ ] **Step 3: Set success/error state transitions and render empty vs no-match messaging**
+
+```tsx
+const resultViewState = useMemo(() => {
+  if (isLoading) return "loading";
+  if (error) return "error";
+  if (!hasRequested) return "idle";
+  if (results.length > 0) return "results";
+  return lastSuccessfulHadCriteria ? "no_match" : "empty";
+}, [error, hasRequested, isLoading, lastSuccessfulHadCriteria, results.length]);
+```
+
+```tsx
+{resultViewState === "empty" ? (
+  <div className="feedback-panel">
+    <p>No photos are available in the catalog yet.</p>
+  </div>
+) : null}
+
+{resultViewState === "no_match" ? (
+  <div className="feedback-panel">
+    <p>No matching photos for the active query.</p>
+  </div>
+) : null}
+```
+
+- [ ] **Step 4: Run focused test slice and verify it passes**
+
+Run: `npm --prefix apps/ui test -- src/pages/SearchRoutePage.test.tsx -t "baseline empty state|exact last failed request payload|loading status while the search request is pending|shows retry UI on failure and retries with active chips"`
+
+Expected: PASS with distinct empty/no-match messaging and retry payload replay locked.
+
+- [ ] **Step 5: Commit implementation changes**
+
+```bash
+git add apps/ui/src/pages/SearchRoutePage.tsx apps/ui/src/pages/SearchRoutePage.test.tsx
+git commit -m "feat(ui): add explicit search result states and deterministic retry replay"
+```
+
+### Task 3: Run full search-route verification and finalize issue #181
+
+**Files:**
+- Modify (if needed): `apps/ui/src/pages/SearchRoutePage.tsx`
+- Modify (if needed): `apps/ui/src/pages/SearchRoutePage.test.tsx`
+
+- [ ] **Step 1: Run full SearchRoutePage suite**
+
+Run: `npm --prefix apps/ui test -- src/pages/SearchRoutePage.test.tsx`
+
+Expected: PASS with no regressions in existing query chips, filter payloads, URL sync, pagination behavior.
+
+- [ ] **Step 2: Run broader UI safety check touching search route dependencies**
+
+Run: `npm --prefix apps/ui test -- src/pages/SearchRoutePage.test.tsx src/pages/BrowseRoutePage.test.tsx src/app/AppShell.test.tsx`
+
+Expected: PASS ensuring shared feedback/state patterns remain stable.
+
+- [ ] **Step 3: Inspect diff scope**
+
+Run: `git status --short`
+
+Expected: only `SearchRoutePage` and its test updates related to issue `#181`.
+
+- [ ] **Step 4: Commit final polish if additional edits were required**
+
+```bash
+git add apps/ui/src/pages/SearchRoutePage.tsx apps/ui/src/pages/SearchRoutePage.test.tsx
+git commit -m "test(ui): verify search result messaging state transitions"
+```

--- a/docs/superpowers/specs/2026-04-30-issue-181-search-result-state-messaging-design.md
+++ b/docs/superpowers/specs/2026-04-30-issue-181-search-result-state-messaging-design.md
@@ -1,0 +1,121 @@
+# Issue #181 Search Result State Messaging Design
+
+## Summary
+
+Issue `#181` implements explicit, deterministic messaging patterns for search result states on `/search`:
+
+- empty results for baseline searches
+- no-match results for active query/filter searches
+- hard-error result states with deterministic retry behavior
+
+The scope is strictly UI-side behavior on top of existing `/api/v1/search` contracts.
+
+## Goals
+
+- Visually and semantically distinguish empty, no-match, loading, and hard-error states.
+- Ensure retry always replays the exact last failed request payload.
+- Preserve active query/filter context while messaging changes.
+
+## Non-Goals
+
+- backend exception taxonomy changes
+- operator diagnostics or failure dashboards
+- broad route-state architecture refactors outside search-result messaging
+
+## Current State
+
+`SearchRoutePage` currently renders:
+
+- loading panel while requests are pending
+- one generic zero-result message for all successful empty responses
+- blocking error panel with Retry button
+
+Gaps relative to `#181`:
+
+- zero-result messaging does not distinguish baseline empty catalog vs active-filter no-match
+- retry currently reuses live form state instead of a frozen request snapshot
+- message semantics are not framed as explicit result-state patterns
+
+## Design
+
+### 1) Explicit search result state classification
+
+Keep state orchestration in `SearchRoutePage`, but compute a derived result-state classification after each request cycle:
+
+- `loading`: request in flight
+- `error`: last request failed
+- `empty`: last successful request returned `0` hits and request had no active query/filters
+- `no_match`: last successful request returned `0` hits and request had active query and/or filters
+- `results`: last successful request returned one or more hits
+
+This is a UI-level derived state; no backend payload changes are required.
+
+### 2) Deterministic retry snapshot
+
+Capture a request snapshot before each search execution:
+
+- `chips`/serialized query
+- date/person/location/has-faces/path-hint filters
+- sort direction
+- page and `cursorByPage`
+
+If request fails, Retry replays that exact snapshot. It does not pull potentially edited draft values from current input controls.
+
+### 3) Messaging behavior
+
+Result-state panels should behave as:
+
+- `loading`: existing loading panel copy remains.
+- `error`: existing blocking panel remains with `Retry`; body text remains mapped to the thrown request error.
+- `empty`: render explicit baseline-empty message (for no active query/filter state).
+- `no_match`: render explicit no-match message for active query/filter state.
+- `results`: render result list, no empty/no-match panel.
+
+No extra recovery action is added to `no_match`; panel remains informational only.
+
+### 4) Context preservation
+
+Query chips, typed filters, and URL-synced state remain intact across:
+
+- loading -> error
+- error -> retry -> success
+- no-match/empty transitions
+
+Only data results and view messaging change; active filter context is not dropped.
+
+## Files
+
+- Modify: `apps/ui/src/pages/SearchRoutePage.tsx`
+  - add derived result-state logic
+  - add retry snapshot capture/replay
+  - split zero-result messaging into empty vs no-match panels
+- Modify: `apps/ui/src/pages/SearchRoutePage.test.tsx`
+  - add/adjust tests for empty vs no-match messaging distinction
+  - add retry snapshot regression test (replay exact failed payload)
+  - verify filter/query context remains visible across state transitions
+
+## Test Strategy
+
+Targeted route tests in `SearchRoutePage.test.tsx`:
+
+- empty state when submitting baseline search (no active query/filters) with zero hits
+- no-match state when active query/filters yield zero hits
+- error state retry replays exact failed payload even if draft inputs changed after failure
+- loading/error/no-match states remain visually distinct
+- active chips/filters remain rendered through error and retry transitions
+
+## Risks and Mitigations
+
+- Risk: Retry replay could accidentally use stale closures or mutable references.
+  - Mitigation: store immutable snapshot object for last attempted request.
+- Risk: Empty/no-match classification might drift if “active filter” logic is duplicated.
+  - Mitigation: reuse existing active-filter booleans already used for chip rendering.
+
+## Acceptance Criteria Mapping
+
+- no-match visually distinct from loading and hard-error:
+  - delivered via explicit `no_match` panel and independent loading/error rendering.
+- error provides deterministic retry/recovery:
+  - delivered via exact failed-request snapshot replay on Retry.
+- state messaging does not drop active filter context:
+  - delivered by preserving chips/filter state and URL sync through transitions.


### PR DESCRIPTION
## Summary
- add issue #181 search-result messaging design spec and implementation plan
- implement explicit `/search` result-state rendering (`loading`, `error`, `empty`, `no_match`, `results`)
- make `Retry` deterministically replay the exact last failed request snapshot instead of live edited form state

## Test Plan
- [x] `npm --prefix apps/ui test -- src/pages/SearchRoutePage.test.tsx -t "baseline empty state|exact last failed request payload|loading status while the search request is pending|shows retry UI on failure and retries with active chips"`
- [x] `npm --prefix apps/ui test -- src/pages/SearchRoutePage.test.tsx`
- [x] `npm --prefix apps/ui test -- src/pages/SearchRoutePage.test.tsx src/pages/BrowseRoutePage.test.tsx src/app/AppShell.test.tsx`