### PR TITLE
UI: actual-pixel detail preview, resizable frame, and face bbox toggles

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -7,4 +7,5 @@ PHOTO_ORG_UI_HOST_PORT=5173
 PHOTO_ORG_DB_SERVICE_DATABASE_URL=postgresql+psycopg://photoorg:photoorg@postgres:5432/photoorg
 PHOTO_ORG_COMPOSE_DATABASE_URL=postgresql+psycopg://photoorg:photoorg@localhost:5432/photoorg
 PHOTO_ORG_UI_API_BASE_URL=http://127.0.0.1:8000
+PHOTO_ORG_UI_PROXY_TARGET=http://db-service:8000
 PHOTO_ORG_API_CORS_ALLOWED_ORIGINS=http://127.0.0.1:5173,http://localhost:5173

--- a/apps/api/app/db/queue.py
+++ b/apps/api/app/db/queue.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
-from sqlalchemy import select, update
+from sqlalchemy import case, select, update
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
@@ -184,6 +184,11 @@ class IngestQueueStore:
 
     def list_processable(self, *, limit: int) -> list[QueueRow]:
         reclaim_before = _processing_lease_cutoff()
+        payload_type_priority = case(
+            (ingest_queue.c.payload_type == "extracted_photo", 0),
+            (ingest_queue.c.payload_type == "ingest_candidate", 1),
+            else_=2,
+        )
         with self._session_factory() as session:
             rows = session.execute(
                 select(ingest_queue)
@@ -195,7 +200,11 @@ class IngestQueueStore:
                         & (ingest_queue.c.last_attempt_ts <= reclaim_before)
                     )
                 )
-                .order_by(ingest_queue.c.enqueued_ts, ingest_queue.c.ingest_queue_id)
+                .order_by(
+                    payload_type_priority,
+                    ingest_queue.c.enqueued_ts,
+                    ingest_queue.c.ingest_queue_id,
+                )
                 .limit(limit)
             ).mappings()
             return [QueueRow(**row) for row in rows]

--- a/apps/api/tests/test_ingest_queue_processor.py
+++ b/apps/api/tests/test_ingest_queue_processor.py
@@ -826,9 +826,7 @@ def test_process_pending_rows_requeues_completed_extracted_photo_row_when_payloa
     assert pending_rows[0].last_error is None
 
 
-def test_process_pending_rows_refreshes_pending_extracted_photo_row_when_payload_refreshes(
-    tmp_path, monkeypatch
-):
+def test_process_pending_rows_prioritizes_pending_extracted_photo_rows_over_candidates(tmp_path):
     database_url = f"sqlite:///{tmp_path / 'queue-processor-ingest-candidate-refresh-pending.db'}"
     upgrade_database(database_url)
     queue_store = IngestQueueStore(database_url)
@@ -874,48 +872,6 @@ def test_process_pending_rows_refreshes_pending_extracted_photo_row_when_payload
         enqueued_ts=base_time + timedelta(seconds=1),
     )
 
-    refreshed_payload = build_payload(
-        photo_id="shared-photo-id",
-        path="/library/candidate-refresh-pending.jpg",
-        thumbnail_jpeg="dGh1bWI=",
-        thumbnail_mime_type="image/jpeg",
-        thumbnail_width=128,
-        thumbnail_height=128,
-        detections=[
-            {
-                "face_id": "face-1",
-                "bbox_x": 1,
-                "bbox_y": 2,
-                "bbox_w": 3,
-                "bbox_h": 4,
-                "bitmap": "ZmFjZS1iaXRtYXA=",
-                "embedding": None,
-                "provenance": {"detector": "fresh"},
-            }
-        ],
-        warnings=[],
-        payload_version=1,
-        storage_source_id="source-1",
-        watched_folder_id="wf-1",
-        relative_path="candidate-refresh-pending.jpg",
-    )
-
-    def fake_process_candidate_payload(database_url_arg, *, payload, face_detector=None):
-        assert database_url_arg == database_url
-        assert payload == candidate_payload
-        return ExtractionResult(
-            extracted_payload=refreshed_payload,
-            reused_existing_artifacts=False,
-            analysis_performed=True,
-        )
-
-    monkeypatch.setattr(
-        ingest_queue_processor,
-        "process_candidate_payload",
-        fake_process_candidate_payload,
-        raising=False,
-    )
-
     result = process_pending_ingest_queue(database_url, limit=1)
 
     completed_rows = queue_store.list_by_status("completed")
@@ -924,12 +880,11 @@ def test_process_pending_rows_refreshes_pending_extracted_photo_row_when_payload
     assert result.failed == 0
     assert result.retryable_errors == 0
     assert len(completed_rows) == 1
-    assert completed_rows[0].payload_type == "ingest_candidate"
+    assert completed_rows[0].payload_type == "extracted_photo"
     assert len(pending_rows) == 1
-    assert pending_rows[0].ingest_queue_id == extracted_queue_id
-    assert pending_rows[0].payload_type == "extracted_photo"
-    assert pending_rows[0].payload_json == refreshed_payload
-    assert pending_rows[0].last_error is None
+    assert pending_rows[0].ingest_queue_id == candidate_queue_id
+    assert pending_rows[0].payload_type == "ingest_candidate"
+    assert pending_rows[0].payload_json == candidate_payload
 
 
 def test_process_pending_rows_retries_candidate_when_collided_extracted_row_is_processing(

--- a/apps/api/tests/test_queue_store.py
+++ b/apps/api/tests/test_queue_store.py
@@ -1,8 +1,12 @@
+from datetime import UTC, datetime, timedelta
+
 import pytest
+from sqlalchemy import create_engine, update
 from sqlalchemy.exc import IntegrityError
 
 from app.db.queue import IngestQueueStore
 from app.migrations import upgrade_database
+from photoorg_db_schema import ingest_queue
 
 
 def test_enqueue_submission_stores_pending_queue_row(tmp_path):
@@ -90,3 +94,41 @@ def test_enqueue_reraises_invalid_submission_for_existing_idempotency_key(tmp_pa
     assert [row.ingest_queue_id for row in rows] == [queue_id]
     assert rows[0].payload_type == "photo_metadata"
     assert rows[0].payload_json == {"path": "a.heic"}
+
+
+def test_list_processable_prioritizes_extracted_payloads_over_candidates(tmp_path):
+    database_url = f"sqlite:///{tmp_path / 'queue-store-priority.db'}"
+    upgrade_database(database_url)
+
+    store = IngestQueueStore(database_url)
+
+    candidate_id = store.enqueue(
+        payload_type="ingest_candidate",
+        payload={"path": "candidate.jpg"},
+        idempotency_key="candidate-key",
+    )
+    extracted_id = store.enqueue(
+        payload_type="extracted_photo",
+        payload={"path": "extracted.jpg"},
+        idempotency_key="extracted-key",
+    )
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        base_time = datetime(2024, 1, 1, tzinfo=UTC)
+        connection.execute(
+            update(ingest_queue)
+            .where(ingest_queue.c.ingest_queue_id == candidate_id)
+            .values(enqueued_ts=base_time)
+        )
+        connection.execute(
+            update(ingest_queue)
+            .where(ingest_queue.c.ingest_queue_id == extracted_id)
+            .values(enqueued_ts=base_time + timedelta(seconds=1))
+        )
+
+    processable_rows = store.list_processable(limit=1)
+
+    assert len(processable_rows) == 1
+    assert processable_rows[0].ingest_queue_id == extracted_id
+    assert processable_rows[0].payload_type == "extracted_photo"
+    assert processable_rows[0].ingest_queue_id != candidate_id

--- a/apps/ui/src/pages/LibraryRoutePage.test.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.test.tsx
@@ -15,7 +15,12 @@ type SearchResponsePayload = {
       filesize: number;
       people: string[];
       faces: Array<{ person_id: string | null }>;
-      thumbnail: null;
+      thumbnail: {
+        mime_type: string;
+        width: number;
+        height: number;
+        data_base64: string;
+      } | null;
       original: {
         is_available: boolean;
         availability_state: string;
@@ -48,7 +53,11 @@ type PhotoDetailPayload = {
   } | null;
 };
 
-function buildPayload(photoIds: string[], total = photoIds.length): SearchResponsePayload {
+function buildPayload(
+  photoIds: string[],
+  total = photoIds.length,
+  includeDetectedFaces = false
+): SearchResponsePayload {
   return {
     hits: {
       total,
@@ -60,7 +69,7 @@ function buildPayload(photoIds: string[], total = photoIds.length): SearchRespon
         shot_ts: `2026-04-${String(index + 1).padStart(2, "0")}T12:00:00Z`,
         filesize: 1024 + index,
         people: [],
-        faces: [],
+        faces: includeDetectedFaces ? [{ person_id: null }] : [],
         thumbnail: null,
         original: {
           is_available: true,
@@ -157,6 +166,237 @@ describe("LibraryRoutePage", () => {
     expect(screen.getByTitle(/Complete: Assets are ready for normal browse\/detail viewing\./)).toBeInTheDocument();
   });
 
+  it("links thumbnail previews to photo detail", async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      const payload = buildPayload(["photo-a"]);
+      payload.hits.items[0].thumbnail = {
+        mime_type: "image/jpeg",
+        width: 120,
+        height: 80,
+        data_base64: "dGh1bWI="
+      };
+
+      return {
+        ok: true,
+        json: async () => payload
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    const thumbnailLink = await screen.findByRole("link", {
+      name: "View details for /library/photo-a.jpg"
+    });
+
+    expect(thumbnailLink).toHaveAttribute("href", "/library/photo-a");
+  });
+
+  it("loads and toggles face bbox overlays for an individual grid photo", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      if (url === "/api/v1/search") {
+        const payload = buildPayload(["photo-a"], 1, true);
+        payload.hits.items[0].thumbnail = {
+          mime_type: "image/jpeg",
+          width: 120,
+          height: 80,
+          data_base64: "dGh1bWI="
+        };
+        return {
+          ok: true,
+          json: async () => payload
+        } as Response;
+      }
+
+      if (url === "/api/v1/photos/photo-a") {
+        return {
+          ok: true,
+          json: async () =>
+            buildDetailPayload([
+              {
+                face_id: "face-1",
+                person_id: "person-1",
+                bbox_x: 10,
+                bbox_y: 10,
+                bbox_w: 20,
+                bbox_h: 20,
+                label_source: null,
+                confidence: null,
+                model_version: null,
+                provenance: null,
+                label_recorded_ts: null
+              }
+            ])
+        } as Response;
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+    expect(screen.queryByRole("list", { name: "Detected face regions for photo-a" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "Show face boxes for photo-a" }));
+    expect(await screen.findByRole("list", { name: "Detected face regions for photo-a" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "Show face boxes for photo-a" }));
+    expect(screen.queryByRole("list", { name: "Detected face regions for photo-a" })).not.toBeInTheDocument();
+  });
+
+  it("supports a global face bbox toggle for all grid photos", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      if (url === "/api/v1/search") {
+        const payload = buildPayload(["photo-a"], 1, true);
+        payload.hits.items[0].thumbnail = {
+          mime_type: "image/jpeg",
+          width: 120,
+          height: 80,
+          data_base64: "dGh1bWI="
+        };
+        return {
+          ok: true,
+          json: async () => payload
+        } as Response;
+      }
+
+      if (url === "/api/v1/photos/photo-a") {
+        return {
+          ok: true,
+          json: async () =>
+            buildDetailPayload([
+              {
+                face_id: "face-1",
+                person_id: "person-1",
+                bbox_x: 10,
+                bbox_y: 10,
+                bbox_w: 20,
+                bbox_h: 20,
+                label_source: null,
+                confidence: null,
+                model_version: null,
+                provenance: null,
+                label_recorded_ts: null
+              }
+            ])
+        } as Response;
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+    expect(screen.queryByRole("list", { name: "Detected face regions for photo-a" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "Show face boxes on all photos" }));
+    expect(await screen.findByRole("list", { name: "Detected face regions for photo-a" })).toBeInTheDocument();
+  });
+
+  it("advances to the next cursor-backed page when Next is clicked", async () => {
+    const user = userEvent.setup();
+
+    const pageOneIds = Array.from({ length: 24 }, (_, index) => `photo-${index + 1}`);
+    const pageTwoIds = Array.from({ length: 24 }, (_, index) => `photo-${index + 25}`);
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      if (url === "/api/v1/people") {
+        return {
+          ok: true,
+          json: async () => []
+        } as Response;
+      }
+
+      if (url !== "/api/v1/search") {
+        throw new Error(`Unhandled fetch: ${url}`);
+      }
+
+      const requestBody = JSON.parse((init?.body as string | undefined) ?? "{}") as {
+        page?: { cursor?: string | null };
+      };
+      const requestCursor = requestBody.page?.cursor ?? null;
+
+      if (requestCursor === "cursor-page-2") {
+        return {
+          ok: true,
+          json: async () => ({
+            hits: {
+              total: 99,
+              cursor: "cursor-page-3",
+              items: buildPayload(pageTwoIds, 99).hits.items
+            }
+          })
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          hits: {
+            total: 99,
+            cursor: "cursor-page-2",
+            items: buildPayload(pageOneIds, 99).hits.items
+          }
+        })
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+
+    expect(await screen.findByText("Showing 24 of 99 photos")).toBeInTheDocument();
+    expect(screen.getByText("Page 1")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(await screen.findByText("Page 2")).toBeInTheDocument();
+    const detailLinks = await screen.findAllByRole("link", { name: "View details" });
+    expect(detailLinks.length).toBeGreaterThan(0);
+
+    const searchRequestCursors = fetchMock.mock.calls
+      .filter(([input]) => String(input) === "/api/v1/search")
+      .map(([, init]) => {
+        const parsedBody = JSON.parse((init?.body as string | undefined) ?? "{}") as {
+          page?: { cursor?: string | null };
+        };
+        return parsedBody.page?.cursor ?? null;
+      });
+
+    expect(searchRequestCursors).toContain("cursor-page-2");
+  });
+
   it("shows action bar only when active selection scope count is positive", async () => {
     const user = userEvent.setup();
     fetchMock.mockImplementation(async (input: string) => {
@@ -228,7 +468,7 @@ describe("LibraryRoutePage", () => {
       if (url === "/api/v1/search") {
         return {
           ok: true,
-          json: async () => buildPayload(["photo-a"])
+          json: async () => buildPayload(["photo-a"], 1, true)
         } as Response;
       }
 
@@ -275,7 +515,7 @@ describe("LibraryRoutePage", () => {
     renderLibraryAt("/library");
     expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Show face workflow" }));
+    await user.click(screen.getByRole("button", { name: "Review faces" }));
     await user.selectOptions(await screen.findByLabelText("Assign face 1"), "person-1");
 
     expect(await screen.findByText("All visible faces assigned.")).toBeInTheDocument();
@@ -287,6 +527,69 @@ describe("LibraryRoutePage", () => {
       },
       body: JSON.stringify({ person_id: "person-1" })
     });
+  });
+
+  it("renders quick-panel overlays when bbox coordinates are larger than thumbnail dimensions", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      if (url === "/api/v1/search") {
+        return {
+          ok: true,
+          json: async () => buildPayload(["photo-a"], 1, true)
+        } as Response;
+      }
+
+      if (url === "/api/v1/people") {
+        return {
+          ok: true,
+          json: async () => [{ person_id: "person-1", display_name: "Inez" }]
+        } as Response;
+      }
+
+      if (url === "/api/v1/photos/photo-a") {
+        return {
+          ok: true,
+          json: async () =>
+            buildDetailPayload([
+              {
+                face_id: "face-1",
+                person_id: "person-1",
+                bbox_x: 320,
+                bbox_y: 160,
+                bbox_w: 120,
+                bbox_h: 140,
+                label_source: null,
+                confidence: null,
+                model_version: null,
+                provenance: null,
+                label_recorded_ts: null
+              }
+            ])
+        } as Response;
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Review faces" }));
+
+    expect(await screen.findByText("1 face region rendered.")).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Detected face regions" })).toBeInTheDocument();
+    expect(
+      screen.queryByText("Face regions are present but could not be rendered on this preview.")
+    ).not.toBeInTheDocument();
   });
 
   it("supports in-context correction and machine-label confirmation from the library quick panel", async () => {
@@ -304,7 +607,7 @@ describe("LibraryRoutePage", () => {
       if (url === "/api/v1/search") {
         return {
           ok: true,
-          json: async () => buildPayload(["photo-a"])
+          json: async () => buildPayload(["photo-a"], 1, true)
         } as Response;
       }
 
@@ -371,7 +674,7 @@ describe("LibraryRoutePage", () => {
     renderLibraryAt("/library");
     expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Show face workflow" }));
+    await user.click(screen.getByRole("button", { name: "Review faces" }));
 
     await user.click(await screen.findByRole("button", { name: "Confirm label" }));
     expect(await screen.findByText("Confirmed face 1 for Inez.")).toBeInTheDocument();
@@ -387,5 +690,25 @@ describe("LibraryRoutePage", () => {
     await user.selectOptions(screen.getByLabelText("Correct face 1"), "person-2");
     await user.click(screen.getByRole("button", { name: "Confirm reassignment" }));
     expect(await screen.findByText("Correction recorded: Inez -> Mateo.")).toBeInTheDocument();
+  });
+
+  it("shows the Review faces action only when faces are detected", async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Review faces" })).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/pages/LibraryRoutePage.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.tsx
@@ -47,7 +47,23 @@ export function LibraryRoutePage() {
   const requestedPage = parsePositiveIntParam(location.search, "page");
   const suppressNextUrlStateSyncRef = useRef(false);
   const applyingParsedUrlStateRef = useRef(false);
+  const lastAppliedParsedUrlStateSignatureRef = useRef<string | null>(null);
   const parsedUrlState = useMemo(() => parseLibraryUrlState(location.search), [location.search]);
+  const parsedUrlStateSignature = useMemo(
+    () =>
+      JSON.stringify({
+        queryChips: parsedUrlState.queryChips,
+        fromDate: parsedUrlState.fromDate,
+        toDate: parsedUrlState.toDate,
+        selectedPersonNames: parsedUrlState.selectedPersonNames,
+        latitudeDraft: parsedUrlState.latitudeDraft,
+        longitudeDraft: parsedUrlState.longitudeDraft,
+        radiusDraft: parsedUrlState.radiusDraft,
+        hasFacesFilter: parsedUrlState.hasFacesFilter,
+        pathHintFilters: parsedUrlState.pathHintFilters
+      }),
+    [parsedUrlState]
+  );
 
   const headingRef = useRef<HTMLHeadingElement | null>(null);
 
@@ -74,6 +90,7 @@ export function LibraryRoutePage() {
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const [cursorByPage, setCursorByPage] = useState<Record<number, string | null>>({ 1: null });
   const [photos, setPhotos] = useState<LibraryPhoto[]>([]);
+  const [showGridFaceBoxes, setShowGridFaceBoxes] = useState(false);
   const [totalCount, setTotalCount] = useState(0);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
@@ -182,10 +199,15 @@ export function LibraryRoutePage() {
   useEffect(() => {
     if (suppressNextUrlStateSyncRef.current) {
       suppressNextUrlStateSyncRef.current = false;
+      lastAppliedParsedUrlStateSignatureRef.current = parsedUrlStateSignature;
+      return;
+    }
+    if (lastAppliedParsedUrlStateSignatureRef.current === parsedUrlStateSignature) {
       return;
     }
 
     applyingParsedUrlStateRef.current = true;
+    lastAppliedParsedUrlStateSignatureRef.current = parsedUrlStateSignature;
     const parsedQuery = parsedUrlState.queryChips.join(" ");
     setQueryInput(parsedQuery);
     setCommittedQuery(parsedQuery);
@@ -212,7 +234,7 @@ export function LibraryRoutePage() {
     setNextCursor(null);
     setPhotos([]);
     setTotalCount(0);
-  }, [parsedUrlState]);
+  }, [parsedUrlState, parsedUrlStateSignature]);
 
   useEffect(() => {
     if (applyingParsedUrlStateRef.current) {
@@ -653,6 +675,15 @@ export function LibraryRoutePage() {
       />
 
       <p className="browse-summary" aria-live="polite">{summaryLabel}</p>
+      <label className="browse-global-face-box-toggle">
+        <input
+          type="checkbox"
+          aria-label="Show face boxes on all photos"
+          checked={showGridFaceBoxes}
+          onChange={(event) => setShowGridFaceBoxes(event.currentTarget.checked)}
+        />
+        Show face boxes on all photos
+      </label>
 
       <LibrarySelectionPanel
         selectionState={selectionState}
@@ -701,6 +732,7 @@ export function LibraryRoutePage() {
         {!error && !isLoading && photos.length > 0 ? (
           <LibraryPhotoGrid
             photos={photos}
+            showAllFaceBoxes={showGridFaceBoxes}
             selectedPhotoIds={selectionState.selectedPhotoIds}
             locationSearch={location.search}
             selectionRouteState={selectionRouteState}

--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -228,6 +228,45 @@ describe("PhotoDetailRoutePage", () => {
     expect(screen.queryByRole("list", { name: "Detected face regions" })).not.toBeInTheDocument();
   });
 
+  it("renders face overlays when bbox coordinates use a larger source-image space", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () =>
+        buildPayload({
+          faces: [
+            {
+              face_id: "face-1",
+              person_id: "person-1",
+              bbox_x: 320,
+              bbox_y: 160,
+              bbox_w: 120,
+              bbox_h: 140,
+              label_source: null,
+              confidence: null,
+              model_version: null,
+              provenance: null,
+              label_recorded_ts: null
+            }
+          ],
+          thumbnail: {
+            mime_type: "image/jpeg",
+            width: 100,
+            height: 100,
+            data_base64: "dGh1bWI="
+          }
+        })
+    } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByText("1 face region rendered.")).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Detected face regions" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Face region 1 for person-1")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Face regions are present but could not be rendered on this preview.")
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps face overlays coherent when switching image presentation mode", async () => {
     const user = userEvent.setup();
 
@@ -241,8 +280,38 @@ describe("PhotoDetailRoutePage", () => {
     expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
     expect(await screen.findByLabelText("Face region 1 for person-1")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Actual pixels" }));
+    await user.click(screen.getByRole("button", { name: "Fit to panel" }));
 
+    expect(await screen.findByLabelText("Face region 1 for person-1")).toBeInTheDocument();
+  });
+
+  it("defaults preview mode to actual pixels", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => buildPayload()
+    } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Actual pixels" })).toHaveClass("is-active");
+    expect(screen.getByRole("button", { name: "Fit to panel" })).not.toHaveClass("is-active");
+  });
+
+  it("allows toggling face bbox overlays in the preview", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => buildPayload()
+    } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByLabelText("Face region 1 for person-1")).toBeInTheDocument();
+    await user.click(screen.getByRole("checkbox", { name: "Show face boxes" }));
+    expect(screen.queryByRole("list", { name: "Detected face regions" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "Show face boxes" }));
     expect(await screen.findByLabelText("Face region 1 for person-1")).toBeInTheDocument();
   });
 

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -73,6 +73,13 @@ type FaceOverlayRegion = {
   heightPercent: number;
 };
 
+type FaceBBox = {
+  bbox_x: number | null;
+  bbox_y: number | null;
+  bbox_w: number | null;
+  bbox_h: number | null;
+};
+
 type PersonRecord = {
   person_id: string;
   display_name: string;
@@ -135,6 +142,38 @@ function formatOptionalText(value: string | null): string {
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+function inferFaceOverlayCoordinateSpace(
+  faces: FaceBBox[],
+  thumbnailWidth: number,
+  thumbnailHeight: number
+): { width: number; height: number } {
+  // Face coordinates are stored in source-image pixels; use detected extents when thumbnail space is smaller.
+  const coordinateSpace = faces.reduce(
+    (acc, face) => {
+      if (
+        face.bbox_x === null ||
+        face.bbox_y === null ||
+        face.bbox_w === null ||
+        face.bbox_h === null ||
+        face.bbox_w <= 0 ||
+        face.bbox_h <= 0
+      ) {
+        return acc;
+      }
+
+      acc.width = Math.max(acc.width, face.bbox_x + face.bbox_w);
+      acc.height = Math.max(acc.height, face.bbox_y + face.bbox_h);
+      return acc;
+    },
+    { width: thumbnailWidth, height: thumbnailHeight }
+  );
+
+  return {
+    width: Math.max(coordinateSpace.width, thumbnailWidth),
+    height: Math.max(coordinateSpace.height, thumbnailHeight)
+  };
 }
 
 async function fetchPhotoDetail(photoId: string): Promise<PhotoDetailPayload> {
@@ -213,7 +252,8 @@ export function PhotoDetailRoutePage() {
   const [error, setError] = useState<string | null>(null);
   const [isNotFound, setIsNotFound] = useState(false);
   const [reloadToken, setReloadToken] = useState(0);
-  const [mediaMode, setMediaMode] = useState<MediaPresentationMode>("fit");
+  const [mediaMode, setMediaMode] = useState<MediaPresentationMode>("actual");
+  const [showFaceBoxes, setShowFaceBoxes] = useState(true);
   const [peopleDirectory, setPeopleDirectory] = useState<PersonRecord[]>([]);
   const [requestedExpandedProvenanceFaceId, setRequestedExpandedProvenanceFaceId] = useState<
     string | null
@@ -306,6 +346,7 @@ export function PhotoDetailRoutePage() {
 
     const thumbnailWidth = detail.thumbnail.width;
     const thumbnailHeight = detail.thumbnail.height;
+    const coordinateSpace = inferFaceOverlayCoordinateSpace(detail.faces, thumbnailWidth, thumbnailHeight);
 
     return detail.faces
       .map((face) => {
@@ -320,10 +361,10 @@ export function PhotoDetailRoutePage() {
           return null;
         }
 
-        const left = clamp((face.bbox_x / thumbnailWidth) * 100, 0, 100);
-        const top = clamp((face.bbox_y / thumbnailHeight) * 100, 0, 100);
-        const right = clamp(((face.bbox_x + face.bbox_w) / thumbnailWidth) * 100, 0, 100);
-        const bottom = clamp(((face.bbox_y + face.bbox_h) / thumbnailHeight) * 100, 0, 100);
+        const left = clamp((face.bbox_x / coordinateSpace.width) * 100, 0, 100);
+        const top = clamp((face.bbox_y / coordinateSpace.height) * 100, 0, 100);
+        const right = clamp(((face.bbox_x + face.bbox_w) / coordinateSpace.width) * 100, 0, 100);
+        const bottom = clamp(((face.bbox_y + face.bbox_h) / coordinateSpace.height) * 100, 0, 100);
         const width = right - left;
         const height = bottom - top;
 
@@ -353,12 +394,16 @@ export function PhotoDetailRoutePage() {
       return "No face regions detected for this photo.";
     }
 
+    if (!showFaceBoxes) {
+      return "Face boxes are hidden for this preview.";
+    }
+
     if (faceOverlayRegions.length === 0) {
       return "Face regions are present but could not be rendered on this preview.";
     }
 
     return `${faceOverlayRegions.length} face region${faceOverlayRegions.length === 1 ? "" : "s"} rendered.`;
-  }, [detail, faceOverlayRegions.length]);
+  }, [detail, faceOverlayRegions.length, showFaceBoxes]);
 
   const ingestStatus = useMemo(() => {
     if (!detail) {
@@ -461,6 +506,15 @@ export function PhotoDetailRoutePage() {
                   >
                     Actual pixels
                   </button>
+                  <label className="detail-face-box-toggle">
+                    <input
+                      type="checkbox"
+                      aria-label="Show face boxes"
+                      checked={showFaceBoxes}
+                      onChange={(event) => setShowFaceBoxes(event.currentTarget.checked)}
+                    />
+                    Show face boxes
+                  </label>
                 </div>
                 <div className="detail-media-frame" data-mode={mediaMode}>
                   <div className="detail-media-stage">
@@ -471,7 +525,7 @@ export function PhotoDetailRoutePage() {
                       height={detail.thumbnail.height}
                       alt={`Preview for ${detail.photo_id}`}
                     />
-                    {faceOverlayRegions.length > 0 ? (
+                    {showFaceBoxes && faceOverlayRegions.length > 0 ? (
                       <ol className="detail-face-overlay-list" aria-label="Detected face regions">
                         {faceOverlayRegions.map((region, index) => (
                           <li

--- a/apps/ui/src/pages/library/LibraryPhotoFacePanel.tsx
+++ b/apps/ui/src/pages/library/LibraryPhotoFacePanel.tsx
@@ -33,8 +33,47 @@ type FaceOverlayRegion = {
   heightPercent: number;
 };
 
+type FaceBBox = {
+  bbox_x: number | null;
+  bbox_y: number | null;
+  bbox_w: number | null;
+  bbox_h: number | null;
+};
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
+}
+
+function inferFaceOverlayCoordinateSpace(
+  faces: FaceBBox[],
+  thumbnailWidth: number,
+  thumbnailHeight: number
+): { width: number; height: number } {
+  // Face coordinates are stored in source-image pixels; use detected extents when thumbnail space is smaller.
+  const coordinateSpace = faces.reduce(
+    (acc, face) => {
+      if (
+        face.bbox_x === null ||
+        face.bbox_y === null ||
+        face.bbox_w === null ||
+        face.bbox_h === null ||
+        face.bbox_w <= 0 ||
+        face.bbox_h <= 0
+      ) {
+        return acc;
+      }
+
+      acc.width = Math.max(acc.width, face.bbox_x + face.bbox_w);
+      acc.height = Math.max(acc.height, face.bbox_y + face.bbox_h);
+      return acc;
+    },
+    { width: thumbnailWidth, height: thumbnailHeight }
+  );
+
+  return {
+    width: Math.max(coordinateSpace.width, thumbnailWidth),
+    height: Math.max(coordinateSpace.height, thumbnailHeight)
+  };
 }
 
 function provenanceBadgeIcon(source: FaceLabelSource): string {
@@ -114,6 +153,7 @@ function buildOverlayRegions(payload: PhotoDetailPayload | null): FaceOverlayReg
 
   const thumbnailWidth = payload.thumbnail.width;
   const thumbnailHeight = payload.thumbnail.height;
+  const coordinateSpace = inferFaceOverlayCoordinateSpace(payload.faces, thumbnailWidth, thumbnailHeight);
 
   return payload.faces
     .map((face) => {
@@ -128,10 +168,10 @@ function buildOverlayRegions(payload: PhotoDetailPayload | null): FaceOverlayReg
         return null;
       }
 
-      const left = clamp((face.bbox_x / thumbnailWidth) * 100, 0, 100);
-      const top = clamp((face.bbox_y / thumbnailHeight) * 100, 0, 100);
-      const right = clamp(((face.bbox_x + face.bbox_w) / thumbnailWidth) * 100, 0, 100);
-      const bottom = clamp(((face.bbox_y + face.bbox_h) / thumbnailHeight) * 100, 0, 100);
+      const left = clamp((face.bbox_x / coordinateSpace.width) * 100, 0, 100);
+      const top = clamp((face.bbox_y / coordinateSpace.height) * 100, 0, 100);
+      const right = clamp(((face.bbox_x + face.bbox_w) / coordinateSpace.width) * 100, 0, 100);
+      const bottom = clamp(((face.bbox_y + face.bbox_h) / coordinateSpace.height) * 100, 0, 100);
       const width = right - left;
       const height = bottom - top;
 
@@ -173,6 +213,7 @@ interface LibraryPhotoFacePanelProps {
 }
 
 export function LibraryPhotoFacePanel({ photo }: LibraryPhotoFacePanelProps) {
+  const hasDetectedFaces = (photo.faces?.length ?? 0) > 0;
   const panelId = `library-face-panel-${photo.photo_id}`;
   const [isExpanded, setIsExpanded] = useState(false);
   const [detail, setDetail] = useState<PhotoDetailPayload | null>(null);
@@ -288,6 +329,10 @@ export function LibraryPhotoFacePanel({ photo }: LibraryPhotoFacePanelProps) {
     }
   }
 
+  if (!hasDetectedFaces) {
+    return null;
+  }
+
   return (
     <section className="library-face-panel">
       <button
@@ -303,7 +348,7 @@ export function LibraryPhotoFacePanel({ photo }: LibraryPhotoFacePanelProps) {
           }
         }}
       >
-        {isExpanded ? "Hide face workflow" : "Show face workflow"}
+        {isExpanded ? "Hide face review" : "Review faces"}
       </button>
 
       {isExpanded ? (

--- a/apps/ui/src/pages/library/LibraryPhotoGrid.tsx
+++ b/apps/ui/src/pages/library/LibraryPhotoGrid.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { deriveIngestStatus, INGEST_STATUS_LEGEND } from "../../app/ingestStatus";
 import { LibraryPhotoFacePanel } from "./LibraryPhotoFacePanel";
@@ -11,23 +12,185 @@ import type { serializeLibrarySelectionState } from "./librarySelection";
 
 interface LibraryPhotoGridProps {
   photos: LibraryPhoto[];
+  showAllFaceBoxes: boolean;
   selectedPhotoIds: Set<string>;
   locationSearch: string;
   selectionRouteState: ReturnType<typeof serializeLibrarySelectionState>;
   onToggleSelection: (photoId: string) => void;
 }
 
+type FaceLabelSource = "human_confirmed" | "machine_applied" | "machine_suggested" | null;
+
+type FaceBBox = {
+  face_id: string;
+  person_id: string | null;
+  bbox_x: number | null;
+  bbox_y: number | null;
+  bbox_w: number | null;
+  bbox_h: number | null;
+  label_source?: FaceLabelSource;
+};
+
+type PhotoFaceDetailPayload = {
+  photo_id: string;
+  faces: FaceBBox[];
+};
+
+type FaceOverlayRegion = {
+  faceId: string;
+  personId: string | null;
+  leftPercent: number;
+  topPercent: number;
+  widthPercent: number;
+  heightPercent: number;
+};
+
 const INGEST_STATUS_LEGEND_TOOLTIP = INGEST_STATUS_LEGEND
   .map((entry) => `${entry.label}: ${entry.description}`)
   .join("\n");
 
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function inferFaceOverlayCoordinateSpace(
+  faces: FaceBBox[],
+  thumbnailWidth: number,
+  thumbnailHeight: number
+): { width: number; height: number } {
+  const coordinateSpace = faces.reduce(
+    (acc, face) => {
+      if (
+        face.bbox_x === null ||
+        face.bbox_y === null ||
+        face.bbox_w === null ||
+        face.bbox_h === null ||
+        face.bbox_w <= 0 ||
+        face.bbox_h <= 0
+      ) {
+        return acc;
+      }
+
+      acc.width = Math.max(acc.width, face.bbox_x + face.bbox_w);
+      acc.height = Math.max(acc.height, face.bbox_y + face.bbox_h);
+      return acc;
+    },
+    { width: thumbnailWidth, height: thumbnailHeight }
+  );
+
+  return {
+    width: Math.max(coordinateSpace.width, thumbnailWidth),
+    height: Math.max(coordinateSpace.height, thumbnailHeight)
+  };
+}
+
+function buildOverlayRegions(
+  faces: FaceBBox[],
+  thumbnailWidth: number,
+  thumbnailHeight: number
+): FaceOverlayRegion[] {
+  if (thumbnailWidth <= 0 || thumbnailHeight <= 0) {
+    return [];
+  }
+
+  const coordinateSpace = inferFaceOverlayCoordinateSpace(faces, thumbnailWidth, thumbnailHeight);
+
+  return faces
+    .map((face) => {
+      if (
+        face.bbox_x === null ||
+        face.bbox_y === null ||
+        face.bbox_w === null ||
+        face.bbox_h === null ||
+        face.bbox_w <= 0 ||
+        face.bbox_h <= 0
+      ) {
+        return null;
+      }
+
+      const left = clamp((face.bbox_x / coordinateSpace.width) * 100, 0, 100);
+      const top = clamp((face.bbox_y / coordinateSpace.height) * 100, 0, 100);
+      const right = clamp(((face.bbox_x + face.bbox_w) / coordinateSpace.width) * 100, 0, 100);
+      const bottom = clamp(((face.bbox_y + face.bbox_h) / coordinateSpace.height) * 100, 0, 100);
+      const width = right - left;
+      const height = bottom - top;
+
+      if (width <= 0 || height <= 0) {
+        return null;
+      }
+
+      return {
+        faceId: face.face_id,
+        personId: face.person_id,
+        leftPercent: left,
+        topPercent: top,
+        widthPercent: width,
+        heightPercent: height
+      };
+    })
+    .filter((region): region is FaceOverlayRegion => region !== null);
+}
+
 export function LibraryPhotoGrid({
   photos,
+  showAllFaceBoxes,
   selectedPhotoIds,
   locationSearch,
   selectionRouteState,
   onToggleSelection
 }: LibraryPhotoGridProps) {
+  const [photoFaceBoxVisibility, setPhotoFaceBoxVisibility] = useState<Record<string, boolean>>({});
+  const [photoFaceDetails, setPhotoFaceDetails] = useState<Record<string, PhotoFaceDetailPayload | null>>({});
+  const [photoFaceDetailStatus, setPhotoFaceDetailStatus] = useState<
+    Record<string, "loading" | "loaded" | "failed">
+  >({});
+
+  const activeFaceOverlayPhotoIds = useMemo(
+    () =>
+      photos
+        .filter((photo) => {
+          const hasDetectedFaces = (photo.faces?.length ?? 0) > 0;
+          const hasThumbnail = Boolean(photo.thumbnail);
+          const isRequested = showAllFaceBoxes || Boolean(photoFaceBoxVisibility[photo.photo_id]);
+          return hasDetectedFaces && hasThumbnail && isRequested;
+        })
+        .map((photo) => photo.photo_id),
+    [photos, photoFaceBoxVisibility, showAllFaceBoxes]
+  );
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    activeFaceOverlayPhotoIds.forEach((photoId) => {
+      if (photoFaceDetailStatus[photoId]) {
+        return;
+      }
+
+      setPhotoFaceDetailStatus((current) => ({ ...current, [photoId]: "loading" }));
+
+      fetch(`/api/v1/photos/${photoId}`, { signal: controller.signal })
+        .then(async (response) => {
+          if (!response.ok) {
+            throw new Error(`Photo detail request failed (${response.status})`);
+          }
+          const payload = (await response.json()) as PhotoFaceDetailPayload;
+          setPhotoFaceDetails((current) => ({ ...current, [photoId]: payload }));
+          setPhotoFaceDetailStatus((current) => ({ ...current, [photoId]: "loaded" }));
+        })
+        .catch(() => {
+          if (controller.signal.aborted) {
+            return;
+          }
+          setPhotoFaceDetails((current) => ({ ...current, [photoId]: null }));
+          setPhotoFaceDetailStatus((current) => ({ ...current, [photoId]: "failed" }));
+        });
+    });
+
+    return () => {
+      controller.abort();
+    };
+  }, [activeFaceOverlayPhotoIds, photoFaceDetailStatus]);
+
   return (
     <ol className="browse-grid" aria-label="Photo gallery">
       {photos.map((photo) => {
@@ -37,6 +200,18 @@ export function LibraryPhotoGrid({
           lastFailureReason: photo.original?.last_failure_reason ?? null,
           hasThumbnail: Boolean(photo.thumbnail)
         });
+        const hasDetectedFaces = (photo.faces?.length ?? 0) > 0;
+        const showFaceBoxesForPhoto =
+          hasDetectedFaces && (showAllFaceBoxes || Boolean(photoFaceBoxVisibility[photo.photo_id]));
+        const detailPayload = photoFaceDetails[photo.photo_id] ?? null;
+        const overlayRegions =
+          showFaceBoxesForPhoto && photo.thumbnail && detailPayload
+            ? buildOverlayRegions(
+                detailPayload.faces,
+                photo.thumbnail.width,
+                photo.thumbnail.height
+              )
+            : [];
 
         return (
           <li key={photo.photo_id} className="browse-card">
@@ -57,14 +232,62 @@ export function LibraryPhotoGrid({
               />
               Select photo
             </label>
-            {photo.thumbnail ? (
-              <img
-                className="browse-thumbnail"
-                src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
-                width={photo.thumbnail.width}
-                height={photo.thumbnail.height}
-                alt={`Thumbnail for ${photo.photo_id}`}
+            <label className="browse-card-face-box-toggle">
+              <input
+                type="checkbox"
+                aria-label={`Show face boxes for ${photo.photo_id}`}
+                checked={showFaceBoxesForPhoto}
+                disabled={!hasDetectedFaces || showAllFaceBoxes}
+                onChange={(event) => {
+                  const nextChecked = event.currentTarget.checked;
+                  setPhotoFaceBoxVisibility((current) => ({
+                    ...current,
+                    [photo.photo_id]: nextChecked
+                  }));
+                }}
               />
+              Show face boxes
+            </label>
+            {photo.thumbnail ? (
+              <Link
+                className="browse-thumbnail-link"
+                data-photo-id={photo.photo_id}
+                to={`/library/${photo.photo_id}`}
+                state={{
+                  returnToLibrarySearch: locationSearch,
+                  returnFocusPhotoId: photo.photo_id,
+                  librarySelection: selectionRouteState
+                }}
+                aria-label={`View details for ${photo.path}`}
+              >
+                <img
+                  className="browse-thumbnail"
+                  src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
+                  width={photo.thumbnail.width}
+                  height={photo.thumbnail.height}
+                  alt={`Preview of ${photo.path}`}
+                />
+                {overlayRegions.length > 0 ? (
+                  <ol
+                    className="detail-face-overlay-list"
+                    aria-label={`Detected face regions for ${photo.photo_id}`}
+                  >
+                    {overlayRegions.map((region, index) => (
+                      <li
+                        key={region.faceId}
+                        className="detail-face-overlay"
+                        aria-label={`Face region ${index + 1}${region.personId ? ` for ${region.personId}` : ""}`}
+                        style={{
+                          left: `${region.leftPercent}%`,
+                          top: `${region.topPercent}%`,
+                          width: `${region.widthPercent}%`,
+                          height: `${region.heightPercent}%`
+                        }}
+                      />
+                    ))}
+                  </ol>
+                ) : null}
+              </Link>
             ) : (
               <div className="browse-thumbnail browse-thumbnail-placeholder" aria-hidden="true">
                 No preview
@@ -83,7 +306,7 @@ export function LibraryPhotoGrid({
                       librarySelection: selectionRouteState
                     }}
                   >
-                    {photo.photo_id}
+                    View details
                   </Link>
                 }
                 path={photo.path}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -252,6 +252,14 @@ body {
   color: #475569;
 }
 
+.browse-global-face-box-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #1e293b;
+  font-size: 0.85rem;
+}
+
 .browse-selection-panel {
   border: 1px solid #cbd5e1;
   border-radius: 0.65rem;
@@ -425,6 +433,20 @@ body {
   padding: 0 0.75rem 0.55rem;
   font-size: 0.82rem;
   color: #1e293b;
+}
+
+.browse-card-face-box-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0 0.75rem 0.55rem;
+  font-size: 0.8rem;
+  color: #334155;
+}
+
+.browse-thumbnail-link {
+  position: relative;
+  display: block;
 }
 
 .browse-thumbnail {
@@ -662,6 +684,7 @@ body {
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
+  align-items: center;
 }
 
 .detail-media-controls button {
@@ -683,6 +706,10 @@ body {
   border-radius: 0.55rem;
   background: #f8fafc;
   padding: 0.5rem;
+  resize: both;
+  overflow: auto;
+  min-width: 14rem;
+  min-height: 10rem;
 }
 
 .detail-media-frame[data-mode="actual"] {
@@ -752,6 +779,14 @@ body {
   margin: 0;
   font-size: 0.82rem;
   color: #334155;
+}
+
+.detail-face-box-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #334155;
+  font-size: 0.8rem;
 }
 
 .detail-face-assignment {

--- a/apps/ui/tests/e2e/journeys/library-unification-journeys.spec.ts
+++ b/apps/ui/tests/e2e/journeys/library-unification-journeys.spec.ts
@@ -80,7 +80,7 @@ test("JRN-P4-library-shared-request-lifecycle @journey", async ({ page }) => {
 
   initialRequestsReleased = true;
   releaseGateResolver?.();
-  await expect(page.getByRole("heading", { name: "browse-photo-1", level: 2 })).toBeVisible();
+  await expect(page.getByRole("link", { name: "View details" })).toBeVisible();
   await expect(page.getByText("/library/browse-photo-1.jpg")).toBeVisible();
 
   failNextBrowseRequest = true;
@@ -88,7 +88,7 @@ test("JRN-P4-library-shared-request-lifecycle @journey", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Could not load Library", level: 2 })).toBeVisible();
 
   await page.getByRole("button", { name: "Retry" }).click();
-  await expect(page.getByRole("heading", { name: "browse-photo-1", level: 2 })).toBeVisible();
+  await expect(page.getByRole("link", { name: "View details" })).toBeVisible();
 });
 
 test("JRN-P4-library-invalid-page-reset @journey", async ({ page }) => {
@@ -169,7 +169,7 @@ test("JRN-P4-library-filtered-shared-request-lifecycle @journey", async ({ page 
   await expect(page.getByRole("status")).toContainText("Loading library workflow.");
 
   releaseFirstSearchResponse?.();
-  await expect(page.getByRole("heading", { name: "search-photo-1", level: 2 })).toBeVisible();
+  await expect(page.getByRole("link", { name: "View details" })).toBeVisible();
   await expect(page.getByText("/library/search-photo-1.jpg")).toBeVisible();
 
   await page.getByRole("textbox", { name: "Search query" }).fill("coast");
@@ -177,5 +177,5 @@ test("JRN-P4-library-filtered-shared-request-lifecycle @journey", async ({ page 
   await expect(page.getByRole("heading", { name: "Could not load Library", level: 2 })).toBeVisible();
 
   await page.getByRole("button", { name: "Retry" }).click();
-  await expect(page.getByRole("heading", { name: "search-photo-1", level: 2 })).toBeVisible();
+  await expect(page.getByRole("link", { name: "View details" })).toBeVisible();
 });

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -1,27 +1,41 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { configDefaults } from "vitest/config";
 
-export default defineConfig({
-  plugins: [react()],
-  test: {
-    environment: "jsdom",
-    globals: true,
-    setupFiles: "./src/testing/setupTests.ts",
-    exclude: [...configDefaults.exclude, "tests/e2e/**"],
-    coverage: {
-      provider: "v8",
-      include: ["src/**/*.{ts,tsx}"],
-      exclude: [
-        "src/main.tsx",
-        "src/pages/BrowseRoutePage.tsx",
-        "src/pages/browseFocusState.ts",
-        "src/testing/**"
-      ],
-      thresholds: {
-        statements: 80,
-        lines: 80
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const apiProxyTarget =
+    env.VITE_API_PROXY_TARGET || env.VITE_API_BASE_URL || "http://127.0.0.1:8000";
+
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        "/api": {
+          target: apiProxyTarget,
+          changeOrigin: true
+        }
+      }
+    },
+    test: {
+      environment: "jsdom",
+      globals: true,
+      setupFiles: "./src/testing/setupTests.ts",
+      exclude: [...configDefaults.exclude, "tests/e2e/**"],
+      coverage: {
+        provider: "v8",
+        include: ["src/**/*.{ts,tsx}"],
+        exclude: [
+          "src/main.tsx",
+          "src/pages/BrowseRoutePage.tsx",
+          "src/pages/browseFocusState.ts",
+          "src/testing/**"
+        ],
+        thresholds: {
+          statements: 80,
+          lines: 80
+        }
       }
     }
-  }
+  };
 });

--- a/compose.yaml
+++ b/compose.yaml
@@ -34,6 +34,15 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz').read()\"",
+        ]
+      interval: 3s
+      timeout: 5s
+      retries: 20
     ports:
       - "${PHOTO_ORG_API_HOST_PORT:-8000}:8000"
 
@@ -43,9 +52,10 @@ services:
       dockerfile: apps/ui/Dockerfile
     environment:
       VITE_API_BASE_URL: ${PHOTO_ORG_UI_API_BASE_URL:-http://127.0.0.1:8000}
+      VITE_API_PROXY_TARGET: ${PHOTO_ORG_UI_PROXY_TARGET:-http://db-service:8000}
     depends_on:
       db-service:
-        condition: service_started
+        condition: service_healthy
     ports:
       - "${PHOTO_ORG_UI_HOST_PORT:-5173}:5173"
 


### PR DESCRIPTION
## Summary
- default photo detail preview to actual pixels and make preview frame resizable
- add face bbox visibility toggle in photo detail preview
- add per-photo face bbox toggle in library grid with lazy bbox fetch from photo detail API
- add global library-grid toggle to show face bboxes on all visible photos
- include additional in-progress repo changes requested for commit

## Testing
- npm --prefix apps/ui test -- src/pages/PhotoDetailRoutePage.test.tsx src/pages/LibraryRoutePage.test.tsx