### PR TITLE
Issue #220: Refactor shared browse/search lifecycle and Library primitives

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -49,11 +49,22 @@ jobs:
       - name: Install UI dependencies
         working-directory: apps/ui
         run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('apps/ui/package-lock.json') }}
       - name: Install Playwright Chromium
         working-directory: apps/ui
-        run: npx playwright install --with-deps chromium
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+        run: |
+          npx playwright install --with-deps chromium || \
+          npx playwright install --with-deps chromium
       - name: Run smoke journeys
         working-directory: apps/ui
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: npm run test:e2e:smoke
       - name: Upload Playwright report
         if: failure()
@@ -77,11 +88,22 @@ jobs:
       - name: Install UI dependencies
         working-directory: apps/ui
         run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('apps/ui/package-lock.json') }}
       - name: Install Playwright Chromium
         working-directory: apps/ui
-        run: npx playwright install --with-deps chromium
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+        run: |
+          npx playwright install --with-deps chromium || \
+          npx playwright install --with-deps chromium
       - name: Run full E2E lane
         working-directory: apps/ui
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: npm run test:e2e:full
       - name: Upload Playwright report
         if: failure()

--- a/apps/ui/src/pages/BrowseRoutePage.tsx
+++ b/apps/ui/src/pages/BrowseRoutePage.tsx
@@ -1,8 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import type { NotificationEntry } from "../app/feedback/feedbackTypes";
-import { ToastStack } from "../app/feedback/ToastStack";
+import { FeedbackSurface } from "../app/feedback/FeedbackSurface";
+import type { FeedbackViewState, NotificationEntry } from "../app/feedback/feedbackTypes";
 import { deriveIngestStatus, INGEST_STATUS_LEGEND } from "../app/ingestStatus";
+import { PhotoResultIdentity } from "./library/PhotoResultIdentity";
+import {
+  INVALID_PAGE_MESSAGE,
+  updateCursorByPage
+} from "./library/pagination";
+import { useRouteRequestState } from "./library/requestLifecycle";
+import { parsePositiveIntParam } from "./library/urlSerialization";
 import {
   consumePendingBrowseFocusPhotoId,
   resolveBrowseReturnState,
@@ -45,7 +52,6 @@ type SearchResponsePayload = {
 };
 
 const PAGE_LIMIT = 24;
-const INVALID_PAGE_MESSAGE = "Reset to page 1 because that page position is unavailable.";
 
 function formatShotTimestamp(shotTs: string | null): string {
   if (!shotTs) {
@@ -106,24 +112,10 @@ async function fetchBrowsePage(
   return (await response.json()) as SearchResponsePayload;
 }
 
-function parseRequestedPage(search: string): number {
-  const rawPage = new URLSearchParams(search).get("page");
-  if (!rawPage) {
-    return 1;
-  }
-
-  const parsedPage = Number.parseInt(rawPage, 10);
-  if (!Number.isFinite(parsedPage) || parsedPage < 1) {
-    return 1;
-  }
-
-  return parsedPage;
-}
-
 export function BrowseRoutePage() {
   const location = useLocation();
   const navigate = useNavigate();
-  const requestedPage = parseRequestedPage(location.search);
+  const requestedPage = parsePositiveIntParam(location.search, "page");
   const initialReturnState = resolveBrowseReturnState(location.state);
 
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
@@ -131,10 +123,16 @@ export function BrowseRoutePage() {
   const [photos, setPhotos] = useState<BrowsePhoto[]>([]);
   const [totalCount, setTotalCount] = useState(0);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [reloadToken, setReloadToken] = useState(0);
   const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
+  const {
+    isLoading,
+    error,
+    reloadToken,
+    beginRequest,
+    completeRequest,
+    failRequest,
+    requestRetry
+  } = useRouteRequestState();
   const headingRef = useRef<HTMLHeadingElement | null>(null);
   const pendingReturnFocusPhotoIdRef = useRef<string | null>(
     initialReturnState?.restoreFocusPhotoId ?? consumePendingBrowseFocusPhotoId()
@@ -179,8 +177,7 @@ export function BrowseRoutePage() {
 
     const controller = new AbortController();
 
-    setIsLoading(true);
-    setError(null);
+    beginRequest();
 
     fetchBrowsePage(sortDirection, cursorForPage ?? null)
       .then((payload) => {
@@ -198,27 +195,21 @@ export function BrowseRoutePage() {
         setTotalCount(payload.hits.total);
         setNextCursor(payload.hits.cursor);
         setCursorByPage((current) => {
-          const next = { ...current, [requestedPage]: cursorForPage ?? null };
-          if (payload.hits.cursor === null) {
-            delete next[requestedPage + 1];
-          } else {
-            next[requestedPage + 1] = payload.hits.cursor;
-          }
-          return next;
+          return updateCursorByPage(
+            current,
+            requestedPage,
+            cursorForPage ?? null,
+            payload.hits.cursor
+          );
         });
-        setIsLoading(false);
+        completeRequest();
       })
       .catch((caughtError: unknown) => {
         if (controller.signal.aborted) {
           return;
         }
 
-        const message =
-          caughtError instanceof Error
-            ? caughtError.message
-            : "Could not load browse results.";
-        setError(message);
-        setIsLoading(false);
+        failRequest(caughtError, "Could not load browse results.");
       });
 
     return () => {
@@ -259,6 +250,11 @@ export function BrowseRoutePage() {
 
   const canGoPrevious = requestedPage > 1 && !isLoading;
   const canGoNext = nextCursor !== null && !isLoading;
+  const feedbackViewState: FeedbackViewState = isLoading
+    ? "loading"
+    : error
+      ? "error"
+      : "ready";
 
   const summaryLabel = useMemo(() => {
     if (isLoading) {
@@ -331,105 +327,96 @@ export function BrowseRoutePage() {
         </ul>
       </section>
 
-      {error ? (
-        <div className="feedback-panel feedback-panel-error">
-          <h2>Could not load Browse</h2>
-          <p>{error}</p>
-          <button type="button" onClick={() => setReloadToken((current) => current + 1)}>
-            Retry
-          </button>
-        </div>
-      ) : null}
-
-      {!error && isLoading ? (
-        <div className="feedback-panel feedback-panel-loading" role="status" aria-live="polite">
-          Loading browse workflow.
-        </div>
-      ) : null}
-
-      {!error && !isLoading && photos.length === 0 ? (
-        <div className="feedback-panel">
-          <p>No photos available for this page.</p>
-        </div>
-      ) : null}
-
-      {!error && !isLoading && photos.length > 0 ? (
-        <ol className="browse-grid" aria-label="Photo gallery">
-          {photos.map((photo) => {
-            const ingestStatus = deriveIngestStatus({
-              availabilityState: photo.original?.availability_state ?? null,
-              isAvailable: photo.original?.is_available ?? null,
-              lastFailureReason: photo.original?.last_failure_reason ?? null,
-              hasThumbnail: Boolean(photo.thumbnail)
-            });
-
-            return (
-              <li key={photo.photo_id} className="browse-card">
-                <p className="browse-ingest-status">
-                  <span className={`ingest-status-badge is-${ingestStatus.tone}`}>{ingestStatus.label}</span>
-                  <span className="browse-ingest-status-detail">{ingestStatus.description}</span>
-                </p>
-                {photo.thumbnail ? (
-                  <img
-                    className="browse-thumbnail"
-                    src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
-                    width={photo.thumbnail.width}
-                    height={photo.thumbnail.height}
-                    alt={`Thumbnail for ${photo.photo_id}`}
-                  />
-                ) : (
-                  <div className="browse-thumbnail browse-thumbnail-placeholder" aria-hidden="true">
-                    No preview
-                  </div>
-                )}
-
-                <div className="browse-card-body">
-                  <h2>
-                    <Link
-                      className="browse-photo-link"
-                      data-photo-id={photo.photo_id}
-                      to={`/browse/${photo.photo_id}`}
-                      state={{
-                        returnToBrowseSearch: location.search,
-                        returnFocusPhotoId: photo.photo_id
-                      }}
-                      onClick={() => setPendingBrowseFocusPhotoId(photo.photo_id)}
-                    >
-                      {photo.photo_id}
-                    </Link>
-                  </h2>
-                  <p className="browse-path" title={photo.path}>{photo.path}</p>
-                  <dl>
-                    <div>
-                      <dt>Captured</dt>
-                      <dd>{formatShotTimestamp(photo.shot_ts)}</dd>
-                    </div>
-                    <div>
-                      <dt>Size</dt>
-                      <dd>{formatFilesize(photo.filesize)}</dd>
-                    </div>
-                    <div>
-                      <dt>People</dt>
-                      <dd>{photo.people.length}</dd>
-                    </div>
-                    <div>
-                      <dt>Original</dt>
-                      <dd>{photo.original?.availability_state ?? "unknown"}</dd>
-                    </div>
-                  </dl>
-                </div>
-              </li>
-            );
-          })}
-        </ol>
-      ) : null}
-
-      <ToastStack
+      <FeedbackSurface
+        viewState={feedbackViewState}
+        loadingLabel="Loading browse workflow."
+        error={error ? { title: "Could not load Browse", message: error } : null}
+        onRetry={requestRetry}
         notifications={notifications}
-        onDismiss={(id) => {
+        onDismissNotification={(id) => {
           setNotifications((current) => current.filter((entry) => entry.id !== id));
         }}
-      />
+      >
+        {!error && !isLoading && photos.length === 0 ? (
+          <div className="feedback-panel">
+            <p>No photos available for this page.</p>
+          </div>
+        ) : null}
+
+        {!error && !isLoading && photos.length > 0 ? (
+          <ol className="browse-grid" aria-label="Photo gallery">
+            {photos.map((photo) => {
+              const ingestStatus = deriveIngestStatus({
+                availabilityState: photo.original?.availability_state ?? null,
+                isAvailable: photo.original?.is_available ?? null,
+                lastFailureReason: photo.original?.last_failure_reason ?? null,
+                hasThumbnail: Boolean(photo.thumbnail)
+              });
+
+              return (
+                <li key={photo.photo_id} className="browse-card">
+                  <p className="browse-ingest-status">
+                    <span className={`ingest-status-badge is-${ingestStatus.tone}`}>{ingestStatus.label}</span>
+                    <span className="browse-ingest-status-detail">{ingestStatus.description}</span>
+                  </p>
+                  {photo.thumbnail ? (
+                    <img
+                      className="browse-thumbnail"
+                      src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
+                      width={photo.thumbnail.width}
+                      height={photo.thumbnail.height}
+                      alt={`Thumbnail for ${photo.photo_id}`}
+                    />
+                  ) : (
+                    <div className="browse-thumbnail browse-thumbnail-placeholder" aria-hidden="true">
+                      No preview
+                    </div>
+                  )}
+
+                  <div className="browse-card-body">
+                    <PhotoResultIdentity
+                      title={
+                        <Link
+                          className="browse-photo-link"
+                          data-photo-id={photo.photo_id}
+                          to={`/browse/${photo.photo_id}`}
+                          state={{
+                            returnToBrowseSearch: location.search,
+                            returnFocusPhotoId: photo.photo_id
+                          }}
+                          onClick={() => setPendingBrowseFocusPhotoId(photo.photo_id)}
+                        >
+                          {photo.photo_id}
+                        </Link>
+                      }
+                      path={photo.path}
+                      pathClassName="browse-path"
+                    />
+                    <dl>
+                      <div>
+                        <dt>Captured</dt>
+                        <dd>{formatShotTimestamp(photo.shot_ts)}</dd>
+                      </div>
+                      <div>
+                        <dt>Size</dt>
+                        <dd>{formatFilesize(photo.filesize)}</dd>
+                      </div>
+                      <div>
+                        <dt>People</dt>
+                        <dd>{photo.people.length}</dd>
+                      </div>
+                      <div>
+                        <dt>Original</dt>
+                        <dd>{photo.original?.availability_state ?? "unknown"}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        ) : null}
+      </FeedbackSurface>
     </section>
   );
 }

--- a/apps/ui/src/pages/SearchRoutePage.tsx
+++ b/apps/ui/src/pages/SearchRoutePage.tsx
@@ -1,5 +1,18 @@
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { FeedbackSurface } from "../app/feedback/FeedbackSurface";
+import type { FeedbackViewState } from "../app/feedback/feedbackTypes";
+import { PhotoResultIdentity } from "./library/PhotoResultIdentity";
+import {
+  buildFirstPageCursorMap,
+  INVALID_PAGE_MESSAGE,
+  updateCursorByPage
+} from "./library/pagination";
+import { useRouteRequestState } from "./library/requestLifecycle";
+import {
+  dedupeTrimmedValues,
+  parseNullableBooleanParam
+} from "./library/urlSerialization";
 import { LocationRadiusPicker } from "./search/LocationRadiusPicker";
 import { FacetFilterPanel } from "./search/FacetFilterPanel";
 import {
@@ -43,7 +56,6 @@ type SortDirection = "asc" | "desc";
 
 const DEFAULT_SORT_DIRECTION: SortDirection = "desc";
 const PAGE_LIMIT = 24;
-const INVALID_PAGE_MESSAGE = "Reset to page 1 because that page position is unavailable.";
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
 type SearchUrlState = {
@@ -72,14 +84,6 @@ type SearchRequestSnapshot = {
   cursorByPage: Record<number, string | null>;
 };
 
-function buildFirstPageCursorMap(nextCursor: string | null): Record<number, string | null> {
-  const cursorMap: Record<number, string | null> = { 1: null };
-  if (nextCursor !== null) {
-    cursorMap[2] = nextCursor;
-  }
-  return cursorMap;
-}
-
 function hasActiveSearchCriteria(snapshot: SearchRequestSnapshot): boolean {
   return (
     snapshot.chips.length > 0 ||
@@ -89,22 +93,6 @@ function hasActiveSearchCriteria(snapshot: SearchRequestSnapshot): boolean {
     snapshot.hasFaces !== null ||
     snapshot.pathHints.length > 0
   );
-}
-
-function dedupeTrimmedValues(values: string[]): string[] {
-  const seen = new Set<string>();
-  const deduped: string[] = [];
-
-  for (const value of values) {
-    const trimmed = value.trim();
-    if (!trimmed || seen.has(trimmed)) {
-      continue;
-    }
-    seen.add(trimmed);
-    deduped.push(trimmed);
-  }
-
-  return deduped;
 }
 
 function isValidIsoDate(value: string): boolean {
@@ -140,9 +128,7 @@ function parseSearchUrlState(search: string): SearchUrlState {
   const selectedPersonNames = dedupeTrimmedValues(params.getAll("person"));
   const pathHintFilters = normalizePathHintFilters(params.getAll("pathHint"));
 
-  const rawHasFaces = (params.get("hasFaces") ?? "").trim();
-  const hasFacesFilter =
-    rawHasFaces === "true" ? true : rawHasFaces === "false" ? false : null;
+  const hasFacesFilter = parseNullableBooleanParam(params.get("hasFaces"));
 
   const latitudeCandidate = (params.get("lat") ?? "").trim();
   const longitudeCandidate = (params.get("lng") ?? "").trim();
@@ -373,8 +359,8 @@ export function SearchRoutePage() {
   const [cursorByPage, setCursorByPage] = useState<Record<number, string | null>>({ 1: null });
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [paginationMessage, setPaginationMessage] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const { isLoading, error, beginRequest, completeRequest, failRequest, clearRequestState } =
+    useRouteRequestState();
   const [hasRequested, setHasRequested] = useState(false);
   const [lastFailedRequest, setLastFailedRequest] = useState<SearchRequestSnapshot | null>(null);
   const [lastSuccessfulHadCriteria, setLastSuccessfulHadCriteria] = useState(false);
@@ -457,8 +443,7 @@ export function SearchRoutePage() {
     setHasFacesFilter(parsedUrlState.hasFacesFilter);
     setPathHintFilters(parsedUrlState.pathHintFilters);
 
-    setIsLoading(false);
-    setError(null);
+    clearRequestState();
     setHasRequested(false);
     setLastFailedRequest(null);
     setLastSuccessfulHadCriteria(false);
@@ -476,7 +461,7 @@ export function SearchRoutePage() {
         count: 0
       }))
     );
-  }, [parsedUrlState]);
+  }, [clearRequestState, parsedUrlState]);
 
   useEffect(() => {
     if (applyingParsedUrlStateRef.current) {
@@ -542,8 +527,7 @@ export function SearchRoutePage() {
       return;
     }
 
-    setIsLoading(true);
-    setError(null);
+    beginRequest();
     setHasRequested(true);
     setPaginationMessage(null);
 
@@ -632,20 +616,15 @@ export function SearchRoutePage() {
       setFacetPathHintCounts(toPathHintFacetCounts(payload.facets, snapshot.pathHints));
       setCursorByPage((current) => {
         const pageCursor = snapshot.cursorByPage[snapshot.page];
-        const next = { ...current, ...snapshot.cursorByPage, [snapshot.page]: pageCursor ?? null };
-        if (payload.hits.cursor === null) {
-          delete next[snapshot.page + 1];
-        } else {
-          next[snapshot.page + 1] = payload.hits.cursor;
-        }
-        return next;
+        return updateCursorByPage(
+          { ...current, ...snapshot.cursorByPage },
+          snapshot.page,
+          pageCursor ?? null,
+          payload.hits.cursor
+        );
       });
     } catch (caughtError: unknown) {
-      const message =
-        caughtError instanceof Error
-          ? caughtError.message
-          : "Could not load search results.";
-      setError(message);
+      failRequest(caughtError, "Could not load search results.");
       setLastFailedRequest(createSearchSnapshot(snapshot));
       setResults([]);
       setTotalCount(0);
@@ -658,7 +637,7 @@ export function SearchRoutePage() {
         }))
       );
     } finally {
-      setIsLoading(false);
+      completeRequest();
     }
   }
 
@@ -922,6 +901,11 @@ export function SearchRoutePage() {
 
   const canGoPrevious = hasRequested && page > 1 && !isLoading;
   const canGoNext = hasRequested && nextCursor !== null && !isLoading;
+  const feedbackViewState: FeedbackViewState = isLoading
+    ? "loading"
+    : error
+      ? "error"
+      : "ready";
 
   return (
     <section aria-labelledby="page-title" className="page search-page">
@@ -1221,46 +1205,40 @@ export function SearchRoutePage() {
         </p>
       ) : null}
 
-      {resultViewState === "loading" ? (
-        <div className="feedback-panel feedback-panel-loading" role="status" aria-live="polite">
-          Loading search workflow.
-        </div>
-      ) : null}
+      <FeedbackSurface
+        viewState={feedbackViewState}
+        loadingLabel="Loading search workflow."
+        error={error ? { title: "Could not load Search", message: error } : null}
+        onRetry={handleRetry}
+        notifications={[]}
+        onDismissNotification={() => {}}
+      >
+        {resultViewState === "empty" ? (
+          <div className="feedback-panel">
+            <p>No photos are available in the catalog yet.</p>
+          </div>
+        ) : null}
 
-      {resultViewState === "error" ? (
-        <div className="feedback-panel feedback-panel-error">
-          <h2>Could not load Search</h2>
-          <p>{error}</p>
-          <button type="button" onClick={handleRetry}>
-            Retry
-          </button>
-        </div>
-      ) : null}
+        {resultViewState === "no_match" ? (
+          <div className="feedback-panel">
+            <p>No matching photos for the active query.</p>
+          </div>
+        ) : null}
 
-      {resultViewState === "empty" ? (
-        <div className="feedback-panel">
-          <p>No photos are available in the catalog yet.</p>
-        </div>
-      ) : null}
-
-      {resultViewState === "no_match" ? (
-        <div className="feedback-panel">
-          <p>No matching photos for the active query.</p>
-        </div>
-      ) : null}
-
-      {resultViewState === "results" ? (
-        <ol className="search-results" aria-label="Search results">
-          {results.map((photo) => (
-            <li key={photo.photo_id}>
-              <h2>{photo.photo_id}</h2>
-              <p className="search-result-path" title={photo.path}>
-                {photo.path}
-              </p>
-            </li>
-          ))}
-        </ol>
-      ) : null}
+        {resultViewState === "results" ? (
+          <ol className="search-results" aria-label="Search results">
+            {results.map((photo) => (
+              <li key={photo.photo_id}>
+                <PhotoResultIdentity
+                  title={photo.photo_id}
+                  path={photo.path}
+                  pathClassName="search-result-path"
+                />
+              </li>
+            ))}
+          </ol>
+        ) : null}
+      </FeedbackSurface>
 
       <p className="search-serialized-query" aria-live="off">
         Active query: {serializedQuery || "(none)"} | Date range:{" "}

--- a/apps/ui/src/pages/library/PhotoResultIdentity.tsx
+++ b/apps/ui/src/pages/library/PhotoResultIdentity.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+
+interface PhotoResultIdentityProps {
+  title: ReactNode;
+  path: string;
+  pathClassName: string;
+}
+
+export function PhotoResultIdentity({ title, path, pathClassName }: PhotoResultIdentityProps) {
+  return (
+    <>
+      <h2>{title}</h2>
+      <p className={pathClassName} title={path}>
+        {path}
+      </p>
+    </>
+  );
+}

--- a/apps/ui/src/pages/library/pagination.test.ts
+++ b/apps/ui/src/pages/library/pagination.test.ts
@@ -1,0 +1,48 @@
+import {
+  buildFirstPageCursorMap,
+  INVALID_PAGE_MESSAGE,
+  updateCursorByPage
+} from "./pagination";
+
+describe("library pagination primitives", () => {
+  it("keeps the deterministic invalid page messaging copy", () => {
+    expect(INVALID_PAGE_MESSAGE).toBe(
+      "Reset to page 1 because that page position is unavailable."
+    );
+  });
+
+  it("builds first page cursor map with second-page cursor when present", () => {
+    expect(buildFirstPageCursorMap("cursor-page-2")).toEqual({
+      1: null,
+      2: "cursor-page-2"
+    });
+  });
+
+  it("builds first page cursor map without second-page entry when cursor is null", () => {
+    expect(buildFirstPageCursorMap(null)).toEqual({
+      1: null
+    });
+  });
+
+  it("updates page cursor map and tracks the next page cursor", () => {
+    const next = updateCursorByPage({ 1: null }, 2, "cursor-page-2", "cursor-page-3");
+    expect(next).toEqual({
+      1: null,
+      2: "cursor-page-2",
+      3: "cursor-page-3"
+    });
+  });
+
+  it("clears stale next page cursor when there is no following page", () => {
+    const next = updateCursorByPage(
+      { 1: null, 2: "cursor-page-2", 3: "stale-cursor" },
+      2,
+      "cursor-page-2",
+      null
+    );
+    expect(next).toEqual({
+      1: null,
+      2: "cursor-page-2"
+    });
+  });
+});

--- a/apps/ui/src/pages/library/pagination.ts
+++ b/apps/ui/src/pages/library/pagination.ts
@@ -1,0 +1,24 @@
+export const INVALID_PAGE_MESSAGE = "Reset to page 1 because that page position is unavailable.";
+
+export function buildFirstPageCursorMap(nextCursor: string | null): Record<number, string | null> {
+  const cursorMap: Record<number, string | null> = { 1: null };
+  if (nextCursor !== null) {
+    cursorMap[2] = nextCursor;
+  }
+  return cursorMap;
+}
+
+export function updateCursorByPage(
+  current: Record<number, string | null>,
+  page: number,
+  pageCursor: string | null,
+  nextCursor: string | null
+): Record<number, string | null> {
+  const next = { ...current, [page]: pageCursor };
+  if (nextCursor === null) {
+    delete next[page + 1];
+  } else {
+    next[page + 1] = nextCursor;
+  }
+  return next;
+}

--- a/apps/ui/src/pages/library/requestLifecycle.test.ts
+++ b/apps/ui/src/pages/library/requestLifecycle.test.ts
@@ -1,0 +1,17 @@
+import { getRequestErrorMessage } from "./requestLifecycle";
+
+describe("request lifecycle primitives", () => {
+  it("uses caught error message when available", () => {
+    expect(getRequestErrorMessage(new Error("Request failed (503)"), "fallback")).toBe(
+      "Request failed (503)"
+    );
+  });
+
+  it("falls back when caught value is not an Error", () => {
+    expect(getRequestErrorMessage("failure", "fallback")).toBe("fallback");
+  });
+
+  it("falls back when error message is empty", () => {
+    expect(getRequestErrorMessage(new Error("   "), "fallback")).toBe("fallback");
+  });
+});

--- a/apps/ui/src/pages/library/requestLifecycle.ts
+++ b/apps/ui/src/pages/library/requestLifecycle.ts
@@ -1,0 +1,48 @@
+import { useCallback, useState } from "react";
+
+export function getRequestErrorMessage(caughtError: unknown, fallbackMessage: string): string {
+  if (caughtError instanceof Error && caughtError.message.trim()) {
+    return caughtError.message;
+  }
+  return fallbackMessage;
+}
+
+export function useRouteRequestState() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const beginRequest = useCallback(() => {
+    setIsLoading(true);
+    setError(null);
+  }, []);
+
+  const completeRequest = useCallback(() => {
+    setIsLoading(false);
+  }, []);
+
+  const failRequest = useCallback((caughtError: unknown, fallbackMessage: string) => {
+    setError(getRequestErrorMessage(caughtError, fallbackMessage));
+    setIsLoading(false);
+  }, []);
+
+  const clearRequestState = useCallback(() => {
+    setIsLoading(false);
+    setError(null);
+  }, []);
+
+  const requestRetry = useCallback(() => {
+    setReloadToken((current) => current + 1);
+  }, []);
+
+  return {
+    isLoading,
+    error,
+    reloadToken,
+    beginRequest,
+    completeRequest,
+    failRequest,
+    clearRequestState,
+    requestRetry
+  };
+}

--- a/apps/ui/src/pages/library/urlSerialization.test.ts
+++ b/apps/ui/src/pages/library/urlSerialization.test.ts
@@ -1,0 +1,30 @@
+import {
+  dedupeTrimmedValues,
+  parseNullableBooleanParam,
+  parsePositiveIntParam
+} from "./urlSerialization";
+
+describe("library URL serialization helpers", () => {
+  it("dedupes and trims non-empty values while preserving order", () => {
+    expect(dedupeTrimmedValues(["  lake ", "", "lake", "coast", " coast "])).toEqual([
+      "lake",
+      "coast"
+    ]);
+  });
+
+  it("parses positive int params from URL search strings", () => {
+    expect(parsePositiveIntParam("?page=3", "page")).toBe(3);
+    expect(parsePositiveIntParam("?page=0", "page")).toBe(1);
+    expect(parsePositiveIntParam("?page=abc", "page")).toBe(1);
+    expect(parsePositiveIntParam("", "page")).toBe(1);
+  });
+
+  it("parses nullable booleans from query values", () => {
+    expect(parseNullableBooleanParam("true")).toBe(true);
+    expect(parseNullableBooleanParam("false")).toBe(false);
+    expect(parseNullableBooleanParam("  true ")).toBe(true);
+    expect(parseNullableBooleanParam("")).toBeNull();
+    expect(parseNullableBooleanParam(null)).toBeNull();
+    expect(parseNullableBooleanParam("nope")).toBeNull();
+  });
+});

--- a/apps/ui/src/pages/library/urlSerialization.ts
+++ b/apps/ui/src/pages/library/urlSerialization.ts
@@ -1,0 +1,40 @@
+export function dedupeTrimmedValues(values: string[]): string[] {
+  const seen = new Set<string>();
+  const deduped: string[] = [];
+
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    deduped.push(trimmed);
+  }
+
+  return deduped;
+}
+
+export function parsePositiveIntParam(search: string, key: string, defaultValue = 1): number {
+  const rawValue = new URLSearchParams(search).get(key);
+  if (!rawValue) {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return defaultValue;
+  }
+
+  return parsed;
+}
+
+export function parseNullableBooleanParam(rawValue: string | null): boolean | null {
+  const candidate = (rawValue ?? "").trim();
+  if (candidate === "true") {
+    return true;
+  }
+  if (candidate === "false") {
+    return false;
+  }
+  return null;
+}

--- a/apps/ui/tests/e2e/journeys/library-unification-journeys.spec.ts
+++ b/apps/ui/tests/e2e/journeys/library-unification-journeys.spec.ts
@@ -1,0 +1,181 @@
+import { expect, test } from "@playwright/test";
+
+type SearchRequestPayload = {
+  q?: string;
+};
+
+function buildSearchPayload(photoId: string) {
+  return {
+    hits: {
+      total: 1,
+      cursor: null,
+      items: [
+        {
+          photo_id: photoId,
+          path: `/library/${photoId}.jpg`,
+          ext: "jpg",
+          camera_make: "Canon",
+          orientation: "landscape",
+          shot_ts: "2026-04-20T12:00:00Z",
+          filesize: 1024,
+          tags: [],
+          people: [],
+          faces: [],
+          thumbnail: null,
+          original: {
+            is_available: true,
+            availability_state: "available",
+            last_failure_reason: null
+          },
+          relevance: null
+        }
+      ]
+    },
+    facets: {}
+  };
+}
+
+test("JRN-P4-browse-shared-request-lifecycle @journey", async ({ page }) => {
+  let releaseGateResolver: (() => void) | null = null;
+  const initialBrowseRequestGate = new Promise<void>((resolve) => {
+    releaseGateResolver = resolve;
+  });
+  let initialRequestsReleased = false;
+  let failNextBrowseRequest = false;
+
+  await page.route("**/api/v1/search", async (route) => {
+    const body = (route.request().postDataJSON() ?? {}) as SearchRequestPayload;
+    if (typeof body.q === "string") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(buildSearchPayload("search-photo-ignored"))
+      });
+      return;
+    }
+
+    if (!initialRequestsReleased) {
+      await initialBrowseRequestGate;
+    }
+
+    if (failNextBrowseRequest) {
+      failNextBrowseRequest = false;
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Service unavailable" })
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(buildSearchPayload("browse-photo-1"))
+    });
+  });
+
+  await page.goto("/browse");
+  await expect(page.getByRole("status")).toContainText("Loading browse workflow.");
+
+  initialRequestsReleased = true;
+  releaseGateResolver?.();
+  await expect(page.getByRole("heading", { name: "browse-photo-1", level: 2 })).toBeVisible();
+  await expect(page.getByText("/library/browse-photo-1.jpg")).toBeVisible();
+
+  failNextBrowseRequest = true;
+  await page.selectOption('select[aria-label="Sort order"]', "asc");
+  await expect(page.getByRole("heading", { name: "Could not load Browse", level: 2 })).toBeVisible();
+
+  await page.getByRole("button", { name: "Retry" }).click();
+  await expect(page.getByRole("heading", { name: "browse-photo-1", level: 2 })).toBeVisible();
+});
+
+test("JRN-P4-browse-invalid-page-reset @journey", async ({ page }) => {
+  await page.route("**/api/v1/search", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(buildSearchPayload("browse-photo-2"))
+    });
+  });
+
+  await page.goto("/browse?page=3");
+
+  await expect(
+    page.getByText("Reset to page 1 because that page position is unavailable.")
+  ).toBeVisible();
+  await expect(page.locator(".browse-page-indicator")).toHaveText("Page 1");
+  await expect(page).toHaveURL(/\/browse$/);
+});
+
+test("JRN-P4-search-shared-request-lifecycle @journey", async ({ page }) => {
+  let releaseFirstSearchResponse: (() => void) | null = null;
+  const firstSearchResponseGate = new Promise<void>((resolve) => {
+    releaseFirstSearchResponse = resolve;
+  });
+  let searchRequestCount = 0;
+
+  await page.route("**/api/v1/people", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([])
+    });
+  });
+
+  await page.route("**/api/v1/search", async (route) => {
+    const body = (route.request().postDataJSON() ?? {}) as SearchRequestPayload;
+    if (typeof body.q !== "string") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(buildSearchPayload("browse-photo-ignored"))
+      });
+      return;
+    }
+
+    searchRequestCount += 1;
+    if (searchRequestCount === 1) {
+      await firstSearchResponseGate;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(buildSearchPayload("search-photo-1"))
+      });
+      return;
+    }
+
+    if (searchRequestCount === 2) {
+      await route.fulfill({
+        status: 503,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Service unavailable" })
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(buildSearchPayload("search-photo-1"))
+    });
+  });
+
+  await page.goto("/search");
+
+  await page.getByRole("textbox", { name: "Search query" }).fill("lake");
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("status")).toContainText("Loading search workflow.");
+
+  releaseFirstSearchResponse?.();
+  await expect(page.getByRole("heading", { name: "search-photo-1", level: 2 })).toBeVisible();
+  await expect(page.getByText("/library/search-photo-1.jpg")).toBeVisible();
+
+  await page.getByRole("textbox", { name: "Search query" }).fill("coast");
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("heading", { name: "Could not load Search", level: 2 })).toBeVisible();
+
+  await page.getByRole("button", { name: "Retry" }).click();
+  await expect(page.getByRole("heading", { name: "search-photo-1", level: 2 })).toBeVisible();
+});

--- a/docs/superpowers/plans/2026-05-01-library-albums-epic-and-stories-draft.md
+++ b/docs/superpowers/plans/2026-05-01-library-albums-epic-and-stories-draft.md
@@ -1,0 +1,677 @@
+# Draft GitHub Epic And Child Stories: Unified Library + Shareable Albums + Export
+
+Date: 2026-05-01
+Source spec: `docs/superpowers/specs/2026-05-01-library-albums-unified-workflow-design.md`
+
+## Purpose
+
+Provide GitHub-ready issue text for one new UI epic and child stories implementing the approved unified Library + Albums direction. This draft is intentionally structured to enable a follow-up de-duplication pass against existing UI issues.
+
+## Proposed New Epic
+
+### Title
+
+`UI EPIC: Unified Library, Shareable Albums, And Export`
+
+### Suggested labels
+
+- `phase:4`
+- `priority:p1`
+- `type:parent`
+- `area:web`
+
+### Body
+
+## Goal
+
+Deliver a unified visual Library workflow that combines browsing and filtering, supports in-context face assignment/confirmation, and enables shareable in-app albums with local export.
+
+## Demo Capabilities
+
+- [ ] users browse and filter photos in one screen (Library)
+- [ ] users select single, page, or all-filtered photo scopes
+- [ ] users assign/confirm/correct face labels from Library context
+- [ ] users save selections to shareable in-app albums backed by photo references
+- [ ] album owners share albums with authenticated users (viewer/editor)
+- [ ] users export album contents to local filesystem (folder write when supported, ZIP fallback)
+
+## Out Of Scope
+
+- unauthenticated/public sharing links
+- cross-tenant sharing
+- model-behavior changes for recognition
+- destructive source-file operations
+
+## Child Stories
+
+- [ ] Implement unified Library route with merged browse + search state
+- [ ] Implement Library selection scope model and action bar
+- [ ] Implement Library in-context face assignment and confirmation workflows
+- [ ] Implement face-state filters for unassigned and unconfirmed machine labels
+- [ ] Implement album domain APIs and persistence contracts
+- [ ] Implement album list/detail UI and add-to-album workflows
+- [ ] Implement authenticated album sharing with role-based access
+- [ ] Implement album export workflow with local write and ZIP fallback
+- [ ] Implement legacy route migration and deep-link redirect behavior
+- [ ] Implement e2e journey coverage for library-to-album-to-export
+
+## Completion Criteria
+
+This EPIC closes when all child stories are complete and the end-to-end workflow is demonstrable: filter/select in Library -> save to album -> share with another authenticated user -> export successfully with deterministic result reporting.
+
+## Dependencies
+
+- Existing UI foundations from #159, #160, #161
+- Existing bulk-action direction from #229 (to be reconciled in dedupe pass)
+- New backend contracts for album entities, sharing, and export jobs
+
+---
+
+## Proposed Child Stories
+
+### 1) Unified Library route
+
+**Title**
+`Implement unified Library route with merged browse and search state`
+
+**Suggested labels**
+- `phase:4`
+- `priority:p1`
+- `type:implementation`
+- `area:web`
+
+**Body**
+
+## Summary
+
+Create a single Library route that combines visual browsing and search/filter controls into one workspace.
+
+## Why This Matters
+
+Users should not context-switch between Browse and Search when visually selecting photos.
+
+## Scope
+
+- add `Library` route as primary entry point
+- compose existing browse/search request and rendering patterns into one state model
+- keep URL-synced filter state and deterministic pagination/sort behavior
+- keep visual photo cards as default result representation
+
+## Non-Goals
+
+- album CRUD
+- export execution flows
+
+## Acceptance Criteria
+
+- one screen contains visual results plus filter/search controls
+- user can filter without changing routes
+- URL round-trip restores equivalent library state
+- deterministic pagination behavior matches existing search semantics
+
+## Verification
+
+- unit/integration tests for merged route state
+- e2e deep-link and restoration checks
+
+## Dependencies
+
+- #160
+- #220
+
+## Potentially supersedes
+
+- parts of #169 (if still open)
+- structural intent of #220
+
+---
+
+### 2) Library selection model and action bar
+
+**Title**
+`Implement Library selection scope model and action bar`
+
+**Suggested labels**
+- `phase:4`
+- `priority:p1`
+- `type:implementation`
+- `area:web`
+
+**Body**
+
+## Summary
+
+Implement selection scopes (`selected`, `page`, `all filtered`) and a scope-aware action bar in Library.
+
+## Why This Matters
+
+Album and export workflows require explicit scope semantics before actions run.
+
+## Scope
+
+- selection reducer/model for photo IDs and filter-scope selection
+- action bar with enabled/disabled rules and selection summary
+- keyboard and accessibility behavior for selection/actions
+
+## Non-Goals
+
+- concrete album/export API integration details beyond entry-point contracts
+
+## Acceptance Criteria
+
+- users can switch between `selected`, `page`, and `all filtered` scopes
+- selection count and scope are explicit and deterministic
+- action bar behavior is accessible and route-stable
+
+## Verification
+
+- reducer/component tests
+- e2e scope transitions across pagination
+
+## Dependencies
+
+- story 1
+
+## Potentially supersedes
+
+- #230
+- #231
+
+---
+
+### 3) Library in-context face labeling workflows
+
+**Title**
+`Implement Library in-context face assignment and confirmation workflows`
+
+**Suggested labels**
+- `phase:4`
+- `priority:p1`
+- `type:implementation`
+- `area:web`
+
+**Body**
+
+## Summary
+
+Expose assign/confirm/correct interactions for detected faces directly in Library quick-panel context.
+
+## Why This Matters
+
+Labeling throughput and confidence improve when users act where they are already selecting photos.
+
+## Scope
+
+- show face overlays and label-source badges in Library preview panel
+- support assign for unassigned faces
+- support confirm/correct for machine-labeled faces
+- reuse deterministic feedback/error handling from existing detail workflow
+
+## Non-Goals
+
+- people-management CRUD
+- recognition-suggestions queue
+
+## Acceptance Criteria
+
+- users can assign, confirm, and correct without mandatory navigation to photo detail
+- provenance context remains visible during actions
+- conflict/permission errors are deterministic and recoverable
+
+## Verification
+
+- component tests for action variants and state updates
+- e2e flow across multiple photos
+
+## Dependencies
+
+- #161
+- #183
+- #184
+- #185
+- #186
+- #189
+
+## Potentially supersedes
+
+- parts of #187 (navigation workflow)
+
+---
+
+### 4) Face-state filters
+
+**Title**
+`Implement face-state filters for unassigned and unconfirmed machine labels`
+
+**Suggested labels**
+- `phase:4`
+- `priority:p1`
+- `type:implementation`
+- `area:web`
+
+**Body**
+
+## Summary
+
+Add filter affordances for `unassigned faces` and `machine-labeled unconfirmed` in Library.
+
+## Why This Matters
+
+Users need direct ways to focus labeling work queues.
+
+## Scope
+
+- add two typed face-state filters with chip/state summary behavior
+- integrate filters with URL-synced query state
+- expose counts where API supports facets
+
+## Non-Goals
+
+- ML threshold policy changes
+
+## Acceptance Criteria
+
+- both filters can be applied/removed deterministically
+- filter state persists in URL and deep-link restore
+- resulting set aligns with backend semantics
+
+## Verification
+
+- unit tests for serialization/parsing
+- integration tests for request payload mapping
+
+## Dependencies
+
+- #160
+- backend face-state filter contract (new)
+
+## Potentially supersedes
+
+- extension of #178
+
+---
+
+### 5) Album domain APIs and persistence
+
+**Title**
+`Implement album domain APIs and persistence for photo-reference collections`
+
+**Suggested labels**
+- `phase:4`
+- `priority:p1`
+- `type:implementation`
+- `area:web`
+
+**Body**
+
+## Summary
+
+Deliver album APIs and persistence for reference-based collections and membership operations.
+
+## Why This Matters
+
+Shareable albums must exist as durable DB entities before UI workflows can rely on them.
+
+## Scope
+
+- create `albums`, `album_items`, and baseline API endpoints
+- support create/list/detail/update/delete and batch add/remove membership
+- deterministic duplicate handling and summary responses
+
+## Non-Goals
+
+- public sharing
+- export packaging details
+
+## Acceptance Criteria
+
+- album CRUD and membership APIs are available and tested
+- duplicate photo add behavior is explicit and idempotent/conflict-defined
+- pagination and access boundaries are deterministic
+
+## Verification
+
+- API tests for CRUD, membership, and conflicts
+
+## Dependencies
+
+- backend implementation slice (new)
+
+## Potentially supersedes
+
+- backend dependency placeholder in #235
+
+---
+
+### 6) Albums UI and add-to-album flows
+
+**Title**
+`Implement Albums UI and add-to-album workflows from Library selection`
+
+**Suggested labels**
+- `phase:4`
+- `priority:p1`
+- `type:implementation`
+- `area:web`
+
+**Body**
+
+## Summary
+
+Implement Albums route (list/detail) and connect Library selection actions to create/add album flows.
+
+## Why This Matters
+
+Users need a reusable, inspectable destination for selected photo sets.
+
+## Scope
+
+- album list and album detail pages
+- add-to-existing and create-new album actions from Library
+- deterministic completion summaries for add operations
+
+## Non-Goals
+
+- advanced album curation tooling
+
+## Acceptance Criteria
+
+- user can create album from current selection scope
+- user can add selection to existing album
+- album detail shows referenced photos and membership updates
+
+## Verification
+
+- component and route integration tests
+- e2e creation and add-existing flows
+
+## Dependencies
+
+- stories 1, 2, 5
+
+## Potentially supersedes
+
+- #235
+
+---
+
+### 7) Authenticated album sharing
+
+**Title**
+`Implement authenticated album sharing with viewer/editor roles`
+
+**Suggested labels**
+- `phase:4`
+- `priority:p1`
+- `type:implementation`
+- `area:web`
+
+**Body**
+
+## Summary
+
+Implement in-app sharing controls for albums with role-based access (viewer/editor).
+
+## Why This Matters
+
+Albums are collaborative artifacts, not just local personal lists.
+
+## Scope
+
+- share management UI (grant/change/revoke)
+- API integration for role assignments
+- role-aware UI gating in album detail and add/remove flows
+
+## Non-Goals
+
+- unauthenticated share links
+- invitation email workflows
+
+## Acceptance Criteria
+
+- owners can grant/revoke viewer/editor access to authenticated users
+- shared users only see allowed actions
+- permission errors are explicit and deterministic
+
+## Verification
+
+- API tests for ACL enforcement
+- e2e owner vs shared-user role matrix
+
+## Dependencies
+
+- story 5
+- story 6
+
+---
+
+### 8) Album export workflow
+
+**Title**
+`Implement album export workflow with local folder write and ZIP fallback`
+
+**Suggested labels**
+- `phase:4`
+- `priority:p1`
+- `type:implementation`
+- `area:web`
+
+**Body**
+
+## Summary
+
+Implement `Export album to...` from album detail with browser capability detection and deterministic fallback behavior.
+
+## Why This Matters
+
+Users need a reliable external handoff of curated album contents.
+
+## Scope
+
+- export entry point from album detail
+- capability detection for directory-write API
+- folder-write happy path where supported
+- ZIP fallback path where not supported
+- completion summary with exported/skipped counts and reasons
+
+## Non-Goals
+
+- cloud destination connectors
+
+## Acceptance Criteria
+
+- user can export from album detail
+- supported browsers offer local folder write flow
+- unsupported browsers receive ZIP fallback without dead-end UX
+- export results are clearly reported
+
+## Verification
+
+- UI tests for capability branches
+- e2e export scenarios for folder-write and ZIP fallback
+
+## Dependencies
+
+- story 6
+- export backend contract (new)
+
+## Potentially supersedes
+
+- #232
+- #233
+- #237 (partially, status surface reuse possible)
+
+---
+
+### 9) Legacy route migration
+
+**Title**
+`Implement browse/search to Library redirects with state-preserving migration`
+
+**Suggested labels**
+- `phase:4`
+- `priority:p1`
+- `type:implementation`
+- `area:web`
+
+**Body**
+
+## Summary
+
+Provide transition-safe redirects from legacy `/browse` and `/search` routes into `Library` while preserving state continuity.
+
+## Why This Matters
+
+Migration should not break existing deep links or user muscle memory.
+
+## Scope
+
+- route redirects from legacy entry points
+- map legacy query params into Library-compatible URL state
+- preserve focus/return behavior where feasible
+
+## Non-Goals
+
+- long-term support for duplicate route implementations
+
+## Acceptance Criteria
+
+- legacy route URLs resolve into Library without losing core state intent
+- no shell navigation regressions
+- deterministic fallback for unsupported/invalid legacy params
+
+## Verification
+
+- route tests and e2e deep-link checks
+
+## Dependencies
+
+- story 1
+- #179
+
+---
+
+### 10) E2E journeys for Library->Album->Export
+
+**Title**
+`Implement end-to-end journey coverage for library selection, album sharing, and export`
+
+**Suggested labels**
+- `phase:4`
+- `priority:p1`
+- `type:implementation`
+- `area:web`
+
+**Body**
+
+## Summary
+
+Add executable journey coverage for the new workflow from selection through sharing and export.
+
+## Why This Matters
+
+This workflow crosses route boundaries and role contexts; regressions are high-risk without journey tests.
+
+## Scope
+
+- journey docs and traceability entries
+- e2e tests for:
+  - build album from filtered library scope
+  - share with second authenticated user
+  - export with capability-aware behavior
+
+## Non-Goals
+
+- exhaustive browser compatibility matrix beyond target support policy
+
+## Acceptance Criteria
+
+- journey IDs and docs map to executable specs
+- workflow assertions are deterministic and role-aware
+- failures are attributable to specific journey steps
+
+## Verification
+
+- run journey suite in CI and local
+
+## Dependencies
+
+- stories 1-9
+- existing journey infra from #208 and #219
+
+---
+
+## Initial De-duplication Candidates For Next Review
+
+Likely overlapping/open items to evaluate for closure, merge, or retargeting:
+
+- Epic overlap: #229 `UI EPIC: Phase 3 Search Result Bulk Actions`
+- Story overlap: #230, #231, #232, #233, #235, #237
+- Structural overlap: #220 (shared browse/search primitives)
+- Potential partial overlap: #187 (multi-item labeling navigation)
+
+No closure actions are taken in this draft; this list is for the explicit review pass requested by the team.
+
+## Existing Issue Review Matrix (Proposed)
+
+Status snapshot date: 2026-05-01
+
+### Existing epic-level issues
+
+- #229 `UI EPIC: Phase 3 Search Result Bulk Actions` (open)
+  - Proposed disposition: **Close as superseded** once the new unified epic is created.
+  - Reason: scope is largely subsumed by the new direction and now also expands beyond Search-only context into Library + Albums + sharing.
+
+- #161 `UI EPIC: Phase 4 Face Labeling Workflow` (open)
+  - Proposed disposition: **Keep open**.
+  - Reason: still the parent for people-management and core face-labeling slices; new epic should depend on it and extend it into Library context.
+
+### Existing story-level issues
+
+- #230 selection scope model (open)
+  - Proposed disposition: **Retarget and keep**.
+  - Action: update title/body from Search-specific to Library-scoped selection semantics.
+
+- #231 bulk action bar (open)
+  - Proposed disposition: **Retarget and keep**.
+  - Action: move from Search-results context to Library action bar context.
+
+- #232 destination-folder copy flow (open)
+  - Proposed disposition: **Merge into new export story**.
+  - Action: close as superseded after migration notes are copied.
+
+- #233 ZIP export (open)
+  - Proposed disposition: **Keep as fallback sub-slice** under album export story.
+  - Action: retarget to explicit fallback behavior in album export.
+
+- #235 save as collection/album (open)
+  - Proposed disposition: **Retarget and keep**.
+  - Action: rename to album reference workflow, align with album entity + sharing model.
+
+- #237 bulk-action status surface (open)
+  - Proposed disposition: **Keep, broaden**.
+  - Action: treat as shared async-job feedback surface used by album export and future bulk operations.
+
+- #234 metadata bulk editor (open)
+  - Proposed disposition: **Keep separate, de-prioritize**.
+  - Reason: valuable but not required for the approved Library+Albums journey baseline.
+
+- #236 CSV/JSON manifest export (open)
+  - Proposed disposition: **Keep separate, de-prioritize**.
+  - Reason: useful adjunct feature, not part of must-have journey.
+
+- #220 browse/search refactor primitives (open)
+  - Proposed disposition: **Retarget and keep**.
+  - Action: recast as migration/refactor story for Library unification internals.
+
+- #187 multi-item labeling navigation (open)
+  - Proposed disposition: **Keep open (possible partial overlap)**.
+  - Reason: can still provide value for detail-centric workflows even after in-context Library actions.
+
+## Recommended sequencing for cleanup
+
+1. Create new unified epic and child-story set.
+2. Immediately retarget #230, #231, #233, #235, #237, #220 to the new epic.
+3. Close #229 (superseded) and close #232 after extracting any unique acceptance criteria.
+4. Leave #234 and #236 open but move to lower priority/milestone if needed.
+5. Keep #161 and #187 open; reassess #187 after Library face-workflow implementation lands.

--- a/docs/superpowers/specs/2026-05-01-library-albums-unified-workflow-design.md
+++ b/docs/superpowers/specs/2026-05-01-library-albums-unified-workflow-design.md
@@ -1,0 +1,223 @@
+# Unified Library + Shareable Albums + Export Workflow Design
+
+Date: 2026-05-01
+
+## Summary
+
+Unify browsing and filtering into a single Library workspace, add shareable in-app albums backed by database photo references, and provide album export to the user's local filesystem.
+
+This design shifts albums from "copied photo bundles" to first-class collaborative entities while preserving an explicit export action for external use.
+
+## Goals
+
+- Combine Browse and Search into one visual-first Library screen.
+- Keep filtering/search controls and photo selection on the same screen.
+- Allow direct face assignment/confirmation from the Library workflow.
+- Add shareable albums as database entities that reference photos.
+- Enable export of album photos to the user's local filesystem.
+
+## Non-Goals
+
+- Public or unauthenticated share links.
+- Cross-tenant sharing.
+- Changing face-recognition model behavior.
+- Binary asset deduplication redesign.
+
+## User Journeys Covered
+
+1. As a user, I can visually browse photos with key attributes and select them.
+2. As a user, I can assign a person's name to detected faces from the active selection workflow.
+3. As a user, I can confirm or correct machine-assigned face labels with provenance visibility.
+4. As a user, I can save selected/filtered photos to an album and later export that album externally.
+
+## IA And Navigation
+
+### Primary routes
+
+- `Library` (new primary working route)
+- `Albums` (new route)
+- `Photo Detail` (retained for deep inspection)
+- `Labeling` (people management retained)
+
+### Route migration
+
+- Default app landing route becomes `Library`.
+- Existing `/browse` and `/search` are preserved as temporary redirects into `Library` URL-state equivalents during migration.
+
+## Approaches Considered
+
+1. Keep separate Browse and Search routes, improve both.
+2. Merge into a unified Library route with persistent filters and visual results. (Recommended)
+3. Make Albums the first-class working route and browse from album context.
+
+## Decision
+
+Adopt Approach 2.
+
+Reasoning: it aligns with the core use case (visual select + filter + act) and avoids context switching while still supporting deep detail and collaboration flows.
+
+## UX Design
+
+### Library workspace
+
+- Always visual result grid.
+- Persistent filter/search controls in the same screen.
+- Selection affordances:
+  - single select
+  - multi-select
+  - select current page
+  - select all filtered results
+- Action bar appears when selection exists.
+
+### Face workflow in Library
+
+- Face regions shown in preview/quick panel.
+- Unassigned faces allow direct assignment.
+- Machine-labeled faces allow `Confirm` or `Correct`.
+- Provenance badges remain visible.
+- New face-state filter affordances:
+  - `Unassigned faces`
+  - `Machine-labeled, unconfirmed`
+
+### Album workflow
+
+- `Add to album` from selection action bar.
+- User can choose existing album or create new album inline.
+- Album detail view lists referenced photos and collaborator access.
+
+### Sharing model
+
+Authenticated in-app sharing only.
+
+- Owner grants access to specific app users.
+- Roles:
+  - `viewer`: read album
+  - `editor`: add/remove album photos and manage working content
+
+### Export workflow
+
+Export is an album action, not a replacement for album storage.
+
+- Action: `Export album to...`
+- Preferred: browser directory picker and direct local-folder write when supported.
+- Fallback: ZIP download artifact for browsers without writable directory APIs.
+- Completion summary includes exported/skipped counts and reasons.
+
+## Data Model
+
+### `albums`
+
+- `album_id` (PK)
+- `name`
+- `owner_user_id`
+- `created_ts`
+- `updated_ts`
+
+### `album_items`
+
+- `album_id` (FK -> albums)
+- `photo_id` (FK -> photos)
+- `added_by_user_id`
+- `added_ts`
+- Unique: `(album_id, photo_id)`
+
+### `album_shares`
+
+- `album_id` (FK -> albums)
+- `user_id`
+- `role` (`viewer` | `editor`)
+- `granted_by_user_id`
+- `granted_ts`
+- Unique: `(album_id, user_id)`
+
+## API Surface
+
+### Albums
+
+- `POST /api/v1/albums` create album
+- `GET /api/v1/albums` list owned + shared albums
+- `GET /api/v1/albums/{album_id}` album metadata + paged items
+- `PATCH /api/v1/albums/{album_id}` rename/update metadata
+- `DELETE /api/v1/albums/{album_id}` delete album
+
+### Album items
+
+- `POST /api/v1/albums/{album_id}/items` add photo references (single/batch)
+- `DELETE /api/v1/albums/{album_id}/items/{photo_id}` remove reference
+
+### Sharing
+
+- `POST /api/v1/albums/{album_id}/shares` grant access to user
+- `PATCH /api/v1/albums/{album_id}/shares/{user_id}` change role
+- `DELETE /api/v1/albums/{album_id}/shares/{user_id}` revoke access
+
+### Export
+
+- `POST /api/v1/albums/{album_id}/exports` create export job manifest
+- `GET /api/v1/albums/{album_id}/exports/{export_id}` poll status and retrieve artifact metadata (fallback ZIP flow)
+
+## Permission Rules
+
+- Owner: full album and share management.
+- Editor: add/remove album items, trigger export.
+- Viewer: read-only access; export allowed unless policy later restricts it.
+
+## Error Handling
+
+- Duplicate album item add returns deterministic conflict response; UI reports "already in album" count.
+- Share grant to unknown user returns validation error.
+- Export failures report per-photo reason categories (missing original, access denied, read failure).
+- Directory-write capability unavailable triggers explicit fallback to ZIP download flow.
+
+## Acceptance Criteria
+
+1. Library route provides both visual browsing and filtering/search on one screen.
+2. Library face workflows support assignment and machine-label confirm/correct without mandatory navigation to Photo Detail.
+3. Users can save selected or filtered photos to albums backed by DB references.
+4. Albums can be shared with authenticated app users and role-enforced access works.
+5. Album export supports local filesystem destination via directory picker where available, with ZIP fallback where not.
+6. Export completion reports include deterministic success/skip counts and skip reasons.
+
+## Testing Strategy
+
+### UI
+
+- Library renders visual cards with active filter state and selection actions.
+- Add-to-album flows for selected subset and select-all-filtered mode.
+- Face-state filter behavior (`unassigned`, `unconfirmed machine labels`).
+- Share panel role changes and permission-gated controls.
+- Export capability detection and ZIP fallback UX.
+
+### API
+
+- CRUD and list coverage for albums.
+- Duplicate reference conflict behavior.
+- Access control matrix (owner/editor/viewer/non-member).
+- Export job lifecycle and result reporting contract.
+
+### E2E journeys
+
+- Build album from filtered Library results.
+- Share album with second authenticated user and verify permissions.
+- Export shared album to local destination path flow (capability-aware).
+
+## Risks And Mitigations
+
+- Browser API fragmentation for local writes.
+  - Mitigation: explicit capability check + ZIP fallback.
+- Selection scale for "all filtered" with large result sets.
+  - Mitigation: server-side selection token/manifest semantics, not client-only ID accumulation.
+- Permission drift between UI and API.
+  - Mitigation: server-authoritative checks and explicit UI gating from role payload.
+
+## Migration Notes
+
+- Existing Browse/Search behaviors become internal modules inside Library.
+- Keep legacy routes as redirects short-term to preserve deep links.
+- Existing Photo Detail face controls remain valid and reused for deep inspection until full Library quick-panel parity is complete.
+
+## Out Of Scope Follow-Ups
+
+- Public share links.
+- Time-bound share invitations.
+- Collaborative album activity feed.

--- a/docs/testing/journeys/JRN-P4-library-unification-shared-primitives.md
+++ b/docs/testing/journeys/JRN-P4-library-unification-shared-primitives.md
@@ -1,0 +1,43 @@
+# Journey: JRN-P4-library-unification-shared-primitives
+
+## Business Outcome
+
+Browse and Search share deterministic request lifecycle handling and result identity rendering as Library unification progresses.
+
+## Acceptance Criteria
+
+### Scenario 1: Browse uses shared loading/error/retry lifecycle
+
+- Given the user opens `/browse`
+- When a request is pending
+- Then Browse shows the route loading state
+- And a failed follow-up request shows retryable route error feedback
+- And selecting Retry restores ready results
+
+### Scenario 2: Browse resets invalid page state deterministically
+
+- Given the user opens `/browse?page=3` without a valid cursor boundary
+- When Browse resolves pagination state
+- Then the route resets to page 1 and shows the invalid-page messaging
+
+### Scenario 3: Search uses shared loading/error/retry lifecycle and result identity
+
+- Given the user opens `/search` and submits a query
+- When a request is pending
+- Then Search shows the route loading state
+- And results render shared identity primitives (photo heading + path)
+- And a failed follow-up request shows retryable route error feedback
+- And selecting Retry restores ready results
+
+## Out Of Scope
+
+- Backend search semantics and ranking behavior
+- Filter contract redesign
+
+## Linked UI Stories
+
+- [#220](https://github.com/noead01/photo-org/issues/220)
+
+## Linked Playwright Specs
+
+- [apps/ui/tests/e2e/journeys/library-unification-journeys.spec.ts](../../../apps/ui/tests/e2e/journeys/library-unification-journeys.spec.ts)


### PR DESCRIPTION
## Summary
- extract shared Library primitives for route request lifecycle (`loading/error/retry/reset`)
- extract shared cursor pagination helpers and URL serialization helpers used by Browse/Search
- extract shared photo result identity rendering primitive used by both route result views
- migrate `BrowseRoutePage` and `SearchRoutePage` to shared feedback + lifecycle primitives while preserving behavior
- add journey and unit test coverage for the extracted primitives and shared browse/search lifecycle flows

## Testing
- `npm --prefix apps/ui test -- src/pages/BrowseRoutePage.test.tsx src/pages/SearchRoutePage.test.tsx src/pages/library/pagination.test.ts src/pages/library/urlSerialization.test.ts src/pages/library/requestLifecycle.test.ts`
- `npm --prefix apps/ui run build`
- `npm --prefix apps/ui run test:e2e -- tests/e2e/journeys/library-unification-journeys.spec.ts`
- `npm --prefix apps/ui run test:e2e:journey`

Closes #220