### PR TITLE
Fix runtime search endpoint exposure

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -8,6 +8,7 @@ from app.routers.ingest_queue import router as ingest_queue_router
 from app.routers.operations import router as operations_router
 from app.routers.people import router as people_router
 from app.routers.photos import router as photos_router
+from app.routers.search import router as search_router
 from app.routers.storage_sources import router as storage_sources_router
 from app.openapi_docs import openapi_yaml_response
 
@@ -76,6 +77,7 @@ def create_app() -> FastAPI:
     app.include_router(face_assignments_router, prefix="/api/v1")
     app.include_router(people_router, prefix="/api/v1")
     app.include_router(photos_router, prefix="/api/v1")
+    app.include_router(search_router, prefix="/api/v1")
     app.include_router(storage_sources_router, prefix="/api/v1")
 
     @app.get("/openapi.yaml", include_in_schema=False)

--- a/apps/api/tests/test_ingest_queue_api.py
+++ b/apps/api/tests/test_ingest_queue_api.py
@@ -234,7 +234,7 @@ def test_process_queue_endpoint_processes_pending_rows_for_worker_role(
     }
 
 
-def test_search_endpoint_is_not_exposed_by_runtime_app(client: TestClient):
+def test_search_endpoint_is_exposed_by_runtime_app(client: TestClient):
     response = client.post("/api/v1/search", json={})
 
-    assert response.status_code == 404
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- mount the search router in the runtime FastAPI app under 
- keep a regression test that verifies  is exposed in the runtime app

## Validation
- uv run pytest tests/test_ingest_queue_api.py -k search_endpoint_is_exposed_by_runtime_app -q
- uv run pytest tests/test_main.py tests/test_ingest_queue_api.py -q