### PR TITLE
feat(ui): add face label provenance badges and inline details (#185)

### DIFF
--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -31,6 +31,7 @@ class PhotosRepository:
         self.faces: Table = Table("faces", md, autoload_with=bind)
         self.people: Table = Table("people", md, autoload_with=bind)
         self.photo_tags: Table = Table("photo_tags", md, autoload_with=bind)
+        self.face_labels: Table = Table("face_labels", md, autoload_with=bind)
         self.photo_files: Table = Table("photo_files", md, autoload_with=bind)
         self.watched_folders: Table = Table("watched_folders", md, autoload_with=bind)
         self.storage_sources: Table = Table("storage_sources", md, autoload_with=bind)
@@ -414,15 +415,76 @@ class PhotosRepository:
                 ]
             )
 
-        for r in self.db.execute(
+        face_rows = self.db.execute(
             select(*face_columns)
             .where(self.faces.c.photo_id.in_(pids))
             .order_by(self.faces.c.photo_id, self.faces.c.face_id)
-        ).all():
+        ).all()
+
+        provenance_map: Dict[tuple[str, str], Dict[str, Any]] = {}
+        if include_face_regions:
+            labeled_face_keys = {
+                (str(r.face_id), str(r.person_id))
+                for r in face_rows
+                if r.person_id is not None and r.face_id is not None
+            }
+            if labeled_face_keys:
+                face_ids = sorted({face_id for face_id, _ in labeled_face_keys})
+                label_rows = (
+                    self.db.execute(
+                        select(
+                            self.face_labels.c.face_id,
+                            self.face_labels.c.person_id,
+                            self.face_labels.c.label_source,
+                            self.face_labels.c.confidence,
+                            self.face_labels.c.model_version,
+                            self.face_labels.c.provenance,
+                            self.face_labels.c.created_ts,
+                            self.face_labels.c.updated_ts,
+                            self.face_labels.c.face_label_id,
+                        )
+                        .where(self.face_labels.c.face_id.in_(face_ids))
+                        .order_by(
+                            self.face_labels.c.face_id,
+                            self.face_labels.c.person_id,
+                            self.face_labels.c.updated_ts.desc(),
+                            self.face_labels.c.created_ts.desc(),
+                            self.face_labels.c.face_label_id.desc(),
+                        )
+                    )
+                    .mappings()
+                    .all()
+                )
+                for row in label_rows:
+                    person_id = row["person_id"]
+                    face_id = row["face_id"]
+                    if person_id is None or face_id is None:
+                        continue
+                    key = (str(face_id), str(person_id))
+                    if key not in labeled_face_keys or key in provenance_map:
+                        continue
+                    provenance_map[key] = {
+                        "label_source": row["label_source"],
+                        "confidence": row["confidence"],
+                        "model_version": row["model_version"],
+                        "provenance": row["provenance"],
+                        "label_recorded_ts": (
+                            iso_utc(row["updated_ts"])
+                            if row["updated_ts"] is not None
+                            else (iso_utc(row["created_ts"]) if row["created_ts"] is not None else None)
+                        ),
+                    }
+
+        for r in face_rows:
             if r.person_id:
                 ppl_map[r.photo_id].append(r.person_id)
             face_item = {"person_id": r.person_id}
             if include_face_regions:
+                provenance = (
+                    provenance_map.get((str(r.face_id), str(r.person_id)))
+                    if r.person_id is not None
+                    else None
+                )
                 face_item.update(
                     {
                         "face_id": r.face_id,
@@ -430,6 +492,11 @@ class PhotosRepository:
                         "bbox_y": r.bbox_y,
                         "bbox_w": r.bbox_w,
                         "bbox_h": r.bbox_h,
+                        "label_source": provenance["label_source"] if provenance else None,
+                        "confidence": provenance["confidence"] if provenance else None,
+                        "model_version": provenance["model_version"] if provenance else None,
+                        "provenance": provenance["provenance"] if provenance else None,
+                        "label_recorded_ts": provenance["label_recorded_ts"] if provenance else None,
                     }
                 )
             faces_map[r.photo_id].append(face_item)

--- a/apps/api/app/schemas/photo_response.py
+++ b/apps/api/app/schemas/photo_response.py
@@ -20,6 +20,26 @@ class PhotoDetailFace(BaseModel):
     bbox_y: int | None = Field(default=None, description="Bounding-box y coordinate.")
     bbox_w: int | None = Field(default=None, description="Bounding-box width in pixels.")
     bbox_h: int | None = Field(default=None, description="Bounding-box height in pixels.")
+    label_source: str | None = Field(
+        default=None,
+        description="Latest face-label source for the current assigned person, if available.",
+    )
+    confidence: float | None = Field(
+        default=None,
+        description="Confidence for machine-produced label records, if available.",
+    )
+    model_version: str | None = Field(
+        default=None,
+        description="Model version attached to latest label provenance, if available.",
+    )
+    provenance: dict[str, object] | None = Field(
+        default=None,
+        description="Raw provenance payload for the latest matching label record.",
+    )
+    label_recorded_ts: str | None = Field(
+        default=None,
+        description="Timestamp of the latest matching label record.",
+    )
 
 
 class PhotoMetadataProjection(BaseModel):

--- a/apps/api/tests/test_photo_detail_api.py
+++ b/apps/api/tests/test_photo_detail_api.py
@@ -8,7 +8,7 @@ from sqlalchemy import create_engine, insert
 from app.dependencies import _get_session_factory
 from app.main import app
 from app.migrations import upgrade_database
-from app.storage import faces, photo_tags, photos
+from app.storage import face_labels, faces, people, photo_tags, photos
 
 
 def test_photo_detail_api_returns_projected_metadata_and_related_fields(tmp_path, monkeypatch):
@@ -75,6 +75,11 @@ def test_photo_detail_api_returns_projected_metadata_and_related_fields(tmp_path
             "bbox_y": 20,
             "bbox_w": 30,
             "bbox_h": 40,
+            "label_source": None,
+            "confidence": None,
+            "model_version": None,
+            "provenance": None,
+            "label_recorded_ts": None,
         }
     ]
     assert payload["thumbnail"] is None
@@ -137,3 +142,113 @@ def test_photo_detail_api_allows_missing_shot_timestamp(tmp_path, monkeypatch):
     assert payload["photo_id"] == "photo-1"
     assert payload["shot_ts"] is None
     assert payload["faces"] == []
+
+
+def test_photo_detail_api_returns_latest_matching_face_label_provenance(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'photo-detail-api-provenance.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 3, 28, 19, 30, tzinfo=UTC)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                sha256="sha-1",
+                phash="phash-1",
+                shot_ts=now,
+                shot_ts_source="exif:DateTimeOriginal",
+                camera_make="Apple",
+                camera_model="iPhone 15 Pro",
+                software="18.1",
+                orientation="Rotate 90 CW",
+                created_ts=now,
+                updated_ts=now,
+                path="/photos/photo-1.jpg",
+                filesize=1024,
+                ext="jpg",
+                modified_ts=now,
+                faces_count=1,
+                faces_detected_ts=now,
+            )
+        )
+        connection.execute(
+            insert(people).values(
+                person_id="person-1",
+                display_name="Inez",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+                bbox_x=10,
+                bbox_y=20,
+                bbox_w=30,
+                bbox_h=40,
+            )
+        )
+        connection.execute(
+            insert(face_labels).values(
+                face_label_id="face-label-1",
+                face_id="face-1",
+                person_id="person-1",
+                label_source="machine_applied",
+                confidence=0.71,
+                model_version="recognizer-v1",
+                provenance={
+                    "workflow": "recognition-suggestions",
+                    "surface": "api",
+                    "action": "auto_apply",
+                },
+                created_ts=datetime(2026, 3, 28, 19, 30, tzinfo=UTC),
+                updated_ts=datetime(2026, 3, 28, 19, 31, tzinfo=UTC),
+            )
+        )
+        connection.execute(
+            insert(face_labels).values(
+                face_label_id="face-label-2",
+                face_id="face-1",
+                person_id="person-1",
+                label_source="human_confirmed",
+                confidence=None,
+                model_version=None,
+                provenance={
+                    "workflow": "face-labeling",
+                    "surface": "api",
+                    "action": "correction",
+                },
+                created_ts=datetime(2026, 3, 28, 19, 32, tzinfo=UTC),
+                updated_ts=datetime(2026, 3, 28, 19, 33, tzinfo=UTC),
+            )
+        )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/photos/photo-1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["faces"] == [
+        {
+            "face_id": "face-1",
+            "person_id": "person-1",
+            "bbox_x": 10,
+            "bbox_y": 20,
+            "bbox_w": 30,
+            "bbox_h": 40,
+            "label_source": "human_confirmed",
+            "confidence": None,
+            "model_version": None,
+            "provenance": {
+                "workflow": "face-labeling",
+                "surface": "api",
+                "action": "correction",
+            },
+            "label_recorded_ts": "2026-03-28T19:33:00Z",
+        }
+    ]

--- a/apps/ui/src/pages/FaceAssignmentControls.test.tsx
+++ b/apps/ui/src/pages/FaceAssignmentControls.test.tsx
@@ -338,4 +338,56 @@ describe("FaceAssignmentControls", () => {
       expect(onCorrected).toHaveBeenCalledWith("face-1", "person-2");
     });
   });
+
+  it("renders provenance badges and expands inline provenance details with fallback values", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <FaceAssignmentControls
+        faces={
+          [
+            {
+              face_id: "face-1",
+              person_id: "person-1",
+              label_source: "human_confirmed",
+              confidence: null,
+              model_version: null,
+              provenance: {
+                workflow: "face-labeling",
+                surface: "api",
+                action: "correction"
+              },
+              label_recorded_ts: "2026-03-28T19:33:00Z"
+            },
+            {
+              face_id: "face-2",
+              person_id: "person-2",
+              label_source: null,
+              confidence: null,
+              model_version: null,
+              provenance: null,
+              label_recorded_ts: null
+            }
+          ] as any
+        }
+        people={[
+          { person_id: "person-1", display_name: "Inez" },
+          { person_id: "person-2", display_name: "Mateo" }
+        ]}
+        onAssigned={vi.fn()}
+        onCorrected={onCorrected}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Show provenance details for face 1" })).toHaveTextContent("👤");
+    expect(screen.getByRole("button", { name: "Show provenance details for face 2" })).toHaveTextContent("❓");
+
+    await user.click(screen.getByRole("button", { name: "Show provenance details for face 1" }));
+
+    expect(await screen.findByText("Source")).toBeInTheDocument();
+    expect(screen.getByText("Human confirmed")).toBeInTheDocument();
+    expect(screen.getByText("correction")).toBeInTheDocument();
+    expect(screen.getByText("face-labeling")).toBeInTheDocument();
+    expect(screen.getAllByText("Not available").length).toBeGreaterThan(0);
+  });
 });

--- a/apps/ui/src/pages/FaceAssignmentControls.tsx
+++ b/apps/ui/src/pages/FaceAssignmentControls.tsx
@@ -1,8 +1,17 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+type FaceLabelSource = "human_confirmed" | "machine_applied" | "machine_suggested" | null;
+
+const NOT_AVAILABLE = "Not available";
 
 export interface FaceAssignmentFace {
   face_id: string;
   person_id: string | null;
+  label_source?: FaceLabelSource;
+  confidence?: number | null;
+  model_version?: string | null;
+  provenance?: Record<string, unknown> | null;
+  label_recorded_ts?: string | null;
 }
 
 export interface FaceAssignmentPerson {
@@ -15,6 +24,7 @@ interface FaceAssignmentControlsProps {
   people: FaceAssignmentPerson[];
   onAssigned: (faceId: string, personId: string) => void;
   onCorrected: (faceId: string, personId: string) => void;
+  requestedExpandedProvenanceFaceId?: string | null;
 }
 
 async function readErrorDetail(response: Response): Promise<string | null> {
@@ -67,11 +77,69 @@ function resolvePersonLabel(people: FaceAssignmentPerson[], personId: string): s
   return match ? match.display_name : personId;
 }
 
+function provenanceBadgeIcon(source: FaceLabelSource | undefined): string {
+  if (source === "human_confirmed") {
+    return "👤";
+  }
+  if (source === "machine_applied") {
+    return "🤖";
+  }
+  if (source === "machine_suggested") {
+    return "💡";
+  }
+  return "❓";
+}
+
+function provenanceSourceLabel(source: FaceLabelSource | undefined): string {
+  if (source === "human_confirmed") {
+    return "Human confirmed";
+  }
+  if (source === "machine_applied") {
+    return "Machine applied";
+  }
+  if (source === "machine_suggested") {
+    return "Machine suggested";
+  }
+  return "Unknown";
+}
+
+function readProvenanceValue(face: FaceAssignmentFace, key: string): string {
+  if (!face.provenance || typeof face.provenance !== "object") {
+    return NOT_AVAILABLE;
+  }
+  const value = face.provenance[key];
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return NOT_AVAILABLE;
+}
+
+function formatConfidence(confidence: number | null | undefined): string {
+  if (typeof confidence !== "number" || !Number.isFinite(confidence)) {
+    return NOT_AVAILABLE;
+  }
+  if (confidence < 0 || confidence > 1) {
+    return NOT_AVAILABLE;
+  }
+  return `${(confidence * 100).toFixed(1)}%`;
+}
+
+function formatRecordedTimestamp(value: string | null | undefined): string {
+  if (!value || value.trim().length === 0) {
+    return NOT_AVAILABLE;
+  }
+  return value;
+}
+
 export function FaceAssignmentControls({
   faces,
   people,
   onAssigned,
-  onCorrected
+  onCorrected,
+  requestedExpandedProvenanceFaceId = null
 }: FaceAssignmentControlsProps) {
   const indexedFaces = useMemo(
     () => faces.map((face, index) => ({ ...face, sequence: index + 1 })),
@@ -96,9 +164,22 @@ export function FaceAssignmentControls({
   const [correctionFaceIdInFlight, setCorrectionFaceIdInFlight] = useState<string | null>(null);
   const [correctionError, setCorrectionError] = useState<string | null>(null);
   const [correctionProvenance, setCorrectionProvenance] = useState<string | null>(null);
+  const [expandedProvenanceFaceId, setExpandedProvenanceFaceId] = useState<string | null>(null);
 
   const activeFace = unlabeledFaces[activeIndex] ?? null;
   const isBusy = isSubmitting || correctionFaceIdInFlight !== null;
+
+  useEffect(() => {
+    if (!requestedExpandedProvenanceFaceId) {
+      return;
+    }
+    const isKnownLabeledFace = labeledFaces.some(
+      (face) => face.face_id === requestedExpandedProvenanceFaceId
+    );
+    if (isKnownLabeledFace) {
+      setExpandedProvenanceFaceId(requestedExpandedProvenanceFaceId);
+    }
+  }, [requestedExpandedProvenanceFaceId, labeledFaces]);
 
   async function assign(faceId: string, personId: string) {
     setIsSubmitting(true);
@@ -212,9 +293,25 @@ export function FaceAssignmentControls({
           <ul>
             {labeledFaces.map((face) => {
               const selectedPersonId = correctionSelections[face.face_id] ?? "";
+              const isProvenanceExpanded = expandedProvenanceFaceId === face.face_id;
               return (
                 <li key={face.face_id}>
-                  <p>{`Face ${face.sequence}: ${resolvePersonLabel(people, face.person_id)}`}</p>
+                  <div className="detail-face-correction-row">
+                    <p>{`Face ${face.sequence}: ${resolvePersonLabel(people, face.person_id)}`}</p>
+                    <button
+                      type="button"
+                      className="detail-face-provenance-badge"
+                      aria-label={`Show provenance details for face ${face.sequence}`}
+                      aria-expanded={isProvenanceExpanded}
+                      onClick={() => {
+                        setExpandedProvenanceFaceId((current) =>
+                          current === face.face_id ? null : face.face_id
+                        );
+                      }}
+                    >
+                      {provenanceBadgeIcon(face.label_source)}
+                    </button>
+                  </div>
                   <div className="detail-face-correction-controls">
                     <select
                       id={`correct-${face.face_id}`}
@@ -251,6 +348,41 @@ export function FaceAssignmentControls({
                       Confirm reassignment
                     </button>
                   </div>
+                  {isProvenanceExpanded ? (
+                    <dl
+                      className="detail-face-provenance-details"
+                      aria-label={`Provenance details for face ${face.sequence}`}
+                    >
+                      <div>
+                        <dt>Source</dt>
+                        <dd>{provenanceSourceLabel(face.label_source)}</dd>
+                      </div>
+                      <div>
+                        <dt>Action</dt>
+                        <dd>{readProvenanceValue(face, "action")}</dd>
+                      </div>
+                      <div>
+                        <dt>Surface</dt>
+                        <dd>{readProvenanceValue(face, "surface")}</dd>
+                      </div>
+                      <div>
+                        <dt>Workflow</dt>
+                        <dd>{readProvenanceValue(face, "workflow")}</dd>
+                      </div>
+                      <div>
+                        <dt>Model version</dt>
+                        <dd>{face.model_version ?? NOT_AVAILABLE}</dd>
+                      </div>
+                      <div>
+                        <dt>Confidence</dt>
+                        <dd>{formatConfidence(face.confidence)}</dd>
+                      </div>
+                      <div>
+                        <dt>Recorded</dt>
+                        <dd>{formatRecordedTimestamp(face.label_recorded_ts)}</dd>
+                      </div>
+                    </dl>
+                  ) : null}
                 </li>
               );
             })}

--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -20,6 +20,11 @@ interface PhotoDetailPayload {
     bbox_y: number | null;
     bbox_w: number | null;
     bbox_h: number | null;
+    label_source: "human_confirmed" | "machine_applied" | "machine_suggested" | null;
+    confidence: number | null;
+    model_version: string | null;
+    provenance: Record<string, unknown> | null;
+    label_recorded_ts: string | null;
   }>;
   thumbnail: {
     mime_type: string;
@@ -68,7 +73,12 @@ function buildPayload(partial: Partial<PhotoDetailPayload> = {}): PhotoDetailPay
         bbox_x: 10,
         bbox_y: 20,
         bbox_w: 30,
-        bbox_h: 40
+        bbox_h: 40,
+        label_source: null,
+        confidence: null,
+        model_version: null,
+        provenance: null,
+        label_recorded_ts: null
       }
     ],
     thumbnail: {
@@ -252,7 +262,12 @@ describe("PhotoDetailRoutePage", () => {
                 bbox_x: 10,
                 bbox_y: 10,
                 bbox_w: 20,
-                bbox_h: 20
+                bbox_h: 20,
+                label_source: null,
+                confidence: null,
+                model_version: null,
+                provenance: null,
+                label_recorded_ts: null
               }
             ]
           })
@@ -303,7 +318,16 @@ describe("PhotoDetailRoutePage", () => {
                 bbox_x: 10,
                 bbox_y: 10,
                 bbox_w: 20,
-                bbox_h: 20
+                bbox_h: 20,
+                label_source: "human_confirmed",
+                confidence: null,
+                model_version: null,
+                provenance: {
+                  workflow: "face-labeling",
+                  surface: "api",
+                  action: "correction"
+                },
+                label_recorded_ts: "2026-03-28T19:33:00Z"
               }
             ]
           })
@@ -345,6 +369,57 @@ describe("PhotoDetailRoutePage", () => {
     expect(await screen.findByText("Correction recorded: Inez -> Mateo.")).toBeInTheDocument();
     expect(screen.getByText("Face 1: Mateo")).toBeInTheDocument();
     expect(screen.getByText("person-2")).toBeInTheDocument();
+  });
+
+  it("opens inline provenance details when overlay provenance badge is clicked", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          buildPayload({
+            faces: [
+              {
+                face_id: "face-1",
+                person_id: "person-1",
+                bbox_x: 10,
+                bbox_y: 10,
+                bbox_w: 20,
+                bbox_h: 20,
+                label_source: "human_confirmed",
+                confidence: null,
+                model_version: null,
+                provenance: {
+                  workflow: "face-labeling",
+                  surface: "api",
+                  action: "correction"
+                },
+                label_recorded_ts: "2026-03-28T19:33:00Z"
+              }
+            ]
+          })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            person_id: "person-1",
+            display_name: "Inez",
+            created_ts: "2026-03-28T19:30:00Z",
+            updated_ts: "2026-03-28T19:30:00Z"
+          }
+        ]
+      } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByLabelText("Face region 1 for person-1")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show provenance details for face region 1" }));
+
+    expect(await screen.findByLabelText("Provenance details for face 1")).toBeInTheDocument();
+    expect(screen.getByText("Human confirmed")).toBeInTheDocument();
+    expect(screen.getByText("correction")).toBeInTheDocument();
   });
 
   it("renders deterministic loading and error transitions", async () => {

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -24,6 +24,11 @@ type PhotoDetailPayload = {
     bbox_y: number | null;
     bbox_w: number | null;
     bbox_h: number | null;
+    label_source: "human_confirmed" | "machine_applied" | "machine_suggested" | null;
+    confidence: number | null;
+    model_version: string | null;
+    provenance: Record<string, unknown> | null;
+    label_recorded_ts: string | null;
   }>;
   thumbnail: {
     mime_type: string;
@@ -61,6 +66,7 @@ type MediaPresentationMode = "fit" | "actual";
 type FaceOverlayRegion = {
   faceId: string;
   personId: string | null;
+  labelSource: "human_confirmed" | "machine_applied" | "machine_suggested" | null;
   leftPercent: number;
   topPercent: number;
   widthPercent: number;
@@ -155,7 +161,17 @@ function applyFaceAssignment(
   personId: string
 ): PhotoDetailPayload {
   const nextFaces = detail.faces.map((face) =>
-    face.face_id === faceId ? { ...face, person_id: personId } : face
+    face.face_id === faceId
+      ? {
+          ...face,
+          person_id: personId,
+          label_source: null,
+          confidence: null,
+          model_version: null,
+          provenance: null,
+          label_recorded_ts: null,
+        }
+      : face
   );
   const nextPeople = Array.from(
     new Set(
@@ -172,6 +188,21 @@ function applyFaceAssignment(
   };
 }
 
+function provenanceBadgeIcon(
+  source: "human_confirmed" | "machine_applied" | "machine_suggested" | null
+): string {
+  if (source === "human_confirmed") {
+    return "👤";
+  }
+  if (source === "machine_applied") {
+    return "🤖";
+  }
+  if (source === "machine_suggested") {
+    return "💡";
+  }
+  return "❓";
+}
+
 export function PhotoDetailRoutePage() {
   const location = useLocation();
   const { photoId } = useParams<{ photoId: string }>();
@@ -184,6 +215,9 @@ export function PhotoDetailRoutePage() {
   const [reloadToken, setReloadToken] = useState(0);
   const [mediaMode, setMediaMode] = useState<MediaPresentationMode>("fit");
   const [peopleDirectory, setPeopleDirectory] = useState<PersonRecord[]>([]);
+  const [requestedExpandedProvenanceFaceId, setRequestedExpandedProvenanceFaceId] = useState<
+    string | null
+  >(null);
 
   useEffect(() => {
     headingRef.current?.focus();
@@ -300,6 +334,7 @@ export function PhotoDetailRoutePage() {
         return {
           faceId: face.face_id,
           personId: face.person_id,
+          labelSource: face.label_source,
           leftPercent: left,
           topPercent: top,
           widthPercent: width,
@@ -442,7 +477,18 @@ export function PhotoDetailRoutePage() {
                               width: `${region.widthPercent}%`,
                               height: `${region.heightPercent}%`
                             }}
-                          />
+                          >
+                            <button
+                              type="button"
+                              className="detail-face-overlay-provenance-button"
+                              aria-label={`Show provenance details for face region ${index + 1}`}
+                              onClick={() => {
+                                setRequestedExpandedProvenanceFaceId(region.faceId);
+                              }}
+                            >
+                              {provenanceBadgeIcon(region.labelSource)}
+                            </button>
+                          </li>
                         ))}
                       </ol>
                     ) : null}
@@ -450,16 +496,14 @@ export function PhotoDetailRoutePage() {
                 </div>
                 <p className="detail-face-state">{faceRegionState}</p>
                 <FaceAssignmentControls
-                  faces={detail.faces.map((face) => ({
-                    face_id: face.face_id,
-                    person_id: face.person_id
-                  }))}
+                  faces={detail.faces}
                   people={peopleDirectory.map((person) => ({
                     person_id: person.person_id,
                     display_name: person.display_name
                   }))}
                   onAssigned={handleFaceAssigned}
                   onCorrected={handleFaceAssigned}
+                  requestedExpandedProvenanceFaceId={requestedExpandedProvenanceFaceId}
                 />
               </>
             ) : (
@@ -469,16 +513,14 @@ export function PhotoDetailRoutePage() {
                 </div>
                 <p className="detail-face-state">{faceRegionState}</p>
                 <FaceAssignmentControls
-                  faces={detail.faces.map((face) => ({
-                    face_id: face.face_id,
-                    person_id: face.person_id
-                  }))}
+                  faces={detail.faces}
                   people={peopleDirectory.map((person) => ({
                     person_id: person.person_id,
                     display_name: person.display_name
                   }))}
                   onAssigned={handleFaceAssigned}
                   onCorrected={handleFaceAssigned}
+                  requestedExpandedProvenanceFaceId={requestedExpandedProvenanceFaceId}
                 />
               </>
             )}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -528,6 +528,25 @@ body {
   box-shadow: 0 0 0 1px rgb(255 255 255 / 85%);
 }
 
+.detail-face-overlay-provenance-button {
+  pointer-events: auto;
+  position: absolute;
+  top: -0.55rem;
+  right: -0.55rem;
+  width: 1.45rem;
+  height: 1.45rem;
+  border-radius: 999px;
+  border: 1px solid #f97316;
+  background: #fff7ed;
+  font-size: 0.7rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
 .detail-face-state {
   margin: 0;
   font-size: 0.82rem;
@@ -591,6 +610,33 @@ body {
   color: #334155;
 }
 
+.detail-face-correction-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.detail-face-provenance-badge {
+  border: 1px solid #cbd5e1;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #0f172a;
+  font-size: 0.8rem;
+  line-height: 1;
+  width: 1.9rem;
+  height: 1.9rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.detail-face-provenance-badge[aria-expanded="true"] {
+  border-color: #93c5fd;
+  background: #eff6ff;
+}
+
 .detail-face-correction-controls {
   display: flex;
   flex-wrap: wrap;
@@ -606,6 +652,37 @@ body {
   margin: 0;
   font-size: 0.82rem;
   color: #1d4ed8;
+}
+
+.detail-face-provenance-details {
+  margin: 0;
+  border: 1px solid #bfdbfe;
+  border-radius: 0.55rem;
+  background: #eff6ff;
+  padding: 0.55rem 0.65rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.detail-face-provenance-details div {
+  display: grid;
+  grid-template-columns: 8rem 1fr;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+}
+
+.detail-face-provenance-details dt,
+.detail-face-provenance-details dd {
+  margin: 0;
+}
+
+.detail-face-provenance-details dt {
+  color: #1e3a8a;
+  font-weight: 600;
+}
+
+.detail-face-provenance-details dd {
+  color: #1e293b;
 }
 
 .ingest-status-badge {

--- a/docs/superpowers/plans/2026-05-01-issue-185-label-provenance-affordances.md
+++ b/docs/superpowers/plans/2026-05-01-issue-185-label-provenance-affordances.md
@@ -1,0 +1,67 @@
+# Issue 185 Label Provenance Indicators And Detail Affordances Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add provenance badges and inline provenance details for face labels in photo detail, including compact overlay badges and explicit legacy fallback handling.
+
+**Architecture:** Extend photo-detail face payloads with latest matching face-label provenance metadata, then thread those fields through `PhotoDetailRoutePage` into `FaceAssignmentControls`. Render compact emoji badges in labeled-face rows and overlay regions, and use a single-expanded inline panel for provenance details.
+
+**Tech Stack:** FastAPI + SQLAlchemy, React + TypeScript, Vitest, Pytest.
+
+---
+
+### Task 1: Backend Photo Detail Provenance Fields
+
+**Files:**
+- Modify: `apps/api/app/repositories/photos_repo.py`
+- Modify: `apps/api/app/schemas/photo_response.py`
+- Test: `apps/api/tests/test_photo_detail_api.py`
+
+- [ ] **Step 1: Add failing API tests for provenance fields**
+- [ ] **Step 2: Run targeted pytest to confirm failure**
+Run: `uv run pytest apps/api/tests/test_photo_detail_api.py -k provenance -q`
+- [ ] **Step 3: Implement repository provenance lookup and schema fields**
+- [ ] **Step 4: Re-run targeted pytest and full photo detail API test file**
+Run: `uv run pytest apps/api/tests/test_photo_detail_api.py -q`
+- [ ] **Step 5: Commit backend changes**
+
+### Task 2: Face Assignment Controls Provenance UI
+
+**Files:**
+- Modify: `apps/ui/src/pages/FaceAssignmentControls.tsx`
+- Modify: `apps/ui/src/styles/app-shell.css`
+- Test: `apps/ui/src/pages/FaceAssignmentControls.test.tsx`
+
+- [ ] **Step 1: Add failing UI tests for provenance badges and inline panel**
+- [ ] **Step 2: Run targeted Vitest to confirm failure**
+Run: `npm --prefix apps/ui test -- src/pages/FaceAssignmentControls.test.tsx`
+- [ ] **Step 3: Implement badge mapping, expandable details, and fallback rendering**
+- [ ] **Step 4: Add CSS for compact badges and details layout**
+- [ ] **Step 5: Re-run targeted Vitest**
+Run: `npm --prefix apps/ui test -- src/pages/FaceAssignmentControls.test.tsx`
+- [ ] **Step 6: Commit UI control changes**
+
+### Task 3: Overlay Badge Integration In Photo Detail
+
+**Files:**
+- Modify: `apps/ui/src/pages/PhotoDetailRoutePage.tsx`
+- Test: `apps/ui/src/pages/PhotoDetailRoutePage.test.tsx`
+
+- [ ] **Step 1: Add failing integration tests for overlay provenance badge interaction**
+- [ ] **Step 2: Run targeted Vitest to confirm failure**
+Run: `npm --prefix apps/ui test -- src/pages/PhotoDetailRoutePage.test.tsx`
+- [ ] **Step 3: Implement overlay badges and link click to inline provenance panel expansion**
+- [ ] **Step 4: Re-run targeted Vitest**
+Run: `npm --prefix apps/ui test -- src/pages/PhotoDetailRoutePage.test.tsx`
+- [ ] **Step 5: Commit integration changes**
+
+### Task 4: Final Verification
+
+**Files:**
+- No additional files expected
+
+- [ ] **Step 1: Run API + UI targeted regression commands**
+Run: `uv run pytest apps/api/tests/test_photo_detail_api.py -q`
+Run: `npm --prefix apps/ui test -- src/pages/FaceAssignmentControls.test.tsx src/pages/PhotoDetailRoutePage.test.tsx`
+- [ ] **Step 2: Review `git status` and summarize completed behavior**
+- [ ] **Step 3: Final commit if any remaining staged verification-only updates exist**

--- a/docs/superpowers/specs/2026-05-01-issue-185-label-provenance-affordances-design.md
+++ b/docs/superpowers/specs/2026-05-01-issue-185-label-provenance-affordances-design.md
@@ -1,0 +1,151 @@
+# Issue #185: Label Provenance Indicators And Detail Affordances Design
+
+Date: 2026-05-01
+Parent: #161
+Issue: #185
+
+## Summary
+
+Expose face-label provenance in photo-detail labeling surfaces so users can quickly distinguish human-confirmed versus machine-generated labeling and inspect source metadata without leaving the current workflow.
+
+## Why This Matters
+
+Face labeling accuracy depends on user trust and clear provenance visibility. If provenance is hidden or ambiguous, users cannot confidently decide when to keep, correct, or challenge existing labels.
+
+## Scope
+
+- Add provenance payload fields to photo detail face objects.
+- Show compact provenance badges in:
+  - labeled face rows in correction UI
+  - face overlay boxes in preview
+- Provide inline expandable provenance details in correction UI.
+- Define deterministic fallback behavior for missing or legacy provenance data.
+- Add API and UI tests for provenance rendering and fallback behavior.
+
+## Non-Goals
+
+- Any database schema change.
+- Any provenance write-path change in assignment/correction APIs.
+- Permission policy changes.
+
+## Data Contract
+
+### API shape change
+
+Extend each face item in photo detail response with:
+
+- `label_source: "human_confirmed" | "machine_applied" | "machine_suggested" | null`
+- `confidence: number | null`
+- `model_version: string | null`
+- `provenance: Record<string, unknown> | null`
+- `label_recorded_ts: string | null`
+
+### Mapping logic
+
+- For each face with `person_id != null`, resolve latest matching `face_labels` row for:
+  - same `face_id`
+  - same `person_id`
+  - newest by timestamp (created/updated ordering)
+- Map row fields into the photo detail face payload.
+- For faces with no matching label row (legacy/missing provenance), return explicit `null` values for all provenance fields.
+- For unlabeled faces (`person_id == null`), return explicit `null` values for all provenance fields.
+
+## UX Design
+
+### Badge system (language-independent symbols)
+
+- `👤` for `human_confirmed`
+- `🤖` for `machine_applied`
+- `💡` for `machine_suggested`
+- `❓` for missing provenance
+
+Each badge has an accessible text label for assistive tech and deterministic automation assertions.
+
+### Labeled-face row behavior
+
+- Render a provenance badge next to each labeled face entry in the correction list.
+- Badge acts as toggle button (`aria-expanded`) for inline provenance details.
+- Single-expanded-row behavior: opening one row collapses any previously open row.
+
+### Overlay behavior
+
+- Render compact provenance badge inside each face overlay with existing overlay box geometry.
+- Tapping/clicking overlay badge expands the matching inline details row in correction UI.
+- Overlay remains compact and non-blocking on mobile.
+
+### Inline details panel fields
+
+For expanded row, show:
+
+- Source
+- Action (`provenance.action`)
+- Surface (`provenance.surface`)
+- Workflow (`provenance.workflow`)
+- Model version
+- Confidence
+- Recorded timestamp
+
+Unknown/missing values render as `Not available`.
+
+## Fallback And Safety Rules
+
+- Missing label record: show `❓` and `Not available` detail values.
+- Missing/invalid provenance object or missing keys: no exception; show fallbacks.
+- Missing or invalid confidence value: `Not available`.
+- Missing timestamp: `Not available`.
+- Overlay click for face not present in labeled list: no-op; do not throw.
+
+## Architecture And Component Changes
+
+### Backend
+
+- `apps/api/app/repositories/photos_repo.py`
+  - Extend face hydration for detail mode to join/lookup latest matching `face_labels` rows.
+- `apps/api/app/schemas/photo_response.py`
+  - Extend `PhotoDetailFace` schema with provenance fields.
+- `apps/api/tests/test_photo_detail_api.py`
+  - Add provenance-positive and provenance-missing assertions.
+
+### Frontend
+
+- `apps/ui/src/pages/PhotoDetailRoutePage.tsx`
+  - Pass provenance-enriched face records to assignment controls.
+  - Render overlay badges and connect click behavior to expanded provenance row state.
+- `apps/ui/src/pages/FaceAssignmentControls.tsx`
+  - Add badge rendering and inline expandable details for labeled faces.
+  - Add single-expanded-row state and overlay-trigger support.
+- `apps/ui/src/styles/app-shell.css`
+  - Add compact provenance badge styles and details-panel styles.
+- `apps/ui/src/pages/FaceAssignmentControls.test.tsx`
+  - Add tests for badge mapping, expand/collapse, overlay-to-row behavior, and fallback rendering.
+
+## Testing Strategy
+
+- API contract tests:
+  - returns provenance fields when face label row exists
+  - returns null provenance fields for legacy/missing rows
+- UI tests:
+  - badge symbol rendering by source type (`👤`, `🤖`, `💡`, `❓`)
+  - inline panel toggle and single-expanded-row behavior
+  - overlay badge opens correct row details
+  - missing values shown as `Not available`
+- Regression:
+  - existing assignment/correction behavior remains unchanged
+
+## Risks And Mitigations
+
+- Risk: incorrect label row chosen when multiple historical rows exist.
+  - Mitigation: deterministic latest-row ordering with explicit tie-break.
+- Risk: emoji rendering differences across platforms.
+  - Mitigation: keep visual symbol compact but provide explicit accessible labels and deterministic text in details panel.
+- Risk: overcrowded overlays on small faces.
+  - Mitigation: badge size tuned for compact footprint; details remain in list panel, not overlay body.
+
+## Acceptance Criteria Mapping
+
+- Label source/provenance visible in labeling UI contexts:
+  - badges in correction rows and overlays.
+- Users inspect provenance details without leaving workflow:
+  - inline expandable panel in correction section.
+- Missing provenance surfaced safely and explicitly:
+  - `❓` badge + `Not available` detail fields.


### PR DESCRIPTION
## Summary
- add face-label provenance fields to photo detail face payloads using latest matching `face_labels` records
- render compact provenance badges in face correction rows and face overlay regions
- add inline expandable provenance details panel with explicit fallback values for missing/legacy data
- wire overlay badge clicks to open matching inline provenance details

## Testing
- `uv run python -m pytest apps/api/tests/test_photo_detail_api.py -q`
- `npm --prefix apps/ui test -- src/pages/FaceAssignmentControls.test.tsx src/pages/PhotoDetailRoutePage.test.tsx`

Closes #185