### PR TITLE
feat(ui): implement face-to-person assignment interactions in photo detail (#183)

### DIFF
--- a/apps/ui/src/pages/FaceAssignmentControls.test.tsx
+++ b/apps/ui/src/pages/FaceAssignmentControls.test.tsx
@@ -79,6 +79,128 @@ describe("FaceAssignmentControls", () => {
     expect(await screen.findByText("You do not have permission to assign faces.")).toBeInTheDocument();
   });
 
+  it("shows API detail for 409 conflicts", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: async () => ({ detail: "Face already assigned" })
+    } as Response);
+
+    render(
+      <FaceAssignmentControls
+        faces={[{ face_id: "face-1", person_id: null }]}
+        people={[{ person_id: "person-1", display_name: "Inez" }]}
+        onAssigned={vi.fn()}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText("Assign face 1"), "person-1");
+
+    expect(await screen.findByText("Face already assigned")).toBeInTheDocument();
+  });
+
+  it("shows fallback message for 404 without detail", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: async () => ({})
+    } as Response);
+
+    render(
+      <FaceAssignmentControls
+        faces={[{ face_id: "face-1", person_id: null }]}
+        people={[{ person_id: "person-1", display_name: "Inez" }]}
+        onAssigned={vi.fn()}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText("Assign face 1"), "person-1");
+
+    expect(await screen.findByText("Face or person no longer exists.")).toBeInTheDocument();
+  });
+
+  it("shows fallback status message for non-mapped server failures", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: "server blew up" })
+    } as Response);
+
+    render(
+      <FaceAssignmentControls
+        faces={[{ face_id: "face-1", person_id: null }]}
+        people={[{ person_id: "person-1", display_name: "Inez" }]}
+        onAssigned={vi.fn()}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText("Assign face 1"), "person-1");
+
+    expect(await screen.findByText("Assignment request failed (500).")).toBeInTheDocument();
+  });
+
+  it("shows network fallback message on fetch exception", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockRejectedValueOnce(new Error("network"));
+
+    render(
+      <FaceAssignmentControls
+        faces={[{ face_id: "face-1", person_id: null }]}
+        people={[{ person_id: "person-1", display_name: "Inez" }]}
+        onAssigned={vi.fn()}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText("Assign face 1"), "person-1");
+
+    expect(await screen.findByText("Could not assign face.")).toBeInTheDocument();
+  });
+
+  it("disables select while assignment request is in flight", async () => {
+    const user = userEvent.setup();
+    let resolveRequest: ((value: Response) => void) | null = null;
+
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveRequest = resolve;
+        })
+    );
+
+    render(
+      <FaceAssignmentControls
+        faces={[{ face_id: "face-1", person_id: null }]}
+        people={[{ person_id: "person-1", display_name: "Inez" }]}
+        onAssigned={vi.fn()}
+      />
+    );
+
+    const select = screen.getByLabelText("Assign face 1");
+    await user.selectOptions(select, "person-1");
+    expect(select).toBeDisabled();
+
+    resolveRequest?.({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        face_id: "face-1",
+        photo_id: "photo-1",
+        person_id: "person-1"
+      })
+    } as Response);
+
+    await waitFor(() => {
+      expect(screen.getByText("All visible faces assigned.")).toBeInTheDocument();
+    });
+  });
+
   it("renders completion when no unlabeled faces remain", () => {
     render(
       <FaceAssignmentControls

--- a/apps/ui/src/pages/FaceAssignmentControls.test.tsx
+++ b/apps/ui/src/pages/FaceAssignmentControls.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FaceAssignmentControls } from "./FaceAssignmentControls";
+
+describe("FaceAssignmentControls", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("assigns active unlabeled face and auto-advances", async () => {
+    const user = userEvent.setup();
+    const onAssigned = vi.fn();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ face_id: "face-1", photo_id: "photo-1", person_id: "person-2" })
+    } as Response);
+
+    render(
+      <FaceAssignmentControls
+        faces={[
+          { face_id: "face-1", person_id: null },
+          { face_id: "face-2", person_id: null },
+          { face_id: "face-3", person_id: "person-1" }
+        ]}
+        people={[
+          { person_id: "person-1", display_name: "Inez" },
+          { person_id: "person-2", display_name: "Mateo" }
+        ]}
+        onAssigned={onAssigned}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText("Assign face 1"), "person-2");
+
+    await waitFor(() => {
+      expect(onAssigned).toHaveBeenCalledWith("face-1", "person-2");
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/faces/face-1/assignments", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Face-Validation-Role": "contributor"
+      },
+      body: JSON.stringify({ person_id: "person-2" })
+    });
+
+    expect(screen.getByLabelText("Assign face 2")).toBeInTheDocument();
+  });
+
+  it("shows deterministic inline 403 error", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: "Face validation role required" })
+    } as Response);
+
+    render(
+      <FaceAssignmentControls
+        faces={[{ face_id: "face-1", person_id: null }]}
+        people={[{ person_id: "person-1", display_name: "Inez" }]}
+        onAssigned={vi.fn()}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText("Assign face 1"), "person-1");
+
+    expect(await screen.findByText("You do not have permission to assign faces.")).toBeInTheDocument();
+  });
+
+  it("renders completion when no unlabeled faces remain", () => {
+    render(
+      <FaceAssignmentControls
+        faces={[{ face_id: "face-1", person_id: "person-1" }]}
+        people={[{ person_id: "person-1", display_name: "Inez" }]}
+        onAssigned={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("All visible faces assigned.")).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/pages/FaceAssignmentControls.tsx
+++ b/apps/ui/src/pages/FaceAssignmentControls.tsx
@@ -1,0 +1,118 @@
+import { useMemo, useState } from "react";
+
+export interface FaceAssignmentFace {
+  face_id: string;
+  person_id: string | null;
+}
+
+export interface FaceAssignmentPerson {
+  person_id: string;
+  display_name: string;
+}
+
+interface FaceAssignmentControlsProps {
+  faces: FaceAssignmentFace[];
+  people: FaceAssignmentPerson[];
+  onAssigned: (faceId: string, personId: string) => void;
+}
+
+async function readErrorDetail(response: Response): Promise<string | null> {
+  try {
+    const payload = (await response.json()) as { detail?: unknown };
+    if (typeof payload.detail === "string" && payload.detail.trim().length > 0) {
+      return payload.detail;
+    }
+  } catch {
+    // Ignore parsing errors and use fallback message mapping.
+  }
+
+  return null;
+}
+
+function mapAssignmentError(status: number, detail: string | null): string {
+  if (status === 403) {
+    return "You do not have permission to assign faces.";
+  }
+
+  if (status === 404) {
+    return detail ?? "Face or person no longer exists.";
+  }
+
+  if (status === 409) {
+    return detail ?? "Face is already assigned.";
+  }
+
+  return `Assignment request failed (${status}).`;
+}
+
+export function FaceAssignmentControls({ faces, people, onAssigned }: FaceAssignmentControlsProps) {
+  const unlabeledFaces = useMemo(() => faces.filter((face) => face.person_id === null), [faces]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const activeFace = unlabeledFaces[activeIndex] ?? null;
+
+  async function assign(faceId: string, personId: string) {
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/v1/faces/${faceId}/assignments`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Face-Validation-Role": "contributor"
+        },
+        body: JSON.stringify({ person_id: personId })
+      });
+
+      if (!response.ok) {
+        const detail = await readErrorDetail(response);
+        setError(mapAssignmentError(response.status, detail));
+        return;
+      }
+
+      onAssigned(faceId, personId);
+      setActiveIndex((current) => current + 1);
+    } catch {
+      setError("Could not assign face.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (activeFace === null) {
+    return <p className="detail-face-assignment-complete">All visible faces assigned.</p>;
+  }
+
+  return (
+    <section className="detail-face-assignment" aria-label="Face assignment">
+      <h3>Assign detected faces</h3>
+      <label htmlFor={`assign-${activeFace.face_id}`}>{`Assign face ${activeIndex + 1}`}</label>
+      <select
+        id={`assign-${activeFace.face_id}`}
+        aria-label={`Assign face ${activeIndex + 1}`}
+        disabled={isSubmitting}
+        value=""
+        onChange={(event) => {
+          const personId = event.target.value;
+          if (!personId) {
+            return;
+          }
+          void assign(activeFace.face_id, personId);
+        }}
+      >
+        <option value="" disabled>
+          Select person
+        </option>
+        {people.map((person) => (
+          <option key={person.person_id} value={person.person_id}>
+            {person.display_name}
+          </option>
+        ))}
+      </select>
+      {error ? <p className="detail-face-assignment-error">{error}</p> : null}
+    </section>
+  );
+}

--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -120,6 +120,19 @@ describe("PhotoDetailRoutePage", () => {
 
   beforeEach(() => {
     fetchMock.mockReset();
+    fetchMock.mockImplementation(async (input) => {
+      if (String(input) === "/api/v1/people") {
+        return {
+          ok: true,
+          json: async () => []
+        } as Response;
+      }
+
+      return {
+        ok: false,
+        status: 500
+      } as Response;
+    });
     vi.stubGlobal("fetch", fetchMock);
   });
 
@@ -146,8 +159,8 @@ describe("PhotoDetailRoutePage", () => {
     expect(screen.getByRole("list", { name: "Detected face regions" })).toBeInTheDocument();
     expect(screen.getByLabelText("Face region 1 for person-1")).toBeInTheDocument();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/v1/photos/photo-1");
+    const photoDetailCalls = fetchMock.mock.calls.filter((call) => call[0] === "/api/v1/photos/photo-1");
+    expect(photoDetailCalls).toHaveLength(1);
   });
 
   it("shows explicit fallback UI for missing optional metadata fields", async () => {
@@ -223,6 +236,57 @@ describe("PhotoDetailRoutePage", () => {
     expect(await screen.findByLabelText("Face region 1 for person-1")).toBeInTheDocument();
   });
 
+  it("loads people options and updates local face state after assignment success", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          buildPayload({
+            people: [],
+            faces: [
+              {
+                face_id: "face-1",
+                person_id: null,
+                bbox_x: 10,
+                bbox_y: 10,
+                bbox_w: 20,
+                bbox_h: 20
+              }
+            ]
+          })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            person_id: "person-1",
+            display_name: "Inez",
+            created_ts: "2026-03-28T19:30:00Z",
+            updated_ts: "2026-03-28T19:30:00Z"
+          }
+        ]
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          face_id: "face-1",
+          photo_id: "photo-1",
+          person_id: "person-1"
+        })
+      } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
+    await user.selectOptions(await screen.findByLabelText("Assign face 1"), "person-1");
+
+    expect(await screen.findByText("All visible faces assigned.")).toBeInTheDocument();
+    expect(screen.getByText("person-1")).toBeInTheDocument();
+  });
+
   it("renders deterministic loading and error transitions", async () => {
     fetchMock.mockResolvedValueOnce({
       ok: false,
@@ -257,7 +321,8 @@ describe("PhotoDetailRoutePage", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
     });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const photoDetailCalls = fetchMock.mock.calls.filter((call) => call[0] === "/api/v1/photos/photo-1");
+    expect(photoDetailCalls).toHaveLength(2);
   });
 
   it("renders pending ingest status when face detection is still in progress", async () => {

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
 import { deriveIngestStatus, INGEST_STATUS_LEGEND } from "../app/ingestStatus";
+import { FaceAssignmentControls } from "./FaceAssignmentControls";
 import {
   resolveDetailReturnState,
   setPendingBrowseFocusPhotoId
@@ -64,6 +65,13 @@ type FaceOverlayRegion = {
   topPercent: number;
   widthPercent: number;
   heightPercent: number;
+};
+
+type PersonRecord = {
+  person_id: string;
+  display_name: string;
+  created_ts: string;
+  updated_ts: string;
 };
 
 class PhotoDetailRequestError extends Error {
@@ -131,6 +139,39 @@ async function fetchPhotoDetail(photoId: string): Promise<PhotoDetailPayload> {
   return (await response.json()) as PhotoDetailPayload;
 }
 
+function sortPeopleDirectory(people: PersonRecord[]): PersonRecord[] {
+  return [...people].sort((left, right) => {
+    const displayComparison = left.display_name.localeCompare(right.display_name, "en-US");
+    if (displayComparison !== 0) {
+      return displayComparison;
+    }
+    return left.person_id.localeCompare(right.person_id, "en-US");
+  });
+}
+
+function applyFaceAssignment(
+  detail: PhotoDetailPayload,
+  faceId: string,
+  personId: string
+): PhotoDetailPayload {
+  const nextFaces = detail.faces.map((face) =>
+    face.face_id === faceId ? { ...face, person_id: personId } : face
+  );
+  const nextPeople = Array.from(
+    new Set(
+      nextFaces
+        .map((face) => face.person_id)
+        .filter((value): value is string => value !== null)
+    )
+  );
+
+  return {
+    ...detail,
+    faces: nextFaces,
+    people: nextPeople
+  };
+}
+
 export function PhotoDetailRoutePage() {
   const location = useLocation();
   const { photoId } = useParams<{ photoId: string }>();
@@ -142,6 +183,7 @@ export function PhotoDetailRoutePage() {
   const [isNotFound, setIsNotFound] = useState(false);
   const [reloadToken, setReloadToken] = useState(0);
   const [mediaMode, setMediaMode] = useState<MediaPresentationMode>("fit");
+  const [peopleDirectory, setPeopleDirectory] = useState<PersonRecord[]>([]);
 
   useEffect(() => {
     headingRef.current?.focus();
@@ -191,6 +233,29 @@ export function PhotoDetailRoutePage() {
       controller.abort();
     };
   }, [photoId, reloadToken]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    fetch("/api/v1/people", { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`People request failed (${response.status})`);
+        }
+
+        const payload = (await response.json()) as PersonRecord[];
+        setPeopleDirectory(sortPeopleDirectory(payload));
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) {
+          setPeopleDirectory([]);
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [reloadToken]);
 
   const facesLabel = useMemo(() => {
     if (!detail) {
@@ -275,6 +340,10 @@ export function PhotoDetailRoutePage() {
   }, [detail]);
 
   const backLinkFocusPhotoId = detail?.photo_id ?? returnState.returnFocusPhotoId ?? photoId ?? null;
+
+  function handleFaceAssigned(faceId: string, personId: string) {
+    setDetail((current) => (current ? applyFaceAssignment(current, faceId, personId) : current));
+  }
 
   return (
     <section aria-labelledby="page-title" className="page detail-page">
@@ -380,6 +449,17 @@ export function PhotoDetailRoutePage() {
                   </div>
                 </div>
                 <p className="detail-face-state">{faceRegionState}</p>
+                <FaceAssignmentControls
+                  faces={detail.faces.map((face) => ({
+                    face_id: face.face_id,
+                    person_id: face.person_id
+                  }))}
+                  people={peopleDirectory.map((person) => ({
+                    person_id: person.person_id,
+                    display_name: person.display_name
+                  }))}
+                  onAssigned={handleFaceAssigned}
+                />
               </>
             ) : (
               <>
@@ -387,6 +467,17 @@ export function PhotoDetailRoutePage() {
                   No preview
                 </div>
                 <p className="detail-face-state">{faceRegionState}</p>
+                <FaceAssignmentControls
+                  faces={detail.faces.map((face) => ({
+                    face_id: face.face_id,
+                    person_id: face.person_id
+                  }))}
+                  people={peopleDirectory.map((person) => ({
+                    person_id: person.person_id,
+                    display_name: person.display_name
+                  }))}
+                  onAssigned={handleFaceAssigned}
+                />
               </>
             )}
           </article>

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -534,6 +534,33 @@ body {
   color: #334155;
 }
 
+.detail-face-assignment {
+  margin-top: 0.75rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.detail-face-assignment h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.detail-face-assignment select {
+  max-width: 18rem;
+}
+
+.detail-face-assignment-error {
+  margin: 0;
+  color: #8b1e1e;
+  font-size: 0.82rem;
+}
+
+.detail-face-assignment-complete {
+  margin: 0.75rem 0 0;
+  font-weight: 600;
+  color: #334155;
+}
+
 .ingest-status-badge {
   border-radius: 999px;
   border: 1px solid transparent;

--- a/docs/superpowers/specs/2026-04-30-issue-183-face-assignment-photo-detail-design.md
+++ b/docs/superpowers/specs/2026-04-30-issue-183-face-assignment-photo-detail-design.md
@@ -1,0 +1,120 @@
+# Issue #183 Design: Face-to-Person Assignment Interactions In Photo Detail
+
+## Summary
+
+Implement assignment interactions for unlabeled faces directly in photo detail with deterministic inline feedback and automatic advance to the next unlabeled face after successful assignment.
+
+## Scope
+
+- Expose assignment action for eligible face regions (faces with `person_id === null`).
+- Provide person selection interaction from existing people records.
+- Submit assignment via backend assignment API and represent success/failure deterministically.
+- Refresh photo detail assignment state in-place after success.
+
+## Non-Goals
+
+- Correction/reassignment for already-labeled faces.
+- Suggestion confidence, candidate ranking, or review-needed workflows.
+- Global permission/session framework beyond required assignment header for this slice.
+
+## UX Decisions (Validated)
+
+- Assignment interaction uses dropdown selection with immediate submit (no separate confirm button).
+- Picker shows person `display_name` only.
+- On success, workflow auto-advances to next unlabeled face in stable face order.
+- Errors are shown inline on the active face assignment row.
+
+## Architecture
+
+### Parent Page: `PhotoDetailRoutePage`
+
+- Remains source of truth for loaded photo detail payload.
+- Loads people directory for assignment options using `GET /api/v1/people`.
+- Hosts assignment success callback that updates local `detail.faces[].person_id` without full-page reload.
+- Recomputes derived display state from updated face assignments.
+
+### New Child Component: `FaceAssignmentControls`
+
+Responsibilities:
+
+- Receives face list + people directory options from parent.
+- Computes ordered unlabeled-face queue.
+- Tracks active unlabeled face, submit-in-flight state, and inline error message.
+- Triggers assignment POST on person selection.
+- Calls parent success callback and advances to next unlabeled face.
+
+This keeps new behavior isolated from existing photo metadata/rendering concerns while avoiding speculative abstraction for future correction workflow.
+
+## API Contract
+
+### People directory
+
+- `GET /api/v1/people`
+- Used to populate selectable options.
+- Label shown in UI: `display_name`.
+- Submitted value: `person_id`.
+
+### Face assignment
+
+- `POST /api/v1/faces/{face_id}/assignments`
+- Headers:
+  - `Content-Type: application/json`
+  - `X-Face-Validation-Role: contributor`
+- Body:
+
+```json
+{
+  "person_id": "person-123"
+}
+```
+
+- Success response: `201` with `{ face_id, photo_id, person_id }`.
+
+## Deterministic Feedback Behavior
+
+### Success
+
+- Clear inline error.
+- Update face assignment state in parent detail model.
+- Advance to next unlabeled face automatically.
+- If no unlabeled faces remain, show explicit completion state (`All visible faces assigned.`).
+
+### Failure mapping (inline)
+
+- `403`: `You do not have permission to assign faces.`
+- `404`: API detail if present, else `Face or person no longer exists.`
+- `409`: API detail if present, else `Face is already assigned.`
+- Other non-OK: `Assignment request failed (500).` (status code interpolated at runtime)
+- Network/exception: `Could not assign face.`
+
+### Interaction constraints
+
+- Disable active picker while request is in flight.
+- Keep workflow single-threaded: only active unlabeled face is interactive.
+- Preserve stable face traversal order using existing `detail.faces` order.
+
+## Testing Strategy
+
+Add/extend UI tests to verify:
+
+- people directory fetch for assignment options;
+- assignment request payload + required header;
+- success updates face label state and advances active face;
+- completion state after final unlabeled face assignment;
+- deterministic inline errors for `403/404/409/500` and network failure;
+- disabled state while assignment request is pending.
+
+## Risks And Mitigations
+
+- Risk: detail page state drift after assignment.
+  - Mitigation: canonical in-memory update path in parent from assignment response.
+- Risk: person display-name ambiguity.
+  - Mitigation: display-only names but submit by `person_id` value.
+- Risk: unauthorized environments.
+  - Mitigation: deterministic `403` inline error; no silent failure.
+
+## Acceptance Criteria Mapping
+
+- Unlabeled faces can be assigned from UI: covered by active unlabeled-face picker and POST flow.
+- Assignment success/failure represented deterministically: covered by status mapping and inline feedback.
+- Detail UI reflects new assignment state after success: covered by parent state update + auto-advance.


### PR DESCRIPTION
## Summary
- add `FaceAssignmentControls` for unlabeled-face assignment with immediate submit to `/api/v1/faces/{face_id}/assignments`
- wire photo detail to load people options, update local face/people state on success, and auto-advance to next unlabeled face
- add deterministic inline error coverage (`403/404/409/500` + network) and in-flight disabled-state tests

## Test Plan
- [x] `node node_modules/vitest/vitest.mjs run src/pages/FaceAssignmentControls.test.tsx`
- [x] `node node_modules/vitest/vitest.mjs run src/pages/PhotoDetailRoutePage.test.tsx src/pages/FaceAssignmentControls.test.tsx`
- [x] `node node_modules/vitest/vitest.mjs run src/pages/BrowseRoutePage.test.tsx src/pages/SearchRoutePage.test.tsx`
- [x] `node node_modules/vitest/vitest.mjs run`

Closes #183.