### PR TITLE
feat(ui): implement face-label correction and reassignment workflow (#184)

### DIFF
--- a/apps/ui/src/pages/FaceAssignmentControls.test.tsx
+++ b/apps/ui/src/pages/FaceAssignmentControls.test.tsx
@@ -4,9 +4,11 @@ import { FaceAssignmentControls } from "./FaceAssignmentControls";
 
 describe("FaceAssignmentControls", () => {
   const fetchMock = vi.fn();
+  const onCorrected = vi.fn();
 
   beforeEach(() => {
     fetchMock.mockReset();
+    onCorrected.mockReset();
     vi.stubGlobal("fetch", fetchMock);
   });
 
@@ -36,6 +38,7 @@ describe("FaceAssignmentControls", () => {
           { person_id: "person-2", display_name: "Mateo" }
         ]}
         onAssigned={onAssigned}
+        onCorrected={onCorrected}
       />
     );
 
@@ -71,6 +74,7 @@ describe("FaceAssignmentControls", () => {
         faces={[{ face_id: "face-1", person_id: null }]}
         people={[{ person_id: "person-1", display_name: "Inez" }]}
         onAssigned={vi.fn()}
+        onCorrected={onCorrected}
       />
     );
 
@@ -93,6 +97,7 @@ describe("FaceAssignmentControls", () => {
         faces={[{ face_id: "face-1", person_id: null }]}
         people={[{ person_id: "person-1", display_name: "Inez" }]}
         onAssigned={vi.fn()}
+        onCorrected={onCorrected}
       />
     );
 
@@ -115,6 +120,7 @@ describe("FaceAssignmentControls", () => {
         faces={[{ face_id: "face-1", person_id: null }]}
         people={[{ person_id: "person-1", display_name: "Inez" }]}
         onAssigned={vi.fn()}
+        onCorrected={onCorrected}
       />
     );
 
@@ -137,6 +143,7 @@ describe("FaceAssignmentControls", () => {
         faces={[{ face_id: "face-1", person_id: null }]}
         people={[{ person_id: "person-1", display_name: "Inez" }]}
         onAssigned={vi.fn()}
+        onCorrected={onCorrected}
       />
     );
 
@@ -155,6 +162,7 @@ describe("FaceAssignmentControls", () => {
         faces={[{ face_id: "face-1", person_id: null }]}
         people={[{ person_id: "person-1", display_name: "Inez" }]}
         onAssigned={vi.fn()}
+        onCorrected={onCorrected}
       />
     );
 
@@ -165,12 +173,12 @@ describe("FaceAssignmentControls", () => {
 
   it("disables select while assignment request is in flight", async () => {
     const user = userEvent.setup();
-    let resolveRequest: ((value: Response) => void) | null = null;
+    let resolveRequest: ((value: Response) => void) | undefined;
 
     fetchMock.mockImplementationOnce(
       () =>
         new Promise<Response>((resolve) => {
-          resolveRequest = resolve;
+          resolveRequest = resolve as (value: Response) => void;
         })
     );
 
@@ -179,6 +187,7 @@ describe("FaceAssignmentControls", () => {
         faces={[{ face_id: "face-1", person_id: null }]}
         people={[{ person_id: "person-1", display_name: "Inez" }]}
         onAssigned={vi.fn()}
+        onCorrected={onCorrected}
       />
     );
 
@@ -186,7 +195,8 @@ describe("FaceAssignmentControls", () => {
     await user.selectOptions(select, "person-1");
     expect(select).toBeDisabled();
 
-    resolveRequest?.({
+    expect(resolveRequest).toBeDefined();
+    resolveRequest!({
       ok: true,
       status: 201,
       json: async () => ({
@@ -207,9 +217,125 @@ describe("FaceAssignmentControls", () => {
         faces={[{ face_id: "face-1", person_id: "person-1" }]}
         people={[{ person_id: "person-1", display_name: "Inez" }]}
         onAssigned={vi.fn()}
+        onCorrected={onCorrected}
       />
     );
 
     expect(screen.getByText("All visible faces assigned.")).toBeInTheDocument();
+  });
+
+  it("corrects a labeled face and shows provenance feedback", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        face_id: "face-1",
+        photo_id: "photo-1",
+        previous_person_id: "person-1",
+        person_id: "person-2"
+      })
+    } as Response);
+
+    render(
+      <FaceAssignmentControls
+        faces={[{ face_id: "face-1", person_id: "person-1" }]}
+        people={[
+          { person_id: "person-1", display_name: "Inez" },
+          { person_id: "person-2", display_name: "Mateo" }
+        ]}
+        onAssigned={vi.fn()}
+        onCorrected={onCorrected}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText("Correct face 1"), "person-2");
+    await user.click(screen.getByRole("button", { name: "Confirm reassignment" }));
+
+    await waitFor(() => {
+      expect(onCorrected).toHaveBeenCalledWith("face-1", "person-2");
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/faces/face-1/corrections", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Face-Validation-Role": "contributor"
+      },
+      body: JSON.stringify({ person_id: "person-2" })
+    });
+    expect(await screen.findByText("Correction recorded: Inez -> Mateo.")).toBeInTheDocument();
+  });
+
+  it("shows deterministic correction permission error", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: "Face validation role required" })
+    } as Response);
+
+    render(
+      <FaceAssignmentControls
+        faces={[{ face_id: "face-1", person_id: "person-1" }]}
+        people={[
+          { person_id: "person-1", display_name: "Inez" },
+          { person_id: "person-2", display_name: "Mateo" }
+        ]}
+        onAssigned={vi.fn()}
+        onCorrected={onCorrected}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText("Correct face 1"), "person-2");
+    await user.click(screen.getByRole("button", { name: "Confirm reassignment" }));
+
+    expect(await screen.findByText("You do not have permission to correct face assignments.")).toBeInTheDocument();
+  });
+
+  it("disables correction controls while correction request is in flight", async () => {
+    const user = userEvent.setup();
+    let resolveRequest: ((value: Response) => void) | undefined;
+
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveRequest = resolve as (value: Response) => void;
+        })
+    );
+
+    render(
+      <FaceAssignmentControls
+        faces={[{ face_id: "face-1", person_id: "person-1" }]}
+        people={[
+          { person_id: "person-1", display_name: "Inez" },
+          { person_id: "person-2", display_name: "Mateo" }
+        ]}
+        onAssigned={vi.fn()}
+        onCorrected={onCorrected}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText("Correct face 1"), "person-2");
+    await user.click(screen.getByRole("button", { name: "Confirm reassignment" }));
+    expect(screen.getByLabelText("Correct face 1")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Confirm reassignment" })).toBeDisabled();
+
+    expect(resolveRequest).toBeDefined();
+    resolveRequest!({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        face_id: "face-1",
+        photo_id: "photo-1",
+        previous_person_id: "person-1",
+        person_id: "person-2"
+      })
+    } as Response);
+
+    await waitFor(() => {
+      expect(onCorrected).toHaveBeenCalledWith("face-1", "person-2");
+    });
   });
 });

--- a/apps/ui/src/pages/FaceAssignmentControls.tsx
+++ b/apps/ui/src/pages/FaceAssignmentControls.tsx
@@ -14,6 +14,7 @@ interface FaceAssignmentControlsProps {
   faces: FaceAssignmentFace[];
   people: FaceAssignmentPerson[];
   onAssigned: (faceId: string, personId: string) => void;
+  onCorrected: (faceId: string, personId: string) => void;
 }
 
 async function readErrorDetail(response: Response): Promise<string | null> {
@@ -45,17 +46,64 @@ function mapAssignmentError(status: number, detail: string | null): string {
   return `Assignment request failed (${status}).`;
 }
 
-export function FaceAssignmentControls({ faces, people, onAssigned }: FaceAssignmentControlsProps) {
-  const unlabeledFaces = useMemo(() => faces.filter((face) => face.person_id === null), [faces]);
+function mapCorrectionError(status: number, detail: string | null): string {
+  if (status === 403) {
+    return "You do not have permission to correct face assignments.";
+  }
+
+  if (status === 404) {
+    return detail ?? "Face or person no longer exists.";
+  }
+
+  if (status === 409) {
+    return detail ?? "Face correction could not be applied.";
+  }
+
+  return `Correction request failed (${status}).`;
+}
+
+function resolvePersonLabel(people: FaceAssignmentPerson[], personId: string): string {
+  const match = people.find((person) => person.person_id === personId);
+  return match ? match.display_name : personId;
+}
+
+export function FaceAssignmentControls({
+  faces,
+  people,
+  onAssigned,
+  onCorrected
+}: FaceAssignmentControlsProps) {
+  const indexedFaces = useMemo(
+    () => faces.map((face, index) => ({ ...face, sequence: index + 1 })),
+    [faces]
+  );
+  const unlabeledFaces = useMemo(
+    () => indexedFaces.filter((face) => face.person_id === null),
+    [indexedFaces]
+  );
+  const labeledFaces = useMemo(
+    () =>
+      indexedFaces.filter(
+        (face): face is FaceAssignmentFace & { sequence: number; person_id: string } =>
+          face.person_id !== null
+      ),
+    [indexedFaces]
+  );
   const [activeIndex, setActiveIndex] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [assignmentError, setAssignmentError] = useState<string | null>(null);
+  const [correctionSelections, setCorrectionSelections] = useState<Record<string, string>>({});
+  const [correctionFaceIdInFlight, setCorrectionFaceIdInFlight] = useState<string | null>(null);
+  const [correctionError, setCorrectionError] = useState<string | null>(null);
+  const [correctionProvenance, setCorrectionProvenance] = useState<string | null>(null);
 
   const activeFace = unlabeledFaces[activeIndex] ?? null;
+  const isBusy = isSubmitting || correctionFaceIdInFlight !== null;
 
   async function assign(faceId: string, personId: string) {
     setIsSubmitting(true);
-    setError(null);
+    setAssignmentError(null);
+    setCorrectionProvenance(null);
 
     try {
       const response = await fetch(`/api/v1/faces/${faceId}/assignments`, {
@@ -69,50 +117,150 @@ export function FaceAssignmentControls({ faces, people, onAssigned }: FaceAssign
 
       if (!response.ok) {
         const detail = await readErrorDetail(response);
-        setError(mapAssignmentError(response.status, detail));
+        setAssignmentError(mapAssignmentError(response.status, detail));
         return;
       }
 
       onAssigned(faceId, personId);
       setActiveIndex((current) => current + 1);
     } catch {
-      setError("Could not assign face.");
+      setAssignmentError("Could not assign face.");
     } finally {
       setIsSubmitting(false);
     }
   }
 
-  if (activeFace === null) {
-    return <p className="detail-face-assignment-complete">All visible faces assigned.</p>;
+  async function correct(faceId: string, previousPersonId: string, personId: string) {
+    setCorrectionFaceIdInFlight(faceId);
+    setCorrectionError(null);
+    setAssignmentError(null);
+    setCorrectionProvenance(null);
+
+    try {
+      const response = await fetch(`/api/v1/faces/${faceId}/corrections`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Face-Validation-Role": "contributor"
+        },
+        body: JSON.stringify({ person_id: personId })
+      });
+
+      if (!response.ok) {
+        const detail = await readErrorDetail(response);
+        setCorrectionError(mapCorrectionError(response.status, detail));
+        return;
+      }
+
+      const payload = (await response.json()) as { previous_person_id?: string; person_id?: string };
+      const previousId = payload.previous_person_id ?? previousPersonId;
+      const nextId = payload.person_id ?? personId;
+      onCorrected(faceId, nextId);
+      setCorrectionSelections((current) => {
+        const { [faceId]: _discard, ...rest } = current;
+        return rest;
+      });
+      setCorrectionProvenance(
+        `Correction recorded: ${resolvePersonLabel(people, previousId)} -> ${resolvePersonLabel(people, nextId)}.`
+      );
+    } catch {
+      setCorrectionError("Could not correct face assignment.");
+    } finally {
+      setCorrectionFaceIdInFlight(null);
+    }
   }
 
   return (
-    <section className="detail-face-assignment" aria-label="Face assignment">
-      <h3>Assign detected faces</h3>
-      <label htmlFor={`assign-${activeFace.face_id}`}>{`Assign face ${activeIndex + 1}`}</label>
-      <select
-        id={`assign-${activeFace.face_id}`}
-        aria-label={`Assign face ${activeIndex + 1}`}
-        disabled={isSubmitting}
-        value=""
-        onChange={(event) => {
-          const personId = event.target.value;
-          if (!personId) {
-            return;
-          }
-          void assign(activeFace.face_id, personId);
-        }}
-      >
-        <option value="" disabled>
-          Select person
-        </option>
-        {people.map((person) => (
-          <option key={person.person_id} value={person.person_id}>
-            {person.display_name}
-          </option>
-        ))}
-      </select>
-      {error ? <p className="detail-face-assignment-error">{error}</p> : null}
-    </section>
+    <>
+      <section className="detail-face-assignment" aria-label="Face assignment">
+        <h3>Assign detected faces</h3>
+        {activeFace === null ? (
+          <p className="detail-face-assignment-complete">All visible faces assigned.</p>
+        ) : (
+          <>
+            <label htmlFor={`assign-${activeFace.face_id}`}>{`Assign face ${activeIndex + 1}`}</label>
+            <select
+              id={`assign-${activeFace.face_id}`}
+              aria-label={`Assign face ${activeIndex + 1}`}
+              disabled={isBusy}
+              value=""
+              onChange={(event) => {
+                const personId = event.target.value;
+                if (!personId) {
+                  return;
+                }
+                void assign(activeFace.face_id, personId);
+              }}
+            >
+              <option value="" disabled>
+                Select person
+              </option>
+              {people.map((person) => (
+                <option key={person.person_id} value={person.person_id}>
+                  {person.display_name}
+                </option>
+              ))}
+            </select>
+          </>
+        )}
+        {assignmentError ? <p className="detail-face-assignment-error">{assignmentError}</p> : null}
+      </section>
+
+      {labeledFaces.length > 0 ? (
+        <section className="detail-face-correction" aria-label="Face correction">
+          <h3>Correct labeled faces</h3>
+          <ul>
+            {labeledFaces.map((face) => {
+              const selectedPersonId = correctionSelections[face.face_id] ?? "";
+              return (
+                <li key={face.face_id}>
+                  <p>{`Face ${face.sequence}: ${resolvePersonLabel(people, face.person_id)}`}</p>
+                  <div className="detail-face-correction-controls">
+                    <select
+                      id={`correct-${face.face_id}`}
+                      aria-label={`Correct face ${face.sequence}`}
+                      disabled={isBusy}
+                      value={selectedPersonId}
+                      onChange={(event) => {
+                        const personId = event.target.value;
+                        setCorrectionSelections((current) => ({
+                          ...current,
+                          [face.face_id]: personId
+                        }));
+                      }}
+                    >
+                      <option value="">Select replacement person</option>
+                      {people
+                        .filter((person) => person.person_id !== face.person_id)
+                        .map((person) => (
+                          <option key={person.person_id} value={person.person_id}>
+                            {person.display_name}
+                          </option>
+                        ))}
+                    </select>
+                    <button
+                      type="button"
+                      disabled={isBusy || selectedPersonId.length === 0}
+                      onClick={() => {
+                        if (!selectedPersonId) {
+                          return;
+                        }
+                        void correct(face.face_id, face.person_id, selectedPersonId);
+                      }}
+                    >
+                      Confirm reassignment
+                    </button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+          {correctionProvenance ? (
+            <p className="detail-face-correction-provenance">{correctionProvenance}</p>
+          ) : null}
+          {correctionError ? <p className="detail-face-assignment-error">{correctionError}</p> : null}
+        </section>
+      ) : null}
+    </>
   );
 }

--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -287,6 +287,66 @@ describe("PhotoDetailRoutePage", () => {
     expect(screen.getByText("person-1")).toBeInTheDocument();
   });
 
+  it("updates local face state after correction success and shows correction provenance", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          buildPayload({
+            people: ["person-1"],
+            faces: [
+              {
+                face_id: "face-1",
+                person_id: "person-1",
+                bbox_x: 10,
+                bbox_y: 10,
+                bbox_w: 20,
+                bbox_h: 20
+              }
+            ]
+          })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            person_id: "person-1",
+            display_name: "Inez",
+            created_ts: "2026-03-28T19:30:00Z",
+            updated_ts: "2026-03-28T19:30:00Z"
+          },
+          {
+            person_id: "person-2",
+            display_name: "Mateo",
+            created_ts: "2026-03-28T19:30:00Z",
+            updated_ts: "2026-03-28T19:30:00Z"
+          }
+        ]
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          face_id: "face-1",
+          photo_id: "photo-1",
+          previous_person_id: "person-1",
+          person_id: "person-2"
+        })
+      } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
+    await user.selectOptions(await screen.findByLabelText("Correct face 1"), "person-2");
+    await user.click(screen.getByRole("button", { name: "Confirm reassignment" }));
+
+    expect(await screen.findByText("Correction recorded: Inez -> Mateo.")).toBeInTheDocument();
+    expect(screen.getByText("Face 1: Mateo")).toBeInTheDocument();
+    expect(screen.getByText("person-2")).toBeInTheDocument();
+  });
+
   it("renders deterministic loading and error transitions", async () => {
     fetchMock.mockResolvedValueOnce({
       ok: false,

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -459,6 +459,7 @@ export function PhotoDetailRoutePage() {
                     display_name: person.display_name
                   }))}
                   onAssigned={handleFaceAssigned}
+                  onCorrected={handleFaceAssigned}
                 />
               </>
             ) : (
@@ -477,6 +478,7 @@ export function PhotoDetailRoutePage() {
                     display_name: person.display_name
                   }))}
                   onAssigned={handleFaceAssigned}
+                  onCorrected={handleFaceAssigned}
                 />
               </>
             )}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -561,6 +561,53 @@ body {
   color: #334155;
 }
 
+.detail-face-correction {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.detail-face-correction h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.detail-face-correction ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.detail-face-correction li {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.detail-face-correction li p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #334155;
+}
+
+.detail-face-correction-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.detail-face-correction-controls select {
+  min-width: 14rem;
+}
+
+.detail-face-correction-provenance {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #1d4ed8;
+}
+
 .ingest-status-badge {
   border-radius: 999px;
   border: 1px solid transparent;


### PR DESCRIPTION
## Summary
- implement labeled-face correction and reassignment interactions in photo detail
- keep existing unlabeled-face assignment flow intact while adding correction controls and deterministic correction error handling
- update local detail state immediately after correction and surface correction provenance feedback (`previous -> new`)

## What Changed
- extended `FaceAssignmentControls` with a correction section for already-labeled faces
- added correction API flow via `POST /api/v1/faces/{face_id}/corrections`
- mapped correction failures into deterministic inline UI messages
- wired correction success through the same parent state update path used by assignment
- added correction-focused CSS for row layout and provenance message
- expanded tests for correction success/error/in-flight behavior and route-level state updates

## Validation
- `npm --prefix apps/ui test -- src/pages/FaceAssignmentControls.test.tsx src/pages/PhotoDetailRoutePage.test.tsx`
- `npm --prefix apps/ui test`
- `npm --prefix apps/ui run build`

## Issue
- Closes #184