### PR TITLE
[codex] Implement Library selection scope model (#230)

### DIFF
--- a/apps/ui/src/pages/BrowseRoutePage.test.tsx
+++ b/apps/ui/src/pages/BrowseRoutePage.test.tsx
@@ -113,6 +113,7 @@ describe("BrowseRoutePage", () => {
     expect(parsedBody.sort).toEqual({ by: "shot_ts", dir: "desc" });
     expect(parsedBody.page).toEqual({ limit: 24, cursor: null });
     expect(screen.getByText("Page 1")).toBeInTheDocument();
+    expect(screen.getByText("Selected scope: 0 photos")).toBeInTheDocument();
   });
 
   it("advances to next page with returned cursor and supports previous", async () => {
@@ -308,5 +309,88 @@ describe("BrowseRoutePage", () => {
     await waitFor(() => {
       expect(heading).toHaveFocus();
     });
+  });
+
+  it("supports selection scope toggles with deterministic count feedback", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => buildPayload(["photo-a", "photo-b"], "cursor-page-2", 9)
+    } as Response);
+
+    renderBrowseAt("/browse");
+
+    expect(await screen.findByText("photo-a")).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("checkbox", { name: "Select photo" })[0]);
+    expect(screen.getByText("Selected scope: 1 photo")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("radio", { name: "This page" }));
+    expect(screen.getByText("This page scope: 2 photos")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("radio", { name: "All filtered" }));
+    expect(screen.getByText("All filtered scope: 9 photos")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("radio", { name: "Selected" }));
+    expect(screen.getByText("Selected scope: 1 photo")).toBeInTheDocument();
+  });
+
+  it("keeps explicit selections across pagination transitions", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => buildPayload(["photo-a"], "cursor-page-2", 3)
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => buildPayload(["photo-b"], "cursor-page-3", 3)
+      } as Response);
+
+    renderBrowseAt("/browse");
+
+    expect(await screen.findByText("photo-a")).toBeInTheDocument();
+    await user.click(screen.getByRole("checkbox", { name: "Select photo" }));
+    expect(screen.getByText("Selected scope: 1 photo")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+    expect(await screen.findByText("photo-b")).toBeInTheDocument();
+    expect(screen.getByText("Selected scope: 1 photo")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Clear selected" })).toBeEnabled();
+  });
+
+  it("hydrates selection state from route-local location state", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => buildPayload(["photo-a"], null, 1)
+    } as Response);
+
+    render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: "/browse",
+            state: {
+              browseSelection: {
+                scope: "selected",
+                selectedPhotoIds: ["photo-a"],
+                allFilteredFingerprint: null
+              }
+            }
+          }
+        ]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route path="/browse" element={<BrowseRoutePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText("photo-a")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Select photo" })).toBeChecked();
+    expect(screen.getByText("Selected scope: 1 photo")).toBeInTheDocument();
   });
 });

--- a/apps/ui/src/pages/BrowseRoutePage.tsx
+++ b/apps/ui/src/pages/BrowseRoutePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { FeedbackSurface } from "../app/feedback/FeedbackSurface";
 import type { FeedbackViewState, NotificationEntry } from "../app/feedback/feedbackTypes";
@@ -10,6 +10,14 @@ import {
 } from "./library/pagination";
 import { useRouteRequestState } from "./library/requestLifecycle";
 import { parsePositiveIntParam } from "./library/urlSerialization";
+import {
+  createLibrarySelectionState,
+  formatSelectionScopeLabel,
+  librarySelectionReducer,
+  parseLibrarySelectionRouteState,
+  resolveSelectionScopeCount,
+  serializeLibrarySelectionState
+} from "./library/librarySelection";
 import {
   consumePendingBrowseFocusPhotoId,
   resolveBrowseReturnState,
@@ -52,6 +60,7 @@ type SearchResponsePayload = {
 };
 
 const PAGE_LIMIT = 24;
+const BROWSE_FILTER_FINGERPRINT = "browse:all-results";
 
 function formatShotTimestamp(shotTs: string | null): string {
   if (!shotTs) {
@@ -124,6 +133,11 @@ export function BrowseRoutePage() {
   const [totalCount, setTotalCount] = useState(0);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
+  const [selectionState, dispatchSelection] = useReducer(
+    librarySelectionReducer,
+    initialReturnState?.browseSelection ?? null,
+    createLibrarySelectionState
+  );
   const {
     isLoading,
     error,
@@ -136,6 +150,10 @@ export function BrowseRoutePage() {
   const headingRef = useRef<HTMLHeadingElement | null>(null);
   const pendingReturnFocusPhotoIdRef = useRef<string | null>(
     initialReturnState?.restoreFocusPhotoId ?? consumePendingBrowseFocusPhotoId()
+  );
+  const selectionRouteState = useMemo(
+    () => serializeLibrarySelectionState(selectionState),
+    [selectionState]
   );
 
   const cursorForPage = cursorByPage[requestedPage];
@@ -167,6 +185,44 @@ export function BrowseRoutePage() {
       ...current.filter((entry) => entry.id !== "browse-warning")
     ]);
   }
+
+  useEffect(() => {
+    dispatchSelection({
+      type: "filtersChanged",
+      activeFilterFingerprint: BROWSE_FILTER_FINGERPRINT
+    });
+  }, []);
+
+  useEffect(() => {
+    const currentRouteSelection = parseLibrarySelectionRouteState(
+      isRecord(location.state) ? location.state.browseSelection : undefined
+    );
+
+    if (areSelectionRouteStatesEqual(currentRouteSelection, selectionRouteState)) {
+      return;
+    }
+
+    const routeState = isRecord(location.state) ? location.state : {};
+    navigate(
+      {
+        pathname: location.pathname,
+        search: location.search
+      },
+      {
+        replace: true,
+        state: {
+          ...routeState,
+          browseSelection: selectionRouteState
+        }
+      }
+    );
+  }, [
+    location.pathname,
+    location.search,
+    location.state,
+    navigate,
+    selectionRouteState
+  ]);
 
   useEffect(() => {
     if (requestedPage > 1 && cursorForPage === undefined) {
@@ -265,6 +321,11 @@ export function BrowseRoutePage() {
     }
     return `Showing ${photos.length} of ${totalCount} photos`;
   }, [error, isLoading, photos.length, requestedPage, totalCount]);
+  const activeScopeCount = resolveSelectionScopeCount(selectionState, {
+    currentPageCount: photos.length,
+    totalFilteredCount: totalCount
+  });
+  const selectionSummaryLabel = `${formatSelectionScopeLabel(selectionState.scope)} scope: ${activeScopeCount} photo${activeScopeCount === 1 ? "" : "s"}`;
 
   return (
     <section aria-labelledby="page-title" className="page browse-page">
@@ -315,6 +376,71 @@ export function BrowseRoutePage() {
       </div>
 
       <p className="browse-summary" aria-live="polite">{summaryLabel}</p>
+      <section className="browse-selection-panel" aria-label="Library selection controls">
+        <fieldset className="browse-selection-scope-group">
+          <legend>Selection scope</legend>
+          <label>
+            <input
+              type="radio"
+              name="browse-selection-scope"
+              value="selected"
+              checked={selectionState.scope === "selected"}
+              onChange={() => {
+                dispatchSelection({
+                  type: "setScope",
+                  scope: "selected",
+                  activeFilterFingerprint: BROWSE_FILTER_FINGERPRINT
+                });
+              }}
+            />
+            Selected
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="browse-selection-scope"
+              value="page"
+              checked={selectionState.scope === "page"}
+              onChange={() => {
+                dispatchSelection({
+                  type: "setScope",
+                  scope: "page",
+                  activeFilterFingerprint: BROWSE_FILTER_FINGERPRINT
+                });
+              }}
+            />
+            This page
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="browse-selection-scope"
+              value="allFiltered"
+              checked={selectionState.scope === "allFiltered"}
+              onChange={() => {
+                dispatchSelection({
+                  type: "setScope",
+                  scope: "allFiltered",
+                  activeFilterFingerprint: BROWSE_FILTER_FINGERPRINT
+                });
+              }}
+            />
+            All filtered
+          </label>
+        </fieldset>
+        <p className="browse-selection-summary" aria-live="polite">
+          {selectionSummaryLabel}
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            dispatchSelection({ type: "clearExplicitSelection" });
+          }}
+          disabled={selectionState.selectedPhotoIds.size === 0}
+        >
+          Clear selected
+        </button>
+      </section>
       <section className="status-legend" aria-label="Ingest status legend">
         <h2>Ingest status legend</h2>
         <ul>
@@ -359,6 +485,19 @@ export function BrowseRoutePage() {
                     <span className={`ingest-status-badge is-${ingestStatus.tone}`}>{ingestStatus.label}</span>
                     <span className="browse-ingest-status-detail">{ingestStatus.description}</span>
                   </p>
+                  <label className="browse-card-selection">
+                    <input
+                      type="checkbox"
+                      checked={selectionState.selectedPhotoIds.has(photo.photo_id)}
+                      onChange={() => {
+                        dispatchSelection({
+                          type: "togglePhotoSelection",
+                          photoId: photo.photo_id
+                        });
+                      }}
+                    />
+                    Select photo
+                  </label>
                   {photo.thumbnail ? (
                     <img
                       className="browse-thumbnail"
@@ -382,7 +521,8 @@ export function BrowseRoutePage() {
                           to={`/browse/${photo.photo_id}`}
                           state={{
                             returnToBrowseSearch: location.search,
-                            returnFocusPhotoId: photo.photo_id
+                            returnFocusPhotoId: photo.photo_id,
+                            browseSelection: selectionRouteState
                           }}
                           onClick={() => setPendingBrowseFocusPhotoId(photo.photo_id)}
                         >
@@ -419,4 +559,30 @@ export function BrowseRoutePage() {
       </FeedbackSurface>
     </section>
   );
+}
+
+function areSelectionRouteStatesEqual(
+  left: ReturnType<typeof parseLibrarySelectionRouteState>,
+  right: ReturnType<typeof serializeLibrarySelectionState>
+): boolean {
+  if (!left) {
+    return false;
+  }
+  if (left.scope !== right.scope) {
+    return false;
+  }
+  if (left.allFilteredFingerprint !== right.allFilteredFingerprint) {
+    return false;
+  }
+  if (left.selectedPhotoIds.length !== right.selectedPhotoIds.length) {
+    return false;
+  }
+
+  return left.selectedPhotoIds.every(
+    (photoId, index) => photoId === right.selectedPhotoIds[index]
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -395,7 +395,14 @@ export function PhotoDetailRoutePage() {
             pathname: "/browse",
             search: returnState.returnToBrowseSearch ?? ""
           }}
-          state={backLinkFocusPhotoId ? { restoreFocusPhotoId: backLinkFocusPhotoId } : undefined}
+          state={
+            backLinkFocusPhotoId || returnState.browseSelection
+              ? {
+                  restoreFocusPhotoId: backLinkFocusPhotoId ?? undefined,
+                  browseSelection: returnState.browseSelection
+                }
+              : undefined
+          }
           onClick={() => {
             if (backLinkFocusPhotoId) {
               setPendingBrowseFocusPhotoId(backLinkFocusPhotoId);

--- a/apps/ui/src/pages/browseFocusState.ts
+++ b/apps/ui/src/pages/browseFocusState.ts
@@ -1,10 +1,17 @@
+import {
+  parseLibrarySelectionRouteState,
+  type LibrarySelectionRouteState
+} from "./library/librarySelection";
+
 export interface BrowseReturnState {
   restoreFocusPhotoId?: string;
+  browseSelection?: LibrarySelectionRouteState;
 }
 
 export interface DetailReturnState {
   returnToBrowseSearch?: string;
   returnFocusPhotoId?: string;
+  browseSelection?: LibrarySelectionRouteState;
 }
 
 let pendingBrowseFocusPhotoId: string | null = null;
@@ -29,11 +36,18 @@ export function resolveBrowseReturnState(state: unknown): BrowseReturnState | nu
   }
 
   const restoreFocusPhotoId = state.restoreFocusPhotoId;
-  if (typeof restoreFocusPhotoId !== "string" || restoreFocusPhotoId.length === 0) {
+  const browseSelection = parseLibrarySelectionRouteState(state.browseSelection);
+  const hasRestoreFocusPhotoId =
+    typeof restoreFocusPhotoId === "string" && restoreFocusPhotoId.length > 0;
+
+  if (!hasRestoreFocusPhotoId && !browseSelection) {
     return null;
   }
 
-  return { restoreFocusPhotoId };
+  return {
+    restoreFocusPhotoId: hasRestoreFocusPhotoId ? restoreFocusPhotoId : undefined,
+    browseSelection: browseSelection ?? undefined
+  };
 }
 
 export function resolveDetailReturnState(state: unknown): DetailReturnState {
@@ -47,6 +61,10 @@ export function resolveDetailReturnState(state: unknown): DetailReturnState {
   }
   if (typeof state.returnFocusPhotoId === "string" && state.returnFocusPhotoId.length > 0) {
     returnState.returnFocusPhotoId = state.returnFocusPhotoId;
+  }
+  const browseSelection = parseLibrarySelectionRouteState(state.browseSelection);
+  if (browseSelection) {
+    returnState.browseSelection = browseSelection;
   }
 
   return returnState;

--- a/apps/ui/src/pages/library/librarySelection.test.ts
+++ b/apps/ui/src/pages/library/librarySelection.test.ts
@@ -1,0 +1,153 @@
+import {
+  createLibrarySelectionState,
+  DEFAULT_LIBRARY_SELECTION_STATE,
+  formatSelectionScopeLabel,
+  librarySelectionReducer,
+  parseLibrarySelectionRouteState,
+  resolveSelectionScopeCount,
+  serializeLibrarySelectionState,
+  type LibrarySelectionState
+} from "./librarySelection";
+
+function buildState(
+  overrides: Partial<LibrarySelectionState> = {}
+): LibrarySelectionState {
+  return {
+    scope: overrides.scope ?? DEFAULT_LIBRARY_SELECTION_STATE.scope,
+    selectedPhotoIds: overrides.selectedPhotoIds ?? new Set<string>(),
+    allFilteredFingerprint:
+      overrides.allFilteredFingerprint ?? DEFAULT_LIBRARY_SELECTION_STATE.allFilteredFingerprint
+  };
+}
+
+describe("librarySelection", () => {
+  it("toggles explicit selection ids", () => {
+    const state = buildState();
+    const selected = librarySelectionReducer(state, {
+      type: "togglePhotoSelection",
+      photoId: "photo-1"
+    });
+
+    expect(selected.selectedPhotoIds.has("photo-1")).toBe(true);
+
+    const unselected = librarySelectionReducer(selected, {
+      type: "togglePhotoSelection",
+      photoId: "photo-1"
+    });
+    expect(unselected.selectedPhotoIds.size).toBe(0);
+  });
+
+  it("switches to allFiltered and stores filter fingerprint", () => {
+    const state = buildState();
+    const nextState = librarySelectionReducer(state, {
+      type: "setScope",
+      scope: "allFiltered",
+      activeFilterFingerprint: "filters:v1"
+    });
+
+    expect(nextState.scope).toBe("allFiltered");
+    expect(nextState.allFilteredFingerprint).toBe("filters:v1");
+  });
+
+  it("clears allFiltered scope when filters change", () => {
+    const state = buildState({
+      scope: "allFiltered",
+      allFilteredFingerprint: "filters:v1",
+      selectedPhotoIds: new Set<string>(["photo-a"])
+    });
+
+    const nextState = librarySelectionReducer(state, {
+      type: "filtersChanged",
+      activeFilterFingerprint: "filters:v2"
+    });
+
+    expect(nextState.scope).toBe("selected");
+    expect(nextState.allFilteredFingerprint).toBeNull();
+    expect(nextState.selectedPhotoIds.has("photo-a")).toBe(true);
+  });
+
+  it("keeps allFiltered scope when sort-only context remains same fingerprint", () => {
+    const state = buildState({
+      scope: "allFiltered",
+      allFilteredFingerprint: "filters:v1"
+    });
+
+    const nextState = librarySelectionReducer(state, {
+      type: "filtersChanged",
+      activeFilterFingerprint: "filters:v1"
+    });
+
+    expect(nextState).toBe(state);
+  });
+
+  it("serializes and restores route-local state", () => {
+    const state = buildState({
+      scope: "page",
+      selectedPhotoIds: new Set<string>(["photo-b", "photo-a"]),
+      allFilteredFingerprint: "ignored-when-not-allFiltered"
+    });
+
+    const serialized = serializeLibrarySelectionState(state);
+    expect(serialized).toEqual({
+      scope: "page",
+      selectedPhotoIds: ["photo-a", "photo-b"],
+      allFilteredFingerprint: null
+    });
+
+    const restored = createLibrarySelectionState(serialized);
+    expect(restored.scope).toBe("page");
+    expect(Array.from(restored.selectedPhotoIds)).toEqual(["photo-a", "photo-b"]);
+    expect(restored.allFilteredFingerprint).toBeNull();
+  });
+
+  it("parses route-local payload and rejects invalid shapes", () => {
+    expect(
+      parseLibrarySelectionRouteState({
+        scope: "selected",
+        selectedPhotoIds: ["photo-1", "photo-1", " "],
+        allFilteredFingerprint: null
+      })
+    ).toEqual({
+      scope: "selected",
+      selectedPhotoIds: ["photo-1"],
+      allFilteredFingerprint: null
+    });
+
+    expect(
+      parseLibrarySelectionRouteState({
+        scope: "bogus",
+        selectedPhotoIds: [],
+        allFilteredFingerprint: null
+      })
+    ).toBeNull();
+  });
+
+  it("resolves selection counts by active scope", () => {
+    const selectedState = buildState({
+      scope: "selected",
+      selectedPhotoIds: new Set(["a", "b", "c"])
+    });
+    expect(
+      resolveSelectionScopeCount(selectedState, { currentPageCount: 7, totalFilteredCount: 99 })
+    ).toBe(3);
+
+    const pageState = buildState({ scope: "page" });
+    expect(
+      resolveSelectionScopeCount(pageState, { currentPageCount: 7, totalFilteredCount: 99 })
+    ).toBe(7);
+
+    const allFilteredState = buildState({ scope: "allFiltered" });
+    expect(
+      resolveSelectionScopeCount(allFilteredState, {
+        currentPageCount: 7,
+        totalFilteredCount: 99
+      })
+    ).toBe(99);
+  });
+
+  it("formats selection scope labels", () => {
+    expect(formatSelectionScopeLabel("selected")).toBe("Selected");
+    expect(formatSelectionScopeLabel("page")).toBe("This page");
+    expect(formatSelectionScopeLabel("allFiltered")).toBe("All filtered");
+  });
+});

--- a/apps/ui/src/pages/library/librarySelection.ts
+++ b/apps/ui/src/pages/library/librarySelection.ts
@@ -1,0 +1,223 @@
+export type LibrarySelectionScope = "selected" | "page" | "allFiltered";
+
+export interface LibrarySelectionState {
+  scope: LibrarySelectionScope;
+  selectedPhotoIds: Set<string>;
+  allFilteredFingerprint: string | null;
+}
+
+export interface LibrarySelectionRouteState {
+  scope: LibrarySelectionScope;
+  selectedPhotoIds: string[];
+  allFilteredFingerprint: string | null;
+}
+
+type TogglePhotoSelectionAction = {
+  type: "togglePhotoSelection";
+  photoId: string;
+};
+
+type SetScopeAction = {
+  type: "setScope";
+  scope: LibrarySelectionScope;
+  activeFilterFingerprint: string;
+};
+
+type FiltersChangedAction = {
+  type: "filtersChanged";
+  activeFilterFingerprint: string;
+};
+
+type ClearExplicitSelectionAction = {
+  type: "clearExplicitSelection";
+};
+
+export type LibrarySelectionAction =
+  | TogglePhotoSelectionAction
+  | SetScopeAction
+  | FiltersChangedAction
+  | ClearExplicitSelectionAction;
+
+export const DEFAULT_LIBRARY_SELECTION_STATE: LibrarySelectionState = {
+  scope: "selected",
+  selectedPhotoIds: new Set<string>(),
+  allFilteredFingerprint: null
+};
+
+export function parseLibrarySelectionRouteState(
+  value: unknown
+): LibrarySelectionRouteState | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const scope = value.scope;
+  const selectedPhotoIds = value.selectedPhotoIds;
+  const allFilteredFingerprint = value.allFilteredFingerprint;
+
+  if (
+    scope !== "selected" &&
+    scope !== "page" &&
+    scope !== "allFiltered"
+  ) {
+    return null;
+  }
+
+  if (!Array.isArray(selectedPhotoIds) || !selectedPhotoIds.every((id) => typeof id === "string")) {
+    return null;
+  }
+
+  if (
+    allFilteredFingerprint !== null &&
+    typeof allFilteredFingerprint !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    scope,
+    selectedPhotoIds: dedupeNonEmptyStrings(selectedPhotoIds),
+    allFilteredFingerprint
+  };
+}
+
+export function createLibrarySelectionState(
+  routeState: LibrarySelectionRouteState | null
+): LibrarySelectionState {
+  if (!routeState) {
+    return cloneLibrarySelectionState(DEFAULT_LIBRARY_SELECTION_STATE);
+  }
+
+  return {
+    scope: routeState.scope,
+    selectedPhotoIds: new Set<string>(routeState.selectedPhotoIds),
+    allFilteredFingerprint:
+      routeState.scope === "allFiltered" ? routeState.allFilteredFingerprint : null
+  };
+}
+
+export function serializeLibrarySelectionState(
+  state: LibrarySelectionState
+): LibrarySelectionRouteState {
+  return {
+    scope: state.scope,
+    selectedPhotoIds: Array.from(state.selectedPhotoIds).sort((left, right) =>
+      left.localeCompare(right, "en-US")
+    ),
+    allFilteredFingerprint:
+      state.scope === "allFiltered" ? state.allFilteredFingerprint : null
+  };
+}
+
+export function librarySelectionReducer(
+  state: LibrarySelectionState,
+  action: LibrarySelectionAction
+): LibrarySelectionState {
+  if (action.type === "togglePhotoSelection") {
+    const normalizedPhotoId = action.photoId.trim();
+    if (normalizedPhotoId.length === 0) {
+      return state;
+    }
+
+    const nextSelectedPhotoIds = new Set(state.selectedPhotoIds);
+    if (nextSelectedPhotoIds.has(normalizedPhotoId)) {
+      nextSelectedPhotoIds.delete(normalizedPhotoId);
+    } else {
+      nextSelectedPhotoIds.add(normalizedPhotoId);
+    }
+
+    return {
+      ...state,
+      selectedPhotoIds: nextSelectedPhotoIds
+    };
+  }
+
+  if (action.type === "setScope") {
+    return {
+      ...state,
+      scope: action.scope,
+      allFilteredFingerprint:
+        action.scope === "allFiltered" ? action.activeFilterFingerprint : null
+    };
+  }
+
+  if (action.type === "filtersChanged") {
+    if (
+      state.scope === "allFiltered" &&
+      state.allFilteredFingerprint !== action.activeFilterFingerprint
+    ) {
+      return {
+        ...state,
+        scope: "selected",
+        allFilteredFingerprint: null
+      };
+    }
+
+    return state;
+  }
+
+  if (action.type === "clearExplicitSelection") {
+    if (state.selectedPhotoIds.size === 0) {
+      return state;
+    }
+    return {
+      ...state,
+      selectedPhotoIds: new Set<string>()
+    };
+  }
+
+  return state;
+}
+
+interface LibrarySelectionCountInput {
+  currentPageCount: number;
+  totalFilteredCount: number;
+}
+
+export function resolveSelectionScopeCount(
+  state: LibrarySelectionState,
+  input: LibrarySelectionCountInput
+): number {
+  if (state.scope === "page") {
+    return input.currentPageCount;
+  }
+
+  if (state.scope === "allFiltered") {
+    return input.totalFilteredCount;
+  }
+
+  return state.selectedPhotoIds.size;
+}
+
+export function formatSelectionScopeLabel(scope: LibrarySelectionScope): string {
+  if (scope === "allFiltered") {
+    return "All filtered";
+  }
+  if (scope === "page") {
+    return "This page";
+  }
+  return "Selected";
+}
+
+function cloneLibrarySelectionState(state: LibrarySelectionState): LibrarySelectionState {
+  return {
+    scope: state.scope,
+    selectedPhotoIds: new Set<string>(state.selectedPhotoIds),
+    allFilteredFingerprint: state.allFilteredFingerprint
+  };
+}
+
+function dedupeNonEmptyStrings(values: string[]): string[] {
+  const unique = new Set<string>();
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      unique.add(trimmed);
+    }
+  }
+  return Array.from(unique);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -252,6 +252,63 @@ body {
   color: #475569;
 }
 
+.browse-selection-panel {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.65rem;
+  background: #ffffff;
+  padding: 0.7rem 0.8rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-items: end;
+}
+
+.browse-selection-scope-group {
+  margin: 0;
+  padding: 0;
+  border: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.browse-selection-scope-group legend {
+  padding: 0;
+  margin-right: 0.2rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.browse-selection-scope-group label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: #1e293b;
+}
+
+.browse-selection-summary {
+  margin: 0;
+  color: #1e293b;
+  font-size: 0.9rem;
+}
+
+.browse-selection-panel button {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.35rem 0.55rem;
+  font: inherit;
+}
+
+.browse-selection-panel button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 .status-legend {
   border: 1px solid #cbd5e1;
   border-radius: 0.65rem;
@@ -298,7 +355,7 @@ body {
   background: #ffffff;
   overflow: hidden;
   display: grid;
-  grid-template-rows: auto 9rem 1fr;
+  grid-template-rows: auto auto 9rem 1fr;
 }
 
 .browse-ingest-status {
@@ -312,6 +369,15 @@ body {
 .browse-ingest-status-detail {
   color: #334155;
   font-size: 0.75rem;
+}
+
+.browse-card-selection {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0 0.75rem 0.55rem;
+  font-size: 0.82rem;
+  color: #1e293b;
 }
 
 .browse-thumbnail {


### PR DESCRIPTION
## Summary
- add a dedicated Library selection model/reducer for `selected`, `page`, and `allFiltered` scopes
- integrate scope controls, per-photo selection, and deterministic count summaries into Browse
- persist selection in route-local state (`location.state`) so deep links stay stable and selection survives browse/detail navigation
- extend browse/detail return-state plumbing for selection handoff
- add reducer and component tests for scope transitions, pagination persistence, and route-state hydration

## Why
Issue #230 requires explicit, verifiable selection scope semantics before downstream actions (albums/export) are wired.

## Validation
- `npm --prefix apps/ui test -- src/pages/library/librarySelection.test.ts src/pages/BrowseRoutePage.test.tsx src/pages/PhotoDetailRoutePage.test.tsx`
- `npm --prefix apps/ui run build`

Closes #230