### PR TITLE
feat(ui): implement people management screen workflows

### DIFF
--- a/apps/ui/src/app/AppRouter.tsx
+++ b/apps/ui/src/app/AppRouter.tsx
@@ -19,6 +19,7 @@ import { BrowseRoutePage } from "../pages/BrowseRoutePage";
 import { SearchRoutePage } from "../pages/SearchRoutePage";
 import { PhotoDetailRoutePage } from "../pages/PhotoDetailRoutePage";
 import { NotFoundPage } from "../pages/NotFoundPage";
+import { PeopleManagementRoutePage } from "../pages/PeopleManagementRoutePage";
 import {
   resolveInitialSessionIdentity,
   type SessionIdentity
@@ -88,6 +89,8 @@ export function AppRouteTree({ initialSessionIdentity }: AppRouteTreeProps = {})
                 <BrowseRoutePage />
               ) : route.key === "search" ? (
                 <SearchRoutePage />
+              ) : route.key === "labeling" ? (
+                <PeopleManagementRoutePage />
               ) : (
                 <PrimaryRoutePage route={route} />
               )

--- a/apps/ui/src/app/AppShell.test.tsx
+++ b/apps/ui/src/app/AppShell.test.tsx
@@ -62,7 +62,7 @@ function expectShellContextText(text: string) {
 }
 
 const ROUTES_WITH_PRIMARY_PAGE_FEEDBACK = PRIMARY_ROUTE_DEFINITIONS.filter(
-  (route) => route.key !== "search"
+  (route) => route.key !== "search" && route.key !== "labeling"
 );
 
 describe("App shell", () => {
@@ -186,37 +186,37 @@ describe("App shell", () => {
 
   it("transitions from route error to ready on retry for primary-placeholder routes", async () => {
     const user = userEvent.setup();
-    renderAtPath("/labeling?demoState=error");
+    renderAtPath("/operations?demoState=error");
 
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
     expect(
       screen.getByRole("heading", {
-        name: "Could not load Labeling",
+        name: "Could not load Operations",
         level: 2
       })
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Retry" }));
 
-    expect(screen.getByRole("heading", { name: "Labeling", level: 1 })).toBeInTheDocument();
-    expect(screen.getByText("Labeling is ready.")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Operations", level: 1 })).toBeInTheDocument();
+    expect(screen.getByText("Operations is ready.")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Dismiss notification" }));
-    expect(screen.queryByText("Labeling is ready.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Operations is ready.")).not.toBeInTheDocument();
   });
 
   it("does not reset feedback state when unrelated query params change", async () => {
     const user = userEvent.setup();
-    renderAtPathWithQueryBump("/labeling?demoState=error&panel=primary");
+    renderAtPathWithQueryBump("/operations?demoState=error&panel=primary");
 
     await user.click(screen.getByRole("button", { name: "Retry" }));
-    expect(screen.getByText("Labeling is ready.")).toBeInTheDocument();
+    expect(screen.getByText("Operations is ready.")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Bump query" }));
 
-    expect(screen.getByRole("heading", { name: "Labeling", level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Operations", level: 1 })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
-    expect(screen.getByText("Labeling is ready.")).toBeInTheDocument();
+    expect(screen.getByText("Operations is ready.")).toBeInTheDocument();
   });
 
   it("renders search query controls on the /search route", async () => {
@@ -230,5 +230,18 @@ describe("App shell", () => {
     expect(await screen.findByRole("heading", { name: "Search", level: 1 })).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: "Search query" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+  });
+
+  it("renders people-management controls on the /labeling route", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => []
+    } as Response);
+
+    renderAtPath("/labeling");
+
+    expect(await screen.findByRole("heading", { name: "Labeling", level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Create person display name" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Create person" })).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/pages/PeopleManagementRoutePage.test.tsx
+++ b/apps/ui/src/pages/PeopleManagementRoutePage.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { PeopleManagementRoutePage } from "./PeopleManagementRoutePage";
+
+const PEOPLE_ENDPOINT = "/api/v1/people";
+
+type PersonPayload = {
+  person_id: string;
+  display_name: string;
+  created_ts: string;
+  updated_ts: string;
+};
+
+function createPerson(personId: string, displayName: string): PersonPayload {
+  return {
+    person_id: personId,
+    display_name: displayName,
+    created_ts: "2026-04-20T12:00:00Z",
+    updated_ts: "2026-04-20T12:00:00Z"
+  };
+}
+
+function renderLabelingPage() {
+  return render(
+    <MemoryRouter
+      initialEntries={["/labeling"]}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Routes>
+        <Route path="/labeling" element={<PeopleManagementRoutePage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function buildPeopleFetch(
+  peopleSeed: PersonPayload[],
+  options: {
+    inUseIds?: string[];
+    failFirstListRequest?: number;
+  } = {}
+) {
+  const people = [...peopleSeed];
+  const inUseIds = new Set(options.inUseIds ?? []);
+  let remainingListFailures = options.failFirstListRequest ?? 0;
+
+  return vi.fn(async (input: string, init?: RequestInit) => {
+    const method = init?.method ?? "GET";
+
+    if (input === PEOPLE_ENDPOINT && method === "GET") {
+      if (remainingListFailures > 0) {
+        remainingListFailures -= 1;
+        return { ok: false, status: 503 } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => [...people]
+      } as Response;
+    }
+
+    if (input === PEOPLE_ENDPOINT && method === "POST") {
+      const payload = JSON.parse(String(init?.body)) as { display_name: string };
+      const trimmed = payload.display_name.trim();
+      const created = createPerson(`person-${people.length + 1}`, trimmed);
+      people.push(created);
+
+      return {
+        ok: true,
+        status: 201,
+        json: async () => created
+      } as Response;
+    }
+
+    if (input.startsWith(`${PEOPLE_ENDPOINT}/`) && method === "PATCH") {
+      const personId = input.replace(`${PEOPLE_ENDPOINT}/`, "");
+      const person = people.find((candidate) => candidate.person_id === personId);
+      if (!person) {
+        return {
+          ok: false,
+          status: 404,
+          json: async () => ({ detail: "Person not found" })
+        } as Response;
+      }
+
+      const payload = JSON.parse(String(init?.body)) as { display_name: string };
+      person.display_name = payload.display_name.trim();
+      person.updated_ts = "2026-04-21T12:00:00Z";
+
+      return {
+        ok: true,
+        json: async () => ({ ...person })
+      } as Response;
+    }
+
+    if (input.startsWith(`${PEOPLE_ENDPOINT}/`) && method === "DELETE") {
+      const personId = input.replace(`${PEOPLE_ENDPOINT}/`, "");
+      const index = people.findIndex((candidate) => candidate.person_id === personId);
+      if (index < 0) {
+        return {
+          ok: false,
+          status: 404,
+          json: async () => ({ detail: "Person not found" })
+        } as Response;
+      }
+
+      if (inUseIds.has(personId)) {
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({ detail: "Person is referenced by face or label data" })
+        } as Response;
+      }
+
+      people.splice(index, 1);
+      return {
+        ok: true,
+        status: 204
+      } as Response;
+    }
+
+    throw new Error(`Unexpected request: ${method} ${input}`);
+  });
+}
+
+describe("PeopleManagementRoutePage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads and renders deterministic people ordering", async () => {
+    const fetchMock = buildPeopleFetch([
+      createPerson("person-2", "Zoe Carter"),
+      createPerson("person-1", "Ana Gomez"),
+      createPerson("person-3", "Ana Carter")
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderLabelingPage();
+
+    expect(await screen.findByRole("heading", { name: "Labeling", level: 1 })).toBeInTheDocument();
+    const list = screen.getByRole("list", { name: "People records" });
+    const labels = within(list)
+      .getAllByRole("heading", { level: 2 })
+      .map((item) => item.textContent);
+
+    expect(labels).toEqual(["Ana Carter", "Ana Gomez", "Zoe Carter"]);
+  });
+
+  it("shows a deterministic empty state", async () => {
+    const fetchMock = buildPeopleFetch([]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderLabelingPage();
+
+    expect(await screen.findByText("No people yet. Create the first person to start labeling.")).toBeInTheDocument();
+  });
+
+  it("shows load error and retries successfully", async () => {
+    const user = userEvent.setup();
+    const fetchMock = buildPeopleFetch(
+      [createPerson("person-1", "Ana Gomez")],
+      { failFirstListRequest: 1 }
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderLabelingPage();
+
+    expect(await screen.findByRole("heading", { name: "Could not load people directory", level: 2 })).toBeInTheDocument();
+    expect(screen.getByText("People request failed (503)")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByText("Ana Gomez")).toBeInTheDocument();
+  });
+
+  it("creates and renames people with inline validation", async () => {
+    const user = userEvent.setup();
+    const fetchMock = buildPeopleFetch([createPerson("person-1", "Ana Gomez")]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderLabelingPage();
+
+    expect(await screen.findByText("Ana Gomez")).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Create person display name"), "  ");
+    await user.click(screen.getByRole("button", { name: "Create person" }));
+    expect(screen.getByText("Display name is required.")).toBeInTheDocument();
+
+    const createInput = screen.getByLabelText("Create person display name");
+    await user.clear(createInput);
+    await user.type(createInput, "Inez Alvarez");
+    await user.click(screen.getByRole("button", { name: "Create person" }));
+
+    expect(await screen.findByText("Inez Alvarez")).toBeInTheDocument();
+
+    const renameInput = screen.getByLabelText("Display name for person Ana Gomez");
+    await user.clear(renameInput);
+    await user.type(renameInput, "Ana Morales");
+    await user.click(screen.getByRole("button", { name: "Rename person Ana Gomez" }));
+
+    expect(await screen.findByText("Ana Morales")).toBeInTheDocument();
+  });
+
+  it("surfaces delete conflicts and removes deletable people", async () => {
+    const user = userEvent.setup();
+    const fetchMock = buildPeopleFetch(
+      [
+        createPerson("person-1", "In Use Person"),
+        createPerson("person-2", "Free Person")
+      ],
+      { inUseIds: ["person-1"] }
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderLabelingPage();
+
+    expect(await screen.findByText("In Use Person")).toBeInTheDocument();
+    expect(screen.getByText("Free Person")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Delete person In Use Person" }));
+    expect(await screen.findByText("Person is referenced by face or label data")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Delete person Free Person" }));
+    expect(screen.queryByText("Free Person")).not.toBeInTheDocument();
+    expect(screen.getByText("In Use Person")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/pages/PeopleManagementRoutePage.tsx
+++ b/apps/ui/src/pages/PeopleManagementRoutePage.tsx
@@ -1,0 +1,346 @@
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+type PersonRecord = {
+  person_id: string;
+  display_name: string;
+  created_ts: string;
+  updated_ts: string;
+};
+
+type BusyAction = "rename" | "delete";
+
+function sortPeopleDirectory(people: PersonRecord[]): PersonRecord[] {
+  return [...people].sort((left, right) => {
+    const displayNameComparison = left.display_name.localeCompare(right.display_name, "en-US");
+    if (displayNameComparison !== 0) {
+      return displayNameComparison;
+    }
+    return left.person_id.localeCompare(right.person_id, "en-US");
+  });
+}
+
+async function readErrorDetail(response: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await response.json()) as { detail?: unknown };
+    if (typeof payload.detail === "string" && payload.detail.trim().length > 0) {
+      return payload.detail;
+    }
+  } catch {
+    // Ignore parsing errors and use fallback.
+  }
+
+  return fallback;
+}
+
+function applyPersonUpdate(people: PersonRecord[], updatedPerson: PersonRecord): PersonRecord[] {
+  return people.map((person) =>
+    person.person_id === updatedPerson.person_id ? updatedPerson : person
+  );
+}
+
+export function PeopleManagementRoutePage() {
+  const [people, setPeople] = useState<PersonRecord[]>([]);
+  const [renameDraftsByPersonId, setRenameDraftsByPersonId] = useState<Record<string, string>>({});
+  const [errorByPersonId, setErrorByPersonId] = useState<Record<string, string>>({});
+  const [createDraft, setCreateDraft] = useState("");
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+  const [isCreating, setIsCreating] = useState(false);
+  const [busyByPersonId, setBusyByPersonId] = useState<Record<string, BusyAction | undefined>>({});
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    setIsLoading(true);
+    setLoadError(null);
+
+    fetch("/api/v1/people", { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`People request failed (${response.status})`);
+        }
+
+        const payload = (await response.json()) as PersonRecord[];
+        const sortedPeople = sortPeopleDirectory(payload);
+        setPeople(sortedPeople);
+        setIsLoading(false);
+      })
+      .catch((caughtError: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setLoadError(
+          caughtError instanceof Error
+            ? caughtError.message
+            : "Could not load people directory."
+        );
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [reloadToken]);
+
+  useEffect(() => {
+    setRenameDraftsByPersonId((current) => {
+      const next: Record<string, string> = {};
+      for (const person of people) {
+        next[person.person_id] = current[person.person_id] ?? person.display_name;
+      }
+      return next;
+    });
+
+    setErrorByPersonId((current) => {
+      const next: Record<string, string> = {};
+      for (const person of people) {
+        if (current[person.person_id]) {
+          next[person.person_id] = current[person.person_id];
+        }
+      }
+      return next;
+    });
+
+    setBusyByPersonId((current) => {
+      const next: Record<string, BusyAction | undefined> = {};
+      for (const person of people) {
+        if (current[person.person_id]) {
+          next[person.person_id] = current[person.person_id];
+        }
+      }
+      return next;
+    });
+  }, [people]);
+
+  const sortedPeople = useMemo(() => sortPeopleDirectory(people), [people]);
+
+  async function handleCreatePerson(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    const trimmedDisplayName = createDraft.trim();
+    if (!trimmedDisplayName) {
+      setCreateError("Display name is required.");
+      return;
+    }
+
+    setCreateError(null);
+    setIsCreating(true);
+
+    try {
+      const response = await fetch("/api/v1/people", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ display_name: trimmedDisplayName })
+      });
+
+      if (!response.ok) {
+        const detail = await readErrorDetail(response, `Create request failed (${response.status})`);
+        setCreateError(detail);
+        return;
+      }
+
+      const createdPerson = (await response.json()) as PersonRecord;
+      setPeople((current) => sortPeopleDirectory([...current, createdPerson]));
+      setCreateDraft("");
+    } catch {
+      setCreateError("Could not create person.");
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  async function handleRenamePerson(person: PersonRecord) {
+    const draft = renameDraftsByPersonId[person.person_id] ?? person.display_name;
+    const trimmedDisplayName = draft.trim();
+
+    if (!trimmedDisplayName) {
+      setErrorByPersonId((current) => ({
+        ...current,
+        [person.person_id]: "Display name is required."
+      }));
+      return;
+    }
+
+    setBusyByPersonId((current) => ({ ...current, [person.person_id]: "rename" }));
+    setErrorByPersonId((current) => ({ ...current, [person.person_id]: "" }));
+
+    try {
+      const response = await fetch(`/api/v1/people/${person.person_id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ display_name: trimmedDisplayName })
+      });
+
+      if (!response.ok) {
+        const detail = await readErrorDetail(response, `Rename request failed (${response.status})`);
+        setErrorByPersonId((current) => ({
+          ...current,
+          [person.person_id]: detail
+        }));
+        return;
+      }
+
+      const updatedPerson = (await response.json()) as PersonRecord;
+      setPeople((current) => sortPeopleDirectory(applyPersonUpdate(current, updatedPerson)));
+      setErrorByPersonId((current) => ({ ...current, [person.person_id]: "" }));
+    } catch {
+      setErrorByPersonId((current) => ({
+        ...current,
+        [person.person_id]: "Could not rename person."
+      }));
+    } finally {
+      setBusyByPersonId((current) => ({ ...current, [person.person_id]: undefined }));
+    }
+  }
+
+  async function handleDeletePerson(person: PersonRecord) {
+    setBusyByPersonId((current) => ({ ...current, [person.person_id]: "delete" }));
+    setErrorByPersonId((current) => ({ ...current, [person.person_id]: "" }));
+
+    try {
+      const response = await fetch(`/api/v1/people/${person.person_id}`, {
+        method: "DELETE"
+      });
+
+      if (!response.ok) {
+        const detail = await readErrorDetail(response, `Delete request failed (${response.status})`);
+        setErrorByPersonId((current) => ({
+          ...current,
+          [person.person_id]: detail
+        }));
+        return;
+      }
+
+      setPeople((current) =>
+        current.filter((candidate) => candidate.person_id !== person.person_id)
+      );
+    } catch {
+      setErrorByPersonId((current) => ({
+        ...current,
+        [person.person_id]: "Could not delete person."
+      }));
+    } finally {
+      setBusyByPersonId((current) => ({ ...current, [person.person_id]: undefined }));
+    }
+  }
+
+  return (
+    <section aria-labelledby="page-title" className="page people-management-page">
+      <div className="people-management-header">
+        <h1 id="page-title">Labeling</h1>
+        <p>People management workflows for create, rename, and delete operations.</p>
+      </div>
+
+      <section className="people-management-panel" aria-label="Create person">
+        <h2>Create person</h2>
+        <form className="people-create-form" onSubmit={handleCreatePerson}>
+          <label htmlFor="create-person-display-name">Display name</label>
+          <div className="people-create-row">
+            <input
+              id="create-person-display-name"
+              aria-label="Create person display name"
+              value={createDraft}
+              onChange={(event) => {
+                setCreateDraft(event.target.value);
+                setCreateError(null);
+              }}
+              disabled={isCreating}
+            />
+            <button type="submit" disabled={isCreating}>
+              Create person
+            </button>
+          </div>
+        </form>
+        {createError ? <p className="people-validation-message">{createError}</p> : null}
+      </section>
+
+      {loadError ? (
+        <div className="feedback-panel feedback-panel-error">
+          <h2>Could not load people directory</h2>
+          <p>{loadError}</p>
+          <button type="button" onClick={() => setReloadToken((current) => current + 1)}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {!loadError && isLoading ? (
+        <div className="feedback-panel feedback-panel-loading" role="status" aria-live="polite">
+          Loading people directory.
+        </div>
+      ) : null}
+
+      {!loadError && !isLoading && sortedPeople.length === 0 ? (
+        <div className="feedback-panel">
+          <p>No people yet. Create the first person to start labeling.</p>
+        </div>
+      ) : null}
+
+      {!loadError && !isLoading && sortedPeople.length > 0 ? (
+        <ul className="people-management-list" aria-label="People records">
+          {sortedPeople.map((person) => {
+            const rowError = errorByPersonId[person.person_id];
+            const busyAction = busyByPersonId[person.person_id];
+
+            return (
+              <li key={person.person_id} className="people-management-item">
+                <h2>{person.display_name}</h2>
+                <p className="people-management-id">ID: {person.person_id}</p>
+                <label htmlFor={`rename-${person.person_id}`}>
+                  Display name
+                </label>
+                <div className="people-management-actions">
+                  <input
+                    id={`rename-${person.person_id}`}
+                    aria-label={`Display name for person ${person.display_name}`}
+                    value={renameDraftsByPersonId[person.person_id] ?? person.display_name}
+                    onChange={(event) => {
+                      const nextValue = event.target.value;
+                      setRenameDraftsByPersonId((current) => ({
+                        ...current,
+                        [person.person_id]: nextValue
+                      }));
+                      setErrorByPersonId((current) => ({
+                        ...current,
+                        [person.person_id]: ""
+                      }));
+                    }}
+                    disabled={busyAction !== undefined}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void handleRenamePerson(person);
+                    }}
+                    disabled={busyAction !== undefined}
+                    aria-label={`Rename person ${person.display_name}`}
+                  >
+                    Rename
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void handleDeletePerson(person);
+                    }}
+                    disabled={busyAction !== undefined}
+                    aria-label={`Delete person ${person.display_name}`}
+                  >
+                    Delete
+                  </button>
+                </div>
+                {rowError ? <p className="people-validation-message">{rowError}</p> : null}
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/ui/src/routes/routeDefinitions.ts
+++ b/apps/ui/src/routes/routeDefinitions.ts
@@ -57,7 +57,7 @@ export const PRIMARY_ROUTE_DEFINITIONS: PrimaryRouteDefinition[] = [
     path: "/labeling",
     navLabel: "Labeling",
     title: "Labeling",
-    description: "Face-labeling workflow surface placeholder.",
+    description: "People management workflows for labeling identities.",
     handoff: baseHandoffExpectation
   },
   {

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -955,6 +955,130 @@ body {
   color: #64748b;
 }
 
+.people-management-page {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.people-management-header p {
+  margin-top: 0;
+  color: #334155;
+}
+
+.people-management-panel {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.7rem;
+  background: #ffffff;
+  padding: 0.8rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.people-management-panel h2 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.people-create-form {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.people-create-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.people-create-row input {
+  flex: 1 1 16rem;
+  min-width: 11rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  padding: 0.42rem 0.52rem;
+  font: inherit;
+}
+
+.people-create-row button {
+  border: 1px solid #93c5fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.42rem 0.65rem;
+  font: inherit;
+}
+
+.people-management-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.people-management-item {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.7rem;
+  background: #ffffff;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.people-management-item h2 {
+  margin: 0;
+  font-size: 0.98rem;
+  color: #0f172a;
+}
+
+.people-management-id {
+  margin: 0;
+  color: #475569;
+  font-size: 0.78rem;
+}
+
+.people-management-item label {
+  color: #334155;
+  font-size: 0.9rem;
+}
+
+.people-management-actions {
+  display: flex;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+}
+
+.people-management-actions input {
+  flex: 1 1 15rem;
+  min-width: 11rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  padding: 0.4rem 0.5rem;
+  font: inherit;
+}
+
+.people-management-actions button {
+  border: 1px solid #93c5fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.38rem 0.58rem;
+  font: inherit;
+}
+
+.people-management-actions button:disabled,
+.people-create-row button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.people-validation-message {
+  margin: 0;
+  color: #b91c1c;
+  font-size: 0.88rem;
+}
+
 @media (max-width: 1024px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -1051,6 +1175,26 @@ body {
   }
 
   .search-person-input-row button {
+    width: fit-content;
+  }
+
+  .people-create-row {
+    flex-direction: column;
+  }
+
+  .people-create-row button {
+    width: fit-content;
+  }
+
+  .people-management-actions {
+    flex-direction: column;
+  }
+
+  .people-management-actions input {
+    width: 100%;
+  }
+
+  .people-management-actions button {
     width: fit-content;
   }
 

--- a/apps/ui/tests/e2e/journeys/app-shell-journeys.spec.ts
+++ b/apps/ui/tests/e2e/journeys/app-shell-journeys.spec.ts
@@ -118,19 +118,66 @@ test("JRN-P3-search-route-deep-link @journey @smoke", async ({ page }) => {
 });
 
 test("JRN-P2-shared-feedback-surfaces @journey @smoke", async ({ page }) => {
-  await page.goto("/labeling?demoState=loading");
+  let phase: "loading" | "error" | "success" = "loading";
+  let releaseFirstPeopleResponse: (() => void) | null = null;
+  const firstPeopleResponseGate = new Promise<void>((resolve) => {
+    releaseFirstPeopleResponse = resolve;
+  });
 
-  await expect(page.getByRole("status")).toContainText(/Loading labeling workflow/i);
+  await page.route("**/api/v1/people", async (route) => {
+    if (phase === "loading") {
+      await firstPeopleResponseGate;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([])
+      });
+      return;
+    }
 
-  await page.goto("/labeling?demoState=error");
+    if (phase === "error") {
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Service unavailable" })
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          person_id: "person-1",
+          display_name: "Ana Gomez",
+          created_ts: "2026-04-20T12:00:00Z",
+          updated_ts: "2026-04-20T12:00:00Z"
+        }
+      ])
+    });
+  });
+
+  await page.goto("/labeling");
+  await expect(page.getByRole("status")).toContainText(/Loading people directory/i);
+  releaseFirstPeopleResponse?.();
+  await expect(
+    page.getByText("No people yet. Create the first person to start labeling.")
+  ).toBeVisible();
+
+  phase = "error";
+  await page.goto("/labeling");
+  await expect(
+    page.getByRole("heading", { name: "Could not load people directory", level: 2 })
+  ).toBeVisible();
 
   const retryButton = page.getByRole("button", { name: "Retry" });
   await expect(retryButton).toBeVisible();
 
+  phase = "success";
   await retryButton.click();
 
-  await expect(page.getByRole("heading", { name: "Labeling", level: 1 })).toBeVisible();
-  await expect(page.getByText("Labeling is ready.")).toBeVisible();
+  await expect(page.getByText("Ana Gomez")).toBeVisible();
   await expectShellRoute(page, "labeling");
   await expect(page).toHaveURL(/\/labeling(?:\?|$)/);
 });


### PR DESCRIPTION
## Summary
- replace the `/labeling` placeholder route with a real people-management screen
- implement people list/create/rename/delete workflows against `/api/v1/people`
- surface deterministic loading, empty, error, validation, and conflict states for people management
- update app-shell routing/tests for the new `/labeling` behavior and add page-level tests

## Verification
- `npm --prefix apps/ui test`

Closes #182