### PR TITLE
fix(ui): resolve SearchRoutePage cursor map TS typing error

### DIFF
--- a/apps/ui/src/pages/SearchRoutePage.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.tsx
@@ -72,6 +72,14 @@ type SearchRequestSnapshot = {
   cursorByPage: Record<number, string | null>;
 };
 
+function buildFirstPageCursorMap(nextCursor: string | null): Record<number, string | null> {
+  const cursorMap: Record<number, string | null> = { 1: null };
+  if (nextCursor !== null) {
+    cursorMap[2] = nextCursor;
+  }
+  return cursorMap;
+}
+
 function hasActiveSearchCriteria(snapshot: SearchRequestSnapshot): boolean {
   return (
     snapshot.chips.length > 0 ||
@@ -569,7 +577,7 @@ export function SearchRoutePage() {
         setLastSuccessfulHadCriteria(hasActiveSearchCriteria(resetSnapshot));
         setFacetHasFacesCounts(parseHasFacesFacetCounts(resetPayload.facets));
         setFacetPathHintCounts(toPathHintFacetCounts(resetPayload.facets, resetSnapshot.pathHints));
-        setCursorByPage({ 1: null, ...(resetPayload.hits.cursor ? { 2: resetPayload.hits.cursor } : {}) });
+        setCursorByPage(buildFirstPageCursorMap(resetPayload.hits.cursor));
         return;
       }
 
@@ -611,7 +619,7 @@ export function SearchRoutePage() {
         setLastSuccessfulHadCriteria(hasActiveSearchCriteria(resetSnapshot));
         setFacetHasFacesCounts(parseHasFacesFacetCounts(resetPayload.facets));
         setFacetPathHintCounts(toPathHintFacetCounts(resetPayload.facets, resetSnapshot.pathHints));
-        setCursorByPage({ 1: null, ...(resetPayload.hits.cursor ? { 2: resetPayload.hits.cursor } : {}) });
+        setCursorByPage(buildFirstPageCursorMap(resetPayload.hits.cursor));
         return;
       }
       setResults(payload.hits.items);


### PR DESCRIPTION
## Summary

Fix the `SearchRoutePage` build failure caused by cursor-map state updates that could widen to `string | undefined`.

- add `buildFirstPageCursorMap(nextCursor)` helper returning `Record<number, string | null>`
- replace both reset-path `setCursorByPage(...)` calls to use the helper
- preserve existing behavior while making the state type-safe for `tsc -b`

## Verification

- `npm --prefix apps/ui run build`
- result: `tsc -b && vite build` passes successfully

## Context

This addresses the TS2345 errors reported in `src/pages/SearchRoutePage.tsx` around conditional spreads producing optional keys with `undefined`.