### PR TITLE
[codex] Rework photo detail layout and face assignment flow

### DIFF
--- a/apps/api/app/processing/faces.py
+++ b/apps/api/app/processing/faces.py
@@ -45,13 +45,14 @@ class OpenCvFaceDetector:
 
     def detect(self, path: Path) -> list[dict]:
         import numpy as np  # type: ignore
-        from PIL import Image  # type: ignore
+        from PIL import Image, ImageOps  # type: ignore
         from pillow_heif import register_heif_opener  # type: ignore
 
         register_heif_opener()
 
         with Image.open(path) as image:
-            rgb_image = image.convert("RGB")
+            prepared = ImageOps.exif_transpose(image)
+            rgb_image = prepared.convert("RGB")
             width, height = rgb_image.size
             grayscale = self._cv2.cvtColor(np.array(rgb_image), self._cv2.COLOR_RGB2GRAY)
             boxes = self._classifier.detectMultiScale(
@@ -80,6 +81,8 @@ class OpenCvFaceDetector:
                             "scale_factor": self._scale_factor,
                             "min_neighbors": self._min_neighbors,
                             "min_size": list(self._min_size),
+                            "bbox_space_width": width,
+                            "bbox_space_height": height,
                         },
                     ).as_row()
                 )

--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -21,6 +21,35 @@ from app.domain.facets import (
 from app.core.pagination import iso_utc
 
 
+def _coerce_positive_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float) and value.is_integer():
+        parsed = int(value)
+        return parsed if parsed > 0 else None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            parsed = int(text)
+        except ValueError:
+            return None
+        return parsed if parsed > 0 else None
+    return None
+
+
+def _extract_bbox_space_dimensions(face_provenance: object) -> tuple[int | None, int | None]:
+    if not isinstance(face_provenance, dict):
+        return (None, None)
+
+    width = _coerce_positive_int(face_provenance.get("bbox_space_width"))
+    height = _coerce_positive_int(face_provenance.get("bbox_space_height"))
+    return (width, height)
+
+
 class PhotosRepository:
     def __init__(self, db: Session):
         self.db = db
@@ -412,6 +441,7 @@ class PhotosRepository:
                     self.faces.c.bbox_y,
                     self.faces.c.bbox_w,
                     self.faces.c.bbox_h,
+                    self.faces.c.provenance,
                 ]
             )
 
@@ -480,6 +510,7 @@ class PhotosRepository:
                 ppl_map[r.photo_id].append(r.person_id)
             face_item = {"person_id": r.person_id}
             if include_face_regions:
+                bbox_space_width, bbox_space_height = _extract_bbox_space_dimensions(r.provenance)
                 provenance = (
                     provenance_map.get((str(r.face_id), str(r.person_id)))
                     if r.person_id is not None
@@ -492,6 +523,8 @@ class PhotosRepository:
                         "bbox_y": r.bbox_y,
                         "bbox_w": r.bbox_w,
                         "bbox_h": r.bbox_h,
+                        "bbox_space_width": bbox_space_width,
+                        "bbox_space_height": bbox_space_height,
                         "label_source": provenance["label_source"] if provenance else None,
                         "confidence": provenance["confidence"] if provenance else None,
                         "model_version": provenance["model_version"] if provenance else None,

--- a/apps/api/app/schemas/photo_response.py
+++ b/apps/api/app/schemas/photo_response.py
@@ -20,6 +20,14 @@ class PhotoDetailFace(BaseModel):
     bbox_y: int | None = Field(default=None, description="Bounding-box y coordinate.")
     bbox_w: int | None = Field(default=None, description="Bounding-box width in pixels.")
     bbox_h: int | None = Field(default=None, description="Bounding-box height in pixels.")
+    bbox_space_width: int | None = Field(
+        default=None,
+        description="Width of the image coordinate space used to produce bounding-box coordinates.",
+    )
+    bbox_space_height: int | None = Field(
+        default=None,
+        description="Height of the image coordinate space used to produce bounding-box coordinates.",
+    )
     label_source: str | None = Field(
         default=None,
         description="Latest face-label source for the current assigned person, if available.",

--- a/apps/api/tests/test_face_assignment_api.py
+++ b/apps/api/tests/test_face_assignment_api.py
@@ -1074,6 +1074,8 @@ def test_photo_detail_api_includes_face_id_for_assignment_workflow(tmp_path, mon
             "bbox_y": 20,
             "bbox_w": 30,
             "bbox_h": 40,
+            "bbox_space_width": None,
+            "bbox_space_height": None,
             "label_source": None,
             "confidence": None,
             "model_version": None,

--- a/apps/api/tests/test_photo_detail_api.py
+++ b/apps/api/tests/test_photo_detail_api.py
@@ -75,6 +75,8 @@ def test_photo_detail_api_returns_projected_metadata_and_related_fields(tmp_path
             "bbox_y": 20,
             "bbox_w": 30,
             "bbox_h": 40,
+            "bbox_space_width": None,
+            "bbox_space_height": None,
             "label_source": None,
             "confidence": None,
             "model_version": None,
@@ -101,6 +103,52 @@ def test_photo_detail_api_returns_404_for_missing_photo(tmp_path, monkeypatch):
 
     assert response.status_code == 404
     assert response.json()["detail"] == "Photo not found"
+
+
+def test_photo_detail_api_exposes_bbox_coordinate_space_dimensions(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'photo-detail-api-bbox-space.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 3, 28, 19, 30, tzinfo=UTC)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                sha256="sha-1",
+                created_ts=now,
+                updated_ts=now,
+                path="/photos/photo-1.jpg",
+                filesize=1024,
+                ext="jpg",
+                faces_count=1,
+            )
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+                bbox_x=1000,
+                bbox_y=300,
+                bbox_w=800,
+                bbox_h=600,
+                provenance={
+                    "bbox_space_width": 4000,
+                    "bbox_space_height": 3000,
+                },
+            )
+        )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/photos/photo-1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["faces"][0]["bbox_space_width"] == 4000
+    assert payload["faces"][0]["bbox_space_height"] == 3000
 
 
 def test_photo_detail_api_allows_missing_shot_timestamp(tmp_path, monkeypatch):
@@ -241,6 +289,8 @@ def test_photo_detail_api_returns_latest_matching_face_label_provenance(tmp_path
             "bbox_y": 20,
             "bbox_w": 30,
             "bbox_h": 40,
+            "bbox_space_width": None,
+            "bbox_space_height": None,
             "label_source": "human_confirmed",
             "confidence": None,
             "model_version": None,

--- a/apps/api/tests/test_processing_faces.py
+++ b/apps/api/tests/test_processing_faces.py
@@ -121,7 +121,8 @@ def test_detector_detect_returns_serialized_face_rows(monkeypatch, tmp_path):
     fake_numpy = SimpleNamespace(array=lambda image: image.__array__())
     fake_rgb_image = _FakeRgbImage()
     fake_image_module = SimpleNamespace(open=lambda _path: _FakeImageContext(fake_rgb_image))
-    fake_pil = SimpleNamespace(Image=fake_image_module)
+    fake_image_ops = SimpleNamespace(exif_transpose=lambda image: image)
+    fake_pil = SimpleNamespace(Image=fake_image_module, ImageOps=fake_image_ops)
     register_calls = []
     fake_heif = SimpleNamespace(register_heif_opener=lambda: register_calls.append(True))
 
@@ -129,6 +130,7 @@ def test_detector_detect_returns_serialized_face_rows(monkeypatch, tmp_path):
     monkeypatch.setitem(__import__("sys").modules, "numpy", fake_numpy)
     monkeypatch.setitem(__import__("sys").modules, "PIL", fake_pil)
     monkeypatch.setitem(__import__("sys").modules, "PIL.Image", fake_image_module)
+    monkeypatch.setitem(__import__("sys").modules, "PIL.ImageOps", fake_image_ops)
     monkeypatch.setitem(__import__("sys").modules, "pillow_heif", fake_heif)
 
     detector = OpenCvFaceDetector(scale_factor=1.2, min_neighbors=7, min_size=(48, 48))
@@ -151,4 +153,6 @@ def test_detector_detect_returns_serialized_face_rows(monkeypatch, tmp_path):
         "scale_factor": 1.2,
         "min_neighbors": 7,
         "min_size": [48, 48],
+        "bbox_space_width": 200,
+        "bbox_space_height": 100,
     }

--- a/apps/ui/src/pages/FaceBBoxOverlay.test.tsx
+++ b/apps/ui/src/pages/FaceBBoxOverlay.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import { buildFaceOverlayRegions, FaceBBoxOverlay } from "./FaceBBoxOverlay";
+
+describe("FaceBBoxOverlay", () => {
+  it("builds overlay regions from explicit bbox coordinate-space dimensions", () => {
+    const regions = buildFaceOverlayRegions(
+      [
+        {
+          face_id: "face-1",
+          person_id: "person-1",
+          bbox_x: 1000,
+          bbox_y: 300,
+          bbox_w: 800,
+          bbox_h: 600,
+          bbox_space_width: 4000,
+          bbox_space_height: 3000
+        }
+      ],
+      100,
+      75
+    );
+
+    expect(regions).toEqual([
+      {
+        faceId: "face-1",
+        personId: "person-1",
+        labelSource: null,
+        leftPercent: 25,
+        topPercent: 10,
+        widthPercent: 20,
+        heightPercent: 20
+      }
+    ]);
+  });
+
+  it("falls back to legacy inferred coordinate-space dimensions when explicit values are absent", () => {
+    const regions = buildFaceOverlayRegions(
+      [
+        {
+          face_id: "face-1",
+          person_id: "person-1",
+          bbox_x: 320,
+          bbox_y: 160,
+          bbox_w: 120,
+          bbox_h: 140
+        }
+      ],
+      100,
+      100
+    );
+
+    expect(regions).toHaveLength(1);
+    expect(regions[0]!.faceId).toBe("face-1");
+    expect(regions[0]!.personId).toBe("person-1");
+    expect(regions[0]!.leftPercent).toBeCloseTo(72.72727272727273, 8);
+    expect(regions[0]!.topPercent).toBeCloseTo(53.333333333333336, 8);
+    expect(regions[0]!.widthPercent).toBeCloseTo(27.272727272727266, 8);
+    expect(regions[0]!.heightPercent).toBeCloseTo(46.666666666666664, 8);
+  });
+
+  it("renders region overlays and optional region content", () => {
+    render(
+      <FaceBBoxOverlay
+        regions={[
+          {
+            faceId: "face-1",
+            personId: "person-1",
+            labelSource: "machine_suggested",
+            leftPercent: 10,
+            topPercent: 20,
+            widthPercent: 30,
+            heightPercent: 40
+          }
+        ]}
+        ariaLabel="Detected face regions"
+        renderRegionContent={(_region, index) => (
+          <button type="button" aria-label={`Show provenance details for face region ${index + 1}`}>
+            badge
+          </button>
+        )}
+      />
+    );
+
+    expect(screen.getByRole("list", { name: "Detected face regions" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Face region 1 for person-1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show provenance details for face region 1" })).toBeInTheDocument();
+  });
+});

--- a/apps/ui/src/pages/FaceBBoxOverlay.tsx
+++ b/apps/ui/src/pages/FaceBBoxOverlay.tsx
@@ -1,0 +1,173 @@
+import type { ReactNode } from "react";
+
+export type FaceLabelSource = "human_confirmed" | "machine_applied" | "machine_suggested" | null;
+
+export type FaceBBoxOverlayFace = {
+  face_id: string;
+  person_id: string | null;
+  bbox_x: number | null;
+  bbox_y: number | null;
+  bbox_w: number | null;
+  bbox_h: number | null;
+  bbox_space_width?: number | null;
+  bbox_space_height?: number | null;
+  label_source?: FaceLabelSource;
+};
+
+export type FaceOverlayRegion = {
+  faceId: string;
+  personId: string | null;
+  labelSource: FaceLabelSource;
+  leftPercent: number;
+  topPercent: number;
+  widthPercent: number;
+  heightPercent: number;
+};
+
+interface FaceBBoxOverlayProps {
+  regions: FaceOverlayRegion[];
+  ariaLabel: string;
+  getRegionAriaLabel?: (region: FaceOverlayRegion, index: number) => string;
+  renderRegionContent?: (region: FaceOverlayRegion, index: number) => ReactNode;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function inferFaceOverlayCoordinateSpace(
+  faces: FaceBBoxOverlayFace[],
+  thumbnailWidth: number,
+  thumbnailHeight: number
+): { width: number; height: number } {
+  const explicitCoordinateSpace = faces.reduce(
+    (acc, face) => {
+      if (
+        face.bbox_space_width !== null &&
+        face.bbox_space_width !== undefined &&
+        face.bbox_space_height !== null &&
+        face.bbox_space_height !== undefined &&
+        face.bbox_space_width > 0 &&
+        face.bbox_space_height > 0
+      ) {
+        acc.width = Math.max(acc.width, face.bbox_space_width);
+        acc.height = Math.max(acc.height, face.bbox_space_height);
+      }
+      return acc;
+    },
+    { width: 0, height: 0 }
+  );
+
+  if (explicitCoordinateSpace.width > 0 && explicitCoordinateSpace.height > 0) {
+    return explicitCoordinateSpace;
+  }
+
+  // Fallback for legacy records without explicit coordinate-space dimensions.
+  const coordinateSpace = faces.reduce(
+    (acc, face) => {
+      if (
+        face.bbox_x === null ||
+        face.bbox_y === null ||
+        face.bbox_w === null ||
+        face.bbox_h === null ||
+        face.bbox_w <= 0 ||
+        face.bbox_h <= 0
+      ) {
+        return acc;
+      }
+
+      acc.width = Math.max(acc.width, face.bbox_x + face.bbox_w);
+      acc.height = Math.max(acc.height, face.bbox_y + face.bbox_h);
+      return acc;
+    },
+    { width: thumbnailWidth, height: thumbnailHeight }
+  );
+
+  return {
+    width: Math.max(coordinateSpace.width, thumbnailWidth),
+    height: Math.max(coordinateSpace.height, thumbnailHeight)
+  };
+}
+
+export function buildFaceOverlayRegions(
+  faces: FaceBBoxOverlayFace[],
+  thumbnailWidth: number,
+  thumbnailHeight: number
+): FaceOverlayRegion[] {
+  if (thumbnailWidth <= 0 || thumbnailHeight <= 0) {
+    return [];
+  }
+
+  const coordinateSpace = inferFaceOverlayCoordinateSpace(faces, thumbnailWidth, thumbnailHeight);
+
+  return faces
+    .map((face) => {
+      if (
+        face.bbox_x === null ||
+        face.bbox_y === null ||
+        face.bbox_w === null ||
+        face.bbox_h === null ||
+        face.bbox_w <= 0 ||
+        face.bbox_h <= 0
+      ) {
+        return null;
+      }
+
+      const left = clamp((face.bbox_x / coordinateSpace.width) * 100, 0, 100);
+      const top = clamp((face.bbox_y / coordinateSpace.height) * 100, 0, 100);
+      const right = clamp(((face.bbox_x + face.bbox_w) / coordinateSpace.width) * 100, 0, 100);
+      const bottom = clamp(((face.bbox_y + face.bbox_h) / coordinateSpace.height) * 100, 0, 100);
+      const width = right - left;
+      const height = bottom - top;
+
+      if (width <= 0 || height <= 0) {
+        return null;
+      }
+
+      return {
+        faceId: face.face_id,
+        personId: face.person_id,
+        labelSource: face.label_source ?? null,
+        leftPercent: left,
+        topPercent: top,
+        widthPercent: width,
+        heightPercent: height
+      } satisfies FaceOverlayRegion;
+    })
+    .filter((region): region is FaceOverlayRegion => region !== null);
+}
+
+function defaultRegionAriaLabel(region: FaceOverlayRegion, index: number): string {
+  return `Face region ${index + 1}${region.personId ? ` for ${region.personId}` : ""}`;
+}
+
+export function FaceBBoxOverlay({
+  regions,
+  ariaLabel,
+  getRegionAriaLabel = defaultRegionAriaLabel,
+  renderRegionContent
+}: FaceBBoxOverlayProps) {
+  if (regions.length === 0) {
+    return null;
+  }
+
+  return (
+    <ol className="detail-face-overlay-list" aria-label={ariaLabel}>
+      {regions.map((region, index) => (
+        <li
+          key={region.faceId}
+          className="detail-face-overlay"
+          aria-label={getRegionAriaLabel(region, index)}
+          style={{
+            left: `${region.leftPercent}%`,
+            top: `${region.topPercent}%`,
+            width: `${region.widthPercent}%`,
+            height: `${region.heightPercent}%`
+          }}
+        >
+          {renderRegionContent ? renderRegionContent(region, index) : null}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/apps/ui/src/pages/LibraryRoutePage.test.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.test.tsx
@@ -39,6 +39,8 @@ type PhotoDetailPayload = {
     bbox_y: number | null;
     bbox_w: number | null;
     bbox_h: number | null;
+    bbox_space_width?: number | null;
+    bbox_space_height?: number | null;
     label_source: "human_confirmed" | "machine_applied" | "machine_suggested" | null;
     confidence: number | null;
     model_version: string | null;
@@ -590,6 +592,73 @@ describe("LibraryRoutePage", () => {
     expect(
       screen.queryByText("Face regions are present but could not be rendered on this preview.")
     ).not.toBeInTheDocument();
+  });
+
+  it("maps quick-panel overlays using explicit bbox coordinate-space dimensions", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      if (url === "/api/v1/search") {
+        return {
+          ok: true,
+          json: async () => buildPayload(["photo-a"], 1, true)
+        } as Response;
+      }
+
+      if (url === "/api/v1/people") {
+        return {
+          ok: true,
+          json: async () => [{ person_id: "person-1", display_name: "Inez" }]
+        } as Response;
+      }
+
+      if (url === "/api/v1/photos/photo-a") {
+        return {
+          ok: true,
+          json: async () =>
+            buildDetailPayload([
+              {
+                face_id: "face-1",
+                person_id: "person-1",
+                bbox_x: 1000,
+                bbox_y: 300,
+                bbox_w: 800,
+                bbox_h: 600,
+                bbox_space_width: 4000,
+                bbox_space_height: 3000,
+                label_source: null,
+                confidence: null,
+                model_version: null,
+                provenance: null,
+                label_recorded_ts: null
+              }
+            ])
+        } as Response;
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Review faces" }));
+
+    const region = await screen.findByLabelText("Face region 1 for person-1");
+    expect(region).toHaveStyle({
+      left: "25%",
+      top: "10%",
+      width: "20%",
+      height: "20%"
+    });
   });
 
   it("supports in-context correction and machine-label confirmation from the library quick panel", async () => {

--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -20,6 +20,8 @@ interface PhotoDetailPayload {
     bbox_y: number | null;
     bbox_w: number | null;
     bbox_h: number | null;
+    bbox_space_width?: number | null;
+    bbox_space_height?: number | null;
     label_source: "human_confirmed" | "machine_applied" | "machine_suggested" | null;
     confidence: number | null;
     model_version: string | null;
@@ -74,6 +76,8 @@ function buildPayload(partial: Partial<PhotoDetailPayload> = {}): PhotoDetailPay
         bbox_y: 20,
         bbox_w: 30,
         bbox_h: 40,
+        bbox_space_width: null,
+        bbox_space_height: null,
         label_source: null,
         confidence: null,
         model_version: null,
@@ -241,6 +245,8 @@ describe("PhotoDetailRoutePage", () => {
               bbox_y: 160,
               bbox_w: 120,
               bbox_h: 140,
+              bbox_space_width: null,
+              bbox_space_height: null,
               label_source: null,
               confidence: null,
               model_version: null,
@@ -265,6 +271,48 @@ describe("PhotoDetailRoutePage", () => {
     expect(
       screen.queryByText("Face regions are present but could not be rendered on this preview.")
     ).not.toBeInTheDocument();
+  });
+
+  it("maps face overlays using explicit bbox coordinate-space dimensions when provided", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () =>
+        buildPayload({
+          faces: [
+            {
+              face_id: "face-1",
+              person_id: "person-1",
+              bbox_x: 1000,
+              bbox_y: 300,
+              bbox_w: 800,
+              bbox_h: 600,
+              bbox_space_width: 4000,
+              bbox_space_height: 3000,
+              label_source: null,
+              confidence: null,
+              model_version: null,
+              provenance: null,
+              label_recorded_ts: null
+            }
+          ],
+          thumbnail: {
+            mime_type: "image/jpeg",
+            width: 100,
+            height: 75,
+            data_base64: "dGh1bWI="
+          }
+        })
+    } as Response);
+
+    renderDetail();
+
+    const region = await screen.findByLabelText("Face region 1 for person-1");
+    expect(region).toHaveStyle({
+      left: "25%",
+      top: "10%",
+      width: "20%",
+      height: "20%"
+    });
   });
 
   it("keeps face overlays coherent when switching image presentation mode", async () => {
@@ -315,7 +363,7 @@ describe("PhotoDetailRoutePage", () => {
     expect(await screen.findByLabelText("Face region 1 for person-1")).toBeInTheDocument();
   });
 
-  it("loads people options and updates local face state after assignment success", async () => {
+  it("opens face actions from the overlay badge and assigns a person from suggestions", async () => {
     const user = userEvent.setup();
 
     fetchMock
@@ -365,10 +413,15 @@ describe("PhotoDetailRoutePage", () => {
     renderDetail();
 
     expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
-    await user.selectOptions(await screen.findByLabelText("Assign face 1"), "person-1");
+    await user.click(
+      await screen.findByRole("button", { name: "Open face actions for face region 1" })
+    );
+    await user.type(screen.getByLabelText("Person name"), "ine");
+    await user.selectOptions(screen.getByLabelText("Person suggestions"), "person-1");
+    await user.click(screen.getByRole("button", { name: "Assign selected person" }));
 
-    expect(await screen.findByText("All visible faces assigned.")).toBeInTheDocument();
-    expect(screen.getByText("person-1")).toBeInTheDocument();
+    expect(await screen.findByText("Face assignment saved for face 1.")).toBeInTheDocument();
+    expect(screen.getByText("Current label: Inez")).toBeInTheDocument();
   });
 
   it("updates local face state after correction success and shows correction provenance", async () => {
@@ -432,15 +485,19 @@ describe("PhotoDetailRoutePage", () => {
     renderDetail();
 
     expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
-    await user.selectOptions(await screen.findByLabelText("Correct face 1"), "person-2");
-    await user.click(screen.getByRole("button", { name: "Confirm reassignment" }));
+    await user.click(
+      await screen.findByRole("button", { name: "Open face actions for face region 1" })
+    );
+    await user.type(screen.getByLabelText("Person name"), "mat");
+    await user.selectOptions(screen.getByLabelText("Person suggestions"), "person-2");
+    await user.click(screen.getByRole("button", { name: "Assign selected person" }));
 
     expect(await screen.findByText("Correction recorded: Inez -> Mateo.")).toBeInTheDocument();
-    expect(screen.getByText("Face 1: Mateo")).toBeInTheDocument();
+    expect(screen.getByText("Current label: Mateo")).toBeInTheDocument();
     expect(screen.getByText("person-2")).toBeInTheDocument();
   });
 
-  it("opens inline provenance details when overlay provenance badge is clicked", async () => {
+  it("creates a new person name from typed input when no exact match exists", async () => {
     const user = userEvent.setup();
 
     fetchMock
@@ -451,20 +508,16 @@ describe("PhotoDetailRoutePage", () => {
             faces: [
               {
                 face_id: "face-1",
-                person_id: "person-1",
+                person_id: null,
                 bbox_x: 10,
                 bbox_y: 10,
                 bbox_w: 20,
                 bbox_h: 20,
-                label_source: "human_confirmed",
+                label_source: null,
                 confidence: null,
                 model_version: null,
-                provenance: {
-                  workflow: "face-labeling",
-                  surface: "api",
-                  action: "correction"
-                },
-                label_recorded_ts: "2026-03-28T19:33:00Z"
+                provenance: null,
+                label_recorded_ts: null
               }
             ]
           })
@@ -479,16 +532,37 @@ describe("PhotoDetailRoutePage", () => {
             updated_ts: "2026-03-28T19:30:00Z"
           }
         ]
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          person_id: "person-2",
+          display_name: "Nova",
+          created_ts: "2026-03-28T19:31:00Z",
+          updated_ts: "2026-03-28T19:31:00Z"
+        })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        json: async () => ({
+          face_id: "face-1",
+          photo_id: "photo-1",
+          person_id: "person-2"
+        })
       } as Response);
 
     renderDetail();
 
-    expect(await screen.findByLabelText("Face region 1 for person-1")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Show provenance details for face region 1" }));
+    expect(await screen.findByLabelText("Face region 1")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Open face actions for face region 1" }));
+    await user.clear(screen.getByLabelText("Person name"));
+    await user.type(screen.getByLabelText("Person name"), "Nova");
+    await user.click(screen.getByRole("button", { name: 'Create and assign "Nova"' }));
 
-    expect(await screen.findByLabelText("Provenance details for face 1")).toBeInTheDocument();
-    expect(screen.getByText("Human confirmed")).toBeInTheDocument();
-    expect(screen.getByText("correction")).toBeInTheDocument();
+    expect(await screen.findByText("Face assignment saved for face 1.")).toBeInTheDocument();
+    expect(screen.getByText("Current label: Nova")).toBeInTheDocument();
   });
 
   it("renders deterministic loading and error transitions", async () => {
@@ -529,7 +603,7 @@ describe("PhotoDetailRoutePage", () => {
     expect(photoDetailCalls).toHaveLength(2);
   });
 
-  it("renders pending ingest status when face detection is still in progress", async () => {
+  it("renders pending ingest status without an ingest legend section", async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,
       json: async () =>
@@ -549,7 +623,7 @@ describe("PhotoDetailRoutePage", () => {
     renderDetail();
 
     expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
-    expect(screen.getByText("Ingest status legend")).toBeInTheDocument();
+    expect(screen.queryByText("Ingest status legend")).not.toBeInTheDocument();
     expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
   });
 

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -1,7 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
-import { deriveIngestStatus, INGEST_STATUS_LEGEND } from "../app/ingestStatus";
-import { FaceAssignmentControls } from "./FaceAssignmentControls";
+import { deriveIngestStatus } from "../app/ingestStatus";
+import {
+  buildFaceOverlayRegions,
+  FaceBBoxOverlay,
+  type FaceOverlayRegion
+} from "./FaceBBoxOverlay";
+import { PhotoFaceActionFlyout } from "./PhotoFaceActionFlyout";
 import {
   resolveDetailReturnState,
   setPendingBrowseFocusPhotoId
@@ -24,6 +29,8 @@ type PhotoDetailPayload = {
     bbox_y: number | null;
     bbox_w: number | null;
     bbox_h: number | null;
+    bbox_space_width?: number | null;
+    bbox_space_height?: number | null;
     label_source: "human_confirmed" | "machine_applied" | "machine_suggested" | null;
     confidence: number | null;
     model_version: string | null;
@@ -62,23 +69,6 @@ type PhotoDetailPayload = {
 const MISSING_VALUE = "Not available";
 
 type MediaPresentationMode = "fit" | "actual";
-
-type FaceOverlayRegion = {
-  faceId: string;
-  personId: string | null;
-  labelSource: "human_confirmed" | "machine_applied" | "machine_suggested" | null;
-  leftPercent: number;
-  topPercent: number;
-  widthPercent: number;
-  heightPercent: number;
-};
-
-type FaceBBox = {
-  bbox_x: number | null;
-  bbox_y: number | null;
-  bbox_w: number | null;
-  bbox_h: number | null;
-};
 
 type PersonRecord = {
   person_id: string;
@@ -138,42 +128,6 @@ function formatGps(lat: number | null, lon: number | null): string {
 
 function formatOptionalText(value: string | null): string {
   return value && value.trim().length > 0 ? value : MISSING_VALUE;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
-
-function inferFaceOverlayCoordinateSpace(
-  faces: FaceBBox[],
-  thumbnailWidth: number,
-  thumbnailHeight: number
-): { width: number; height: number } {
-  // Face coordinates are stored in source-image pixels; use detected extents when thumbnail space is smaller.
-  const coordinateSpace = faces.reduce(
-    (acc, face) => {
-      if (
-        face.bbox_x === null ||
-        face.bbox_y === null ||
-        face.bbox_w === null ||
-        face.bbox_h === null ||
-        face.bbox_w <= 0 ||
-        face.bbox_h <= 0
-      ) {
-        return acc;
-      }
-
-      acc.width = Math.max(acc.width, face.bbox_x + face.bbox_w);
-      acc.height = Math.max(acc.height, face.bbox_y + face.bbox_h);
-      return acc;
-    },
-    { width: thumbnailWidth, height: thumbnailHeight }
-  );
-
-  return {
-    width: Math.max(coordinateSpace.width, thumbnailWidth),
-    height: Math.max(coordinateSpace.height, thumbnailHeight)
-  };
 }
 
 async function fetchPhotoDetail(photoId: string): Promise<PhotoDetailPayload> {
@@ -253,11 +207,11 @@ export function PhotoDetailRoutePage() {
   const [isNotFound, setIsNotFound] = useState(false);
   const [reloadToken, setReloadToken] = useState(0);
   const [mediaMode, setMediaMode] = useState<MediaPresentationMode>("actual");
+  const [imageScalePercent, setImageScalePercent] = useState(100);
   const [showFaceBoxes, setShowFaceBoxes] = useState(true);
+  const [isDetailFlyoutOpen, setIsDetailFlyoutOpen] = useState(false);
+  const [requestedFaceActionFaceId, setRequestedFaceActionFaceId] = useState<string | null>(null);
   const [peopleDirectory, setPeopleDirectory] = useState<PersonRecord[]>([]);
-  const [requestedExpandedProvenanceFaceId, setRequestedExpandedProvenanceFaceId] = useState<
-    string | null
-  >(null);
 
   useEffect(() => {
     headingRef.current?.focus();
@@ -344,45 +298,7 @@ export function PhotoDetailRoutePage() {
       return [];
     }
 
-    const thumbnailWidth = detail.thumbnail.width;
-    const thumbnailHeight = detail.thumbnail.height;
-    const coordinateSpace = inferFaceOverlayCoordinateSpace(detail.faces, thumbnailWidth, thumbnailHeight);
-
-    return detail.faces
-      .map((face) => {
-        if (
-          face.bbox_x === null ||
-          face.bbox_y === null ||
-          face.bbox_w === null ||
-          face.bbox_h === null ||
-          face.bbox_w <= 0 ||
-          face.bbox_h <= 0
-        ) {
-          return null;
-        }
-
-        const left = clamp((face.bbox_x / coordinateSpace.width) * 100, 0, 100);
-        const top = clamp((face.bbox_y / coordinateSpace.height) * 100, 0, 100);
-        const right = clamp(((face.bbox_x + face.bbox_w) / coordinateSpace.width) * 100, 0, 100);
-        const bottom = clamp(((face.bbox_y + face.bbox_h) / coordinateSpace.height) * 100, 0, 100);
-        const width = right - left;
-        const height = bottom - top;
-
-        if (width <= 0 || height <= 0) {
-          return null;
-        }
-
-        return {
-          faceId: face.face_id,
-          personId: face.person_id,
-          labelSource: face.label_source,
-          leftPercent: left,
-          topPercent: top,
-          widthPercent: width,
-          heightPercent: height
-        };
-      })
-      .filter((region): region is FaceOverlayRegion => region !== null);
+    return buildFaceOverlayRegions(detail.faces, detail.thumbnail.width, detail.thumbnail.height);
   }, [detail]);
 
   const faceRegionState = useMemo(() => {
@@ -420,9 +336,35 @@ export function PhotoDetailRoutePage() {
   }, [detail]);
 
   const backLinkFocusPhotoId = detail?.photo_id ?? returnState.returnFocusPhotoId ?? photoId ?? null;
+  const mediaScale = imageScalePercent / 100;
+  const mediaStageStyle: CSSProperties = mediaMode === "fit"
+    ? { width: `${Math.max(25, imageScalePercent)}%` }
+    : { width: detail?.thumbnail ? `${Math.max(80, Math.round(detail.thumbnail.width * mediaScale))}px` : "auto" };
 
   function handleFaceAssigned(faceId: string, personId: string) {
     setDetail((current) => (current ? applyFaceAssignment(current, faceId, personId) : current));
+  }
+
+  function handlePersonCreated(person: {
+    person_id: string;
+    display_name: string;
+    created_ts?: string;
+    updated_ts?: string;
+  }) {
+    setPeopleDirectory((current) => {
+      if (current.some((candidate) => candidate.person_id === person.person_id)) {
+        return current;
+      }
+      return sortPeopleDirectory([
+        ...current,
+        {
+          person_id: person.person_id,
+          display_name: person.display_name,
+          created_ts: person.created_ts ?? new Date().toISOString(),
+          updated_ts: person.updated_ts ?? new Date().toISOString()
+        }
+      ]);
+    });
   }
 
   return (
@@ -457,18 +399,6 @@ export function PhotoDetailRoutePage() {
           Back to library
         </Link>
       </div>
-      <section className="status-legend" aria-label="Ingest status legend">
-        <h2>Ingest status legend</h2>
-        <ul>
-          {INGEST_STATUS_LEGEND.map((entry) => (
-            <li key={entry.tone}>
-              <span className={`ingest-status-badge is-${entry.tone}`}>{entry.label}</span>
-              <span>{entry.description}</span>
-            </li>
-          ))}
-        </ul>
-      </section>
-
       {isLoading ? (
         <div className="feedback-panel feedback-panel-loading" role="status" aria-live="polite">
           Loading photo detail.
@@ -486,216 +416,241 @@ export function PhotoDetailRoutePage() {
       ) : null}
 
       {!isLoading && !error && detail ? (
-        <div className="detail-layout">
-          <article className="detail-panel">
+        <div className="detail-workspace">
+          <article className="detail-preview-panel">
             <h2>Preview</h2>
+            <div className="detail-media-controls" role="group" aria-label="Preview display mode">
+              <button
+                type="button"
+                className={mediaMode === "fit" ? "is-active" : undefined}
+                onClick={() => setMediaMode("fit")}
+              >
+                Fit to panel
+              </button>
+              <button
+                type="button"
+                className={mediaMode === "actual" ? "is-active" : undefined}
+                onClick={() => setMediaMode("actual")}
+              >
+                Actual pixels
+              </button>
+              <label className="detail-face-box-toggle">
+                <input
+                  type="checkbox"
+                  aria-label="Show face boxes"
+                  checked={showFaceBoxes}
+                  onChange={(event) => setShowFaceBoxes(event.currentTarget.checked)}
+                />
+                Show face boxes
+              </label>
+              <label className="detail-photo-scale">
+                <span>Photo size</span>
+                <input
+                  type="range"
+                  min={25}
+                  max={225}
+                  step={5}
+                  value={imageScalePercent}
+                  aria-label="Photo size"
+                  onChange={(event) => setImageScalePercent(Number(event.currentTarget.value))}
+                />
+                <span>{imageScalePercent}%</span>
+              </label>
+              <button
+                type="button"
+                onClick={() => {
+                  setIsDetailFlyoutOpen((current) => !current);
+                }}
+              >
+                {isDetailFlyoutOpen ? "Hide details" : "Show details"}
+              </button>
+            </div>
+            {ingestStatus ? (
+              <p className="detail-ingest-inline">
+                <span className={`ingest-status-badge is-${ingestStatus.tone}`}>{ingestStatus.label}</span>
+                <span>{ingestStatus.description}</span>
+              </p>
+            ) : null}
             {detail.thumbnail ? (
-              <>
-                <div className="detail-media-controls" role="group" aria-label="Preview display mode">
-                  <button
-                    type="button"
-                    className={mediaMode === "fit" ? "is-active" : undefined}
-                    onClick={() => setMediaMode("fit")}
-                  >
-                    Fit to panel
-                  </button>
-                  <button
-                    type="button"
-                    className={mediaMode === "actual" ? "is-active" : undefined}
-                    onClick={() => setMediaMode("actual")}
-                  >
-                    Actual pixels
-                  </button>
-                  <label className="detail-face-box-toggle">
-                    <input
-                      type="checkbox"
-                      aria-label="Show face boxes"
-                      checked={showFaceBoxes}
-                      onChange={(event) => setShowFaceBoxes(event.currentTarget.checked)}
+              <div className="detail-media-frame" data-mode={mediaMode}>
+                <div className="detail-media-stage" style={mediaStageStyle}>
+                  <img
+                    className="detail-media-image"
+                    src={`data:${detail.thumbnail.mime_type};base64,${detail.thumbnail.data_base64}`}
+                    width={detail.thumbnail.width}
+                    height={detail.thumbnail.height}
+                    alt={`Preview for ${detail.photo_id}`}
+                  />
+                  {showFaceBoxes ? (
+                    <FaceBBoxOverlay
+                      regions={faceOverlayRegions}
+                      ariaLabel="Detected face regions"
+                      renderRegionContent={(region, index) => (
+                        <button
+                          type="button"
+                          className="detail-face-overlay-provenance-button"
+                          aria-label={`Open face actions for face region ${index + 1}`}
+                          onClick={() => {
+                            setRequestedFaceActionFaceId(region.faceId);
+                            setIsDetailFlyoutOpen(true);
+                          }}
+                        >
+                          {provenanceBadgeIcon(region.labelSource)}
+                        </button>
+                      )}
                     />
-                    Show face boxes
-                  </label>
+                  ) : null}
                 </div>
-                <div className="detail-media-frame" data-mode={mediaMode}>
-                  <div className="detail-media-stage">
-                    <img
-                      className="detail-media-image"
-                      src={`data:${detail.thumbnail.mime_type};base64,${detail.thumbnail.data_base64}`}
-                      width={detail.thumbnail.width}
-                      height={detail.thumbnail.height}
-                      alt={`Preview for ${detail.photo_id}`}
-                    />
-                    {showFaceBoxes && faceOverlayRegions.length > 0 ? (
-                      <ol className="detail-face-overlay-list" aria-label="Detected face regions">
-                        {faceOverlayRegions.map((region, index) => (
-                          <li
-                            key={region.faceId}
-                            className="detail-face-overlay"
-                            aria-label={`Face region ${index + 1}${region.personId ? ` for ${region.personId}` : ""}`}
-                            style={{
-                              left: `${region.leftPercent}%`,
-                              top: `${region.topPercent}%`,
-                              width: `${region.widthPercent}%`,
-                              height: `${region.heightPercent}%`
-                            }}
-                          >
-                            <button
-                              type="button"
-                              className="detail-face-overlay-provenance-button"
-                              aria-label={`Show provenance details for face region ${index + 1}`}
-                              onClick={() => {
-                                setRequestedExpandedProvenanceFaceId(region.faceId);
-                              }}
-                            >
-                              {provenanceBadgeIcon(region.labelSource)}
-                            </button>
-                          </li>
-                        ))}
-                      </ol>
-                    ) : null}
-                  </div>
-                </div>
-                <p className="detail-face-state">{faceRegionState}</p>
-                <FaceAssignmentControls
-                  faces={detail.faces}
-                  people={peopleDirectory.map((person) => ({
-                    person_id: person.person_id,
-                    display_name: person.display_name
-                  }))}
-                  onAssigned={handleFaceAssigned}
-                  onCorrected={handleFaceAssigned}
-                  requestedExpandedProvenanceFaceId={requestedExpandedProvenanceFaceId}
-                />
-              </>
+              </div>
             ) : (
-              <>
-                <div className="browse-thumbnail browse-thumbnail-placeholder" aria-hidden="true">
-                  No preview
-                </div>
-                <p className="detail-face-state">{faceRegionState}</p>
-                <FaceAssignmentControls
-                  faces={detail.faces}
-                  people={peopleDirectory.map((person) => ({
-                    person_id: person.person_id,
-                    display_name: person.display_name
-                  }))}
-                  onAssigned={handleFaceAssigned}
-                  onCorrected={handleFaceAssigned}
-                  requestedExpandedProvenanceFaceId={requestedExpandedProvenanceFaceId}
-                />
-              </>
+              <div className="browse-thumbnail browse-thumbnail-placeholder" aria-hidden="true">
+                No preview
+              </div>
             )}
+            <p className="detail-face-state">{faceRegionState}</p>
           </article>
 
-          <article className="detail-panel">
-            <h2>{detail.photo_id}</h2>
+          <button
+            type="button"
+            className={`detail-flyout-backdrop${isDetailFlyoutOpen ? " is-open" : ""}`}
+            aria-label="Hide details flyout"
+            onClick={() => setIsDetailFlyoutOpen(false)}
+          />
+
+          <aside
+            className={`detail-flyout${isDetailFlyoutOpen ? " is-open" : ""}`}
+            aria-label="Photo details flyout"
+          >
+            <div className="detail-flyout-header">
+              <h2>{detail.photo_id}</h2>
+              <button type="button" onClick={() => setIsDetailFlyoutOpen(false)}>
+                Close
+              </button>
+            </div>
             <p className="detail-path">{detail.path}</p>
-            <dl>
-              <div>
-                <dt>Captured</dt>
-                <dd>{formatTimestamp(detail.shot_ts)}</dd>
-              </div>
-              <div>
-                <dt>File size</dt>
-                <dd>{formatFilesize(detail.filesize)}</dd>
-              </div>
-              <div>
-                <dt>Camera make</dt>
-                <dd>{formatOptionalText(detail.camera_make)}</dd>
-              </div>
-              <div>
-                <dt>Orientation</dt>
-                <dd>{formatOptionalText(detail.orientation)}</dd>
-              </div>
-              <div>
-                <dt>Availability</dt>
-                <dd>{detail.original?.availability_state ?? "Unknown availability"}</dd>
-              </div>
-              <div>
-                <dt>Ingest status</dt>
-                <dd>
-                  {ingestStatus ? (
-                    <span className={`ingest-status-badge is-${ingestStatus.tone}`}>{ingestStatus.label}</span>
-                  ) : (
-                    "Unknown"
-                  )}
-                </dd>
-              </div>
-            </dl>
-            {ingestStatus ? <p className="detail-ingest-status-detail">{ingestStatus.description}</p> : null}
-          </article>
 
-          <article className="detail-panel">
-            <h2>Metadata</h2>
-            <dl>
-              <div>
-                <dt>SHA-256</dt>
-                <dd>{detail.metadata.sha256}</dd>
-              </div>
-              <div>
-                <dt>Perceptual hash</dt>
-                <dd>{formatOptionalText(detail.metadata.phash)}</dd>
-              </div>
-              <div>
-                <dt>Timestamp source</dt>
-                <dd>{formatOptionalText(detail.metadata.shot_ts_source)}</dd>
-              </div>
-              <div>
-                <dt>Camera model</dt>
-                <dd>{formatOptionalText(detail.metadata.camera_model)}</dd>
-              </div>
-              <div>
-                <dt>Software</dt>
-                <dd>{formatOptionalText(detail.metadata.software)}</dd>
-              </div>
-              <div>
-                <dt>GPS</dt>
-                <dd>{formatGps(detail.metadata.gps_latitude, detail.metadata.gps_longitude)}</dd>
-              </div>
-              <div>
-                <dt>GPS altitude</dt>
-                <dd>
-                  {detail.metadata.gps_altitude === null
-                    ? MISSING_VALUE
-                    : `${detail.metadata.gps_altitude.toFixed(1)} m`}
-                </dd>
-              </div>
-              <div>
-                <dt>Faces</dt>
-                <dd>{facesLabel}</dd>
-              </div>
-              <div>
-                <dt>Face detection run</dt>
-                <dd>{formatTimestamp(detail.metadata.faces_detected_ts)}</dd>
-              </div>
-              <div>
-                <dt>Created</dt>
-                <dd>{formatTimestamp(detail.metadata.created_ts)}</dd>
-              </div>
-              <div>
-                <dt>Updated</dt>
-                <dd>{formatTimestamp(detail.metadata.updated_ts)}</dd>
-              </div>
-              <div>
-                <dt>Modified</dt>
-                <dd>{formatTimestamp(detail.metadata.modified_ts)}</dd>
-              </div>
-            </dl>
-          </article>
+            <article className="detail-panel">
+              <h2>Summary</h2>
+              <dl>
+                <div>
+                  <dt>Captured</dt>
+                  <dd>{formatTimestamp(detail.shot_ts)}</dd>
+                </div>
+                <div>
+                  <dt>File size</dt>
+                  <dd>{formatFilesize(detail.filesize)}</dd>
+                </div>
+                <div>
+                  <dt>Camera make</dt>
+                  <dd>{formatOptionalText(detail.camera_make)}</dd>
+                </div>
+                <div>
+                  <dt>Orientation</dt>
+                  <dd>{formatOptionalText(detail.orientation)}</dd>
+                </div>
+                <div>
+                  <dt>Availability</dt>
+                  <dd>{detail.original?.availability_state ?? "Unknown availability"}</dd>
+                </div>
+                <div>
+                  <dt>Ingest status</dt>
+                  <dd>
+                    {ingestStatus ? (
+                      <span className={`ingest-status-badge is-${ingestStatus.tone}`}>{ingestStatus.label}</span>
+                    ) : (
+                      "Unknown"
+                    )}
+                  </dd>
+                </div>
+              </dl>
+              {ingestStatus ? <p className="detail-ingest-status-detail">{ingestStatus.description}</p> : null}
+            </article>
 
-          <article className="detail-panel">
-            <h2>Classification</h2>
-            <dl>
-              <div>
-                <dt>Tags</dt>
-                <dd>{detail.tags.length > 0 ? detail.tags.join(", ") : "No tags"}</dd>
-              </div>
-              <div>
-                <dt>People</dt>
-                <dd>{detail.people.length > 0 ? detail.people.join(", ") : "No recognized people"}</dd>
-              </div>
-            </dl>
-          </article>
+            <PhotoFaceActionFlyout
+              faces={detail.faces}
+              people={peopleDirectory.map((person) => ({
+                person_id: person.person_id,
+                display_name: person.display_name,
+                created_ts: person.created_ts,
+                updated_ts: person.updated_ts
+              }))}
+              requestedFaceActionFaceId={requestedFaceActionFaceId}
+              onFaceUpdated={handleFaceAssigned}
+              onPersonCreated={handlePersonCreated}
+            />
+
+            <article className="detail-panel">
+              <h2>Metadata</h2>
+              <dl>
+                <div>
+                  <dt>SHA-256</dt>
+                  <dd>{detail.metadata.sha256}</dd>
+                </div>
+                <div>
+                  <dt>Perceptual hash</dt>
+                  <dd>{formatOptionalText(detail.metadata.phash)}</dd>
+                </div>
+                <div>
+                  <dt>Timestamp source</dt>
+                  <dd>{formatOptionalText(detail.metadata.shot_ts_source)}</dd>
+                </div>
+                <div>
+                  <dt>Camera model</dt>
+                  <dd>{formatOptionalText(detail.metadata.camera_model)}</dd>
+                </div>
+                <div>
+                  <dt>Software</dt>
+                  <dd>{formatOptionalText(detail.metadata.software)}</dd>
+                </div>
+                <div>
+                  <dt>GPS</dt>
+                  <dd>{formatGps(detail.metadata.gps_latitude, detail.metadata.gps_longitude)}</dd>
+                </div>
+                <div>
+                  <dt>GPS altitude</dt>
+                  <dd>
+                    {detail.metadata.gps_altitude === null
+                      ? MISSING_VALUE
+                      : `${detail.metadata.gps_altitude.toFixed(1)} m`}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Faces</dt>
+                  <dd>{facesLabel}</dd>
+                </div>
+                <div>
+                  <dt>Face detection run</dt>
+                  <dd>{formatTimestamp(detail.metadata.faces_detected_ts)}</dd>
+                </div>
+                <div>
+                  <dt>Created</dt>
+                  <dd>{formatTimestamp(detail.metadata.created_ts)}</dd>
+                </div>
+                <div>
+                  <dt>Updated</dt>
+                  <dd>{formatTimestamp(detail.metadata.updated_ts)}</dd>
+                </div>
+                <div>
+                  <dt>Modified</dt>
+                  <dd>{formatTimestamp(detail.metadata.modified_ts)}</dd>
+                </div>
+              </dl>
+            </article>
+
+            <article className="detail-panel">
+              <h2>Classification</h2>
+              <dl>
+                <div>
+                  <dt>Tags</dt>
+                  <dd>{detail.tags.length > 0 ? detail.tags.join(", ") : "No tags"}</dd>
+                </div>
+                <div>
+                  <dt>People</dt>
+                  <dd>{detail.people.length > 0 ? detail.people.join(", ") : "No recognized people"}</dd>
+                </div>
+              </dl>
+            </article>
+          </aside>
         </div>
       ) : null}
 

--- a/apps/ui/src/pages/PhotoFaceActionFlyout.tsx
+++ b/apps/ui/src/pages/PhotoFaceActionFlyout.tsx
@@ -1,0 +1,374 @@
+import { useEffect, useMemo, useState } from "react";
+
+type FaceLabelSource = "human_confirmed" | "machine_applied" | "machine_suggested" | null;
+
+const NOT_AVAILABLE = "Not available";
+
+interface FaceActionFace {
+  face_id: string;
+  person_id: string | null;
+  label_source?: FaceLabelSource;
+  confidence?: number | null;
+  model_version?: string | null;
+  provenance?: Record<string, unknown> | null;
+  label_recorded_ts?: string | null;
+}
+
+interface FaceActionPerson {
+  person_id: string;
+  display_name: string;
+  created_ts?: string;
+  updated_ts?: string;
+}
+
+interface PhotoFaceActionFlyoutProps {
+  faces: FaceActionFace[];
+  people: FaceActionPerson[];
+  requestedFaceActionFaceId?: string | null;
+  onFaceUpdated: (faceId: string, personId: string) => void;
+  onPersonCreated: (person: FaceActionPerson) => void;
+}
+
+async function readErrorDetail(response: Response): Promise<string | null> {
+  try {
+    const payload = (await response.json()) as { detail?: unknown };
+    if (typeof payload.detail === "string" && payload.detail.trim().length > 0) {
+      return payload.detail;
+    }
+  } catch {
+    // Fall back to default message mapping.
+  }
+  return null;
+}
+
+function normalizeName(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function resolvePersonLabel(people: FaceActionPerson[], personId: string): string {
+  const match = people.find((person) => person.person_id === personId);
+  return match ? match.display_name : personId;
+}
+
+function provenanceSourceLabel(source: FaceLabelSource | undefined): string {
+  if (source === "human_confirmed") {
+    return "Human confirmed";
+  }
+  if (source === "machine_applied") {
+    return "Machine applied";
+  }
+  if (source === "machine_suggested") {
+    return "Machine suggested";
+  }
+  return "Unknown";
+}
+
+function readProvenanceValue(face: FaceActionFace, key: string): string {
+  if (!face.provenance || typeof face.provenance !== "object") {
+    return NOT_AVAILABLE;
+  }
+  const value = face.provenance[key];
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return NOT_AVAILABLE;
+}
+
+function formatConfidence(confidence: number | null | undefined): string {
+  if (typeof confidence !== "number" || !Number.isFinite(confidence)) {
+    return NOT_AVAILABLE;
+  }
+  if (confidence < 0 || confidence > 1) {
+    return NOT_AVAILABLE;
+  }
+  return `${(confidence * 100).toFixed(1)}%`;
+}
+
+function formatRecordedTimestamp(value: string | null | undefined): string {
+  if (!value || value.trim().length === 0) {
+    return NOT_AVAILABLE;
+  }
+  return value;
+}
+
+export function PhotoFaceActionFlyout({
+  faces,
+  people,
+  requestedFaceActionFaceId = null,
+  onFaceUpdated,
+  onPersonCreated
+}: PhotoFaceActionFlyoutProps) {
+  const indexedFaces = useMemo(
+    () => faces.map((face, index) => ({ ...face, sequence: index + 1 })),
+    [faces]
+  );
+  const [selectedFaceId, setSelectedFaceId] = useState<string | null>(indexedFaces[0]?.face_id ?? null);
+  const [personDraft, setPersonDraft] = useState("");
+  const [selectedPersonId, setSelectedPersonId] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (indexedFaces.length === 0) {
+      setSelectedFaceId(null);
+      return;
+    }
+    setSelectedFaceId((current) =>
+      current && indexedFaces.some((face) => face.face_id === current) ? current : indexedFaces[0].face_id
+    );
+  }, [indexedFaces]);
+
+  useEffect(() => {
+    if (!requestedFaceActionFaceId) {
+      return;
+    }
+    if (!indexedFaces.some((face) => face.face_id === requestedFaceActionFaceId)) {
+      return;
+    }
+    setSelectedFaceId(requestedFaceActionFaceId);
+    setPersonDraft("");
+    setSelectedPersonId("");
+    setError(null);
+  }, [requestedFaceActionFaceId, indexedFaces]);
+
+  const selectedFace = indexedFaces.find((face) => face.face_id === selectedFaceId) ?? null;
+  const normalizedDraft = normalizeName(personDraft);
+  const exactMatch = useMemo(
+    () => people.find((person) => normalizeName(person.display_name) === normalizedDraft) ?? null,
+    [people, normalizedDraft]
+  );
+
+  const orderedPeople = useMemo(() => {
+    const sortedPeople = [...people].sort((left, right) =>
+      left.display_name.localeCompare(right.display_name, "en-US")
+    );
+    if (!normalizedDraft) {
+      return sortedPeople;
+    }
+
+    const suggestions: FaceActionPerson[] = [];
+    const others: FaceActionPerson[] = [];
+    for (const person of sortedPeople) {
+      if (normalizeName(person.display_name).includes(normalizedDraft)) {
+        suggestions.push(person);
+      } else {
+        others.push(person);
+      }
+    }
+    suggestions.sort((left, right) => {
+      const leftStarts = normalizeName(left.display_name).startsWith(normalizedDraft) ? 0 : 1;
+      const rightStarts = normalizeName(right.display_name).startsWith(normalizedDraft) ? 0 : 1;
+      if (leftStarts !== rightStarts) {
+        return leftStarts - rightStarts;
+      }
+      return left.display_name.localeCompare(right.display_name, "en-US");
+    });
+    return [...suggestions, ...others];
+  }, [people, normalizedDraft]);
+
+  const trimmedDraft = personDraft.trim();
+  const createCandidate = trimmedDraft.length > 0 && !exactMatch ? trimmedDraft : null;
+  const selectedExistingPerson = orderedPeople.find((person) => person.person_id === selectedPersonId) ?? null;
+  const targetExistingPersonId = selectedExistingPerson?.person_id ?? exactMatch?.person_id ?? "";
+  const canApply =
+    !isSubmitting &&
+    selectedFace !== null &&
+    (targetExistingPersonId.length > 0 || createCandidate !== null);
+
+  async function applySelection() {
+    if (!selectedFace) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setMessage(null);
+    setError(null);
+
+    try {
+      let nextPersonId = targetExistingPersonId;
+      let nextPersonName = selectedExistingPerson?.display_name ?? exactMatch?.display_name ?? createCandidate ?? "";
+      if (!nextPersonId && createCandidate) {
+        const createResponse = await fetch("/api/v1/people", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({ display_name: createCandidate })
+        });
+        if (!createResponse.ok) {
+          const detail = await readErrorDetail(createResponse);
+          setError(detail ?? `Create request failed (${createResponse.status}).`);
+          return;
+        }
+        const createdPerson = (await createResponse.json()) as FaceActionPerson;
+        onPersonCreated(createdPerson);
+        nextPersonId = createdPerson.person_id;
+        nextPersonName = createdPerson.display_name;
+      }
+
+      if (!nextPersonId) {
+        return;
+      }
+
+      if (selectedFace.person_id !== null && selectedFace.person_id === nextPersonId) {
+        setMessage(`Face ${selectedFace.sequence} already maps to ${nextPersonName}.`);
+        return;
+      }
+
+      const endpoint =
+        selectedFace.person_id === null
+          ? `/api/v1/faces/${selectedFace.face_id}/assignments`
+          : `/api/v1/faces/${selectedFace.face_id}/corrections`;
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Face-Validation-Role": "contributor"
+        },
+        body: JSON.stringify({ person_id: nextPersonId })
+      });
+      if (!response.ok) {
+        const detail = await readErrorDetail(response);
+        setError(detail ?? `Face update request failed (${response.status}).`);
+        return;
+      }
+
+      if (selectedFace.person_id === null) {
+        setMessage(`Face assignment saved for face ${selectedFace.sequence}.`);
+      } else {
+        const payload = (await response.json()) as { previous_person_id?: string; person_id?: string };
+        const previousId = payload.previous_person_id ?? selectedFace.person_id;
+        const updatedId = payload.person_id ?? nextPersonId;
+        setMessage(
+          `Correction recorded: ${resolvePersonLabel(people, previousId)} -> ${resolvePersonLabel(people, updatedId)}.`
+        );
+      }
+
+      onFaceUpdated(selectedFace.face_id, nextPersonId);
+      setSelectedPersonId("");
+      setPersonDraft("");
+    } catch {
+      setError("Could not update face assignment.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (indexedFaces.length === 0) {
+    return (
+      <section className="detail-face-actions" aria-label="Face actions">
+        <h3>Face actions</h3>
+        <p className="detail-face-assignment-complete">No detected faces for this photo.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="detail-face-actions" aria-label="Face actions">
+      <h3>Face actions</h3>
+      <ul className="detail-face-action-list">
+        {indexedFaces.map((face) => (
+          <li key={face.face_id}>
+            <button
+              type="button"
+              className={selectedFaceId === face.face_id ? "is-active" : undefined}
+              onClick={() => {
+                setSelectedFaceId(face.face_id);
+                setMessage(null);
+                setError(null);
+              }}
+            >
+              Face {face.sequence}
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {selectedFace ? (
+        <div className="detail-face-actions-body">
+          <p>
+            Current label:{" "}
+            {selectedFace.person_id ? resolvePersonLabel(people, selectedFace.person_id) : "Unassigned"}
+          </p>
+
+          <label htmlFor="detail-face-person-name">Person name</label>
+          <input
+            id="detail-face-person-name"
+            aria-label="Person name"
+            value={personDraft}
+            onChange={(event) => {
+              setPersonDraft(event.target.value);
+              setError(null);
+              setMessage(null);
+            }}
+            disabled={isSubmitting}
+          />
+
+          <label htmlFor="detail-face-person-suggestions">Person suggestions</label>
+          <select
+            id="detail-face-person-suggestions"
+            aria-label="Person suggestions"
+            value={selectedPersonId}
+            disabled={isSubmitting}
+            onChange={(event) => {
+              setSelectedPersonId(event.target.value);
+              setError(null);
+              setMessage(null);
+            }}
+          >
+            <option value="">Select person</option>
+            {orderedPeople.map((person) => (
+              <option key={person.person_id} value={person.person_id}>
+                {person.display_name}
+              </option>
+            ))}
+          </select>
+
+          <button type="button" disabled={!canApply} onClick={() => void applySelection()}>
+            {createCandidate && selectedPersonId.length === 0
+              ? `Create and assign "${createCandidate}"`
+              : "Assign selected person"}
+          </button>
+
+          {message ? <p className="detail-face-correction-provenance">{message}</p> : null}
+          {error ? <p className="detail-face-assignment-error">{error}</p> : null}
+
+          <dl className="detail-face-provenance-details" aria-label={`Provenance details for face ${selectedFace.sequence}`}>
+            <div>
+              <dt>Source</dt>
+              <dd>{provenanceSourceLabel(selectedFace.label_source)}</dd>
+            </div>
+            <div>
+              <dt>Action</dt>
+              <dd>{readProvenanceValue(selectedFace, "action")}</dd>
+            </div>
+            <div>
+              <dt>Surface</dt>
+              <dd>{readProvenanceValue(selectedFace, "surface")}</dd>
+            </div>
+            <div>
+              <dt>Workflow</dt>
+              <dd>{readProvenanceValue(selectedFace, "workflow")}</dd>
+            </div>
+            <div>
+              <dt>Model version</dt>
+              <dd>{selectedFace.model_version ?? NOT_AVAILABLE}</dd>
+            </div>
+            <div>
+              <dt>Confidence</dt>
+              <dd>{formatConfidence(selectedFace.confidence)}</dd>
+            </div>
+            <div>
+              <dt>Recorded</dt>
+              <dd>{formatRecordedTimestamp(selectedFace.label_recorded_ts)}</dd>
+            </div>
+          </dl>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/ui/src/pages/library/LibraryPhotoFacePanel.tsx
+++ b/apps/ui/src/pages/library/LibraryPhotoFacePanel.tsx
@@ -1,15 +1,21 @@
 import { useMemo, useState } from "react";
+import {
+  buildFaceOverlayRegions,
+  FaceBBoxOverlay,
+  type FaceLabelSource,
+  type FaceOverlayRegion
+} from "../FaceBBoxOverlay";
 import { FaceAssignmentControls } from "../FaceAssignmentControls";
 import type { FaceAssignmentFace, FaceAssignmentPerson } from "../FaceAssignmentControls";
 import type { LibraryPhoto } from "./libraryRouteTypes";
-
-type FaceLabelSource = "human_confirmed" | "machine_applied" | "machine_suggested" | null;
 
 type FaceRegion = FaceAssignmentFace & {
   bbox_x: number | null;
   bbox_y: number | null;
   bbox_w: number | null;
   bbox_h: number | null;
+  bbox_space_width?: number | null;
+  bbox_space_height?: number | null;
 };
 
 type PhotoDetailPayload = {
@@ -22,59 +28,6 @@ type PhotoDetailPayload = {
     data_base64: string;
   } | null;
 };
-
-type FaceOverlayRegion = {
-  faceId: string;
-  personId: string | null;
-  labelSource: FaceLabelSource;
-  leftPercent: number;
-  topPercent: number;
-  widthPercent: number;
-  heightPercent: number;
-};
-
-type FaceBBox = {
-  bbox_x: number | null;
-  bbox_y: number | null;
-  bbox_w: number | null;
-  bbox_h: number | null;
-};
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
-
-function inferFaceOverlayCoordinateSpace(
-  faces: FaceBBox[],
-  thumbnailWidth: number,
-  thumbnailHeight: number
-): { width: number; height: number } {
-  // Face coordinates are stored in source-image pixels; use detected extents when thumbnail space is smaller.
-  const coordinateSpace = faces.reduce(
-    (acc, face) => {
-      if (
-        face.bbox_x === null ||
-        face.bbox_y === null ||
-        face.bbox_w === null ||
-        face.bbox_h === null ||
-        face.bbox_w <= 0 ||
-        face.bbox_h <= 0
-      ) {
-        return acc;
-      }
-
-      acc.width = Math.max(acc.width, face.bbox_x + face.bbox_w);
-      acc.height = Math.max(acc.height, face.bbox_y + face.bbox_h);
-      return acc;
-    },
-    { width: thumbnailWidth, height: thumbnailHeight }
-  );
-
-  return {
-    width: Math.max(coordinateSpace.width, thumbnailWidth),
-    height: Math.max(coordinateSpace.height, thumbnailHeight)
-  };
-}
 
 function provenanceBadgeIcon(source: FaceLabelSource): string {
   if (source === "human_confirmed") {
@@ -151,45 +104,11 @@ function buildOverlayRegions(payload: PhotoDetailPayload | null): FaceOverlayReg
     return [];
   }
 
-  const thumbnailWidth = payload.thumbnail.width;
-  const thumbnailHeight = payload.thumbnail.height;
-  const coordinateSpace = inferFaceOverlayCoordinateSpace(payload.faces, thumbnailWidth, thumbnailHeight);
-
-  return payload.faces
-    .map((face) => {
-      if (
-        face.bbox_x === null ||
-        face.bbox_y === null ||
-        face.bbox_w === null ||
-        face.bbox_h === null ||
-        face.bbox_w <= 0 ||
-        face.bbox_h <= 0
-      ) {
-        return null;
-      }
-
-      const left = clamp((face.bbox_x / coordinateSpace.width) * 100, 0, 100);
-      const top = clamp((face.bbox_y / coordinateSpace.height) * 100, 0, 100);
-      const right = clamp(((face.bbox_x + face.bbox_w) / coordinateSpace.width) * 100, 0, 100);
-      const bottom = clamp(((face.bbox_y + face.bbox_h) / coordinateSpace.height) * 100, 0, 100);
-      const width = right - left;
-      const height = bottom - top;
-
-      if (width <= 0 || height <= 0) {
-        return null;
-      }
-
-      return {
-        faceId: face.face_id,
-        personId: face.person_id,
-        labelSource: face.label_source ?? null,
-        leftPercent: left,
-        topPercent: top,
-        widthPercent: width,
-        heightPercent: height
-      };
-    })
-    .filter((region): region is FaceOverlayRegion => region !== null);
+  return buildFaceOverlayRegions(
+    payload.faces,
+    payload.thumbnail.width,
+    payload.thumbnail.height
+  );
 }
 
 async function fetchPhotoDetail(photoId: string): Promise<PhotoDetailPayload> {
@@ -384,34 +303,22 @@ export function LibraryPhotoFacePanel({ photo }: LibraryPhotoFacePanelProps) {
                       height={detail.thumbnail.height}
                       alt={`Preview for ${detail.photo_id}`}
                     />
-                    {overlayRegions.length > 0 ? (
-                      <ol className="detail-face-overlay-list" aria-label="Detected face regions">
-                        {overlayRegions.map((region, index) => (
-                          <li
-                            key={region.faceId}
-                            className="detail-face-overlay"
-                            aria-label={`Face region ${index + 1}${region.personId ? ` for ${region.personId}` : ""}`}
-                            style={{
-                              left: `${region.leftPercent}%`,
-                              top: `${region.topPercent}%`,
-                              width: `${region.widthPercent}%`,
-                              height: `${region.heightPercent}%`
-                            }}
-                          >
-                            <button
-                              type="button"
-                              className="detail-face-overlay-provenance-button"
-                              aria-label={`Show provenance details for face region ${index + 1}`}
-                              onClick={() => {
-                                setRequestedExpandedProvenanceFaceId(region.faceId);
-                              }}
-                            >
-                              {provenanceBadgeIcon(region.labelSource)}
-                            </button>
-                          </li>
-                        ))}
-                      </ol>
-                    ) : null}
+                    <FaceBBoxOverlay
+                      regions={overlayRegions}
+                      ariaLabel="Detected face regions"
+                      renderRegionContent={(region, index) => (
+                        <button
+                          type="button"
+                          className="detail-face-overlay-provenance-button"
+                          aria-label={`Show provenance details for face region ${index + 1}`}
+                          onClick={() => {
+                            setRequestedExpandedProvenanceFaceId(region.faceId);
+                          }}
+                        >
+                          {provenanceBadgeIcon(region.labelSource)}
+                        </button>
+                      )}
+                    />
                   </div>
                 </div>
               ) : (

--- a/apps/ui/src/pages/library/LibraryPhotoGrid.tsx
+++ b/apps/ui/src/pages/library/LibraryPhotoGrid.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { deriveIngestStatus, INGEST_STATUS_LEGEND } from "../../app/ingestStatus";
+import {
+  buildFaceOverlayRegions,
+  FaceBBoxOverlay,
+  type FaceBBoxOverlayFace
+} from "../FaceBBoxOverlay";
 import { LibraryPhotoFacePanel } from "./LibraryPhotoFacePanel";
 import { PhotoResultIdentity } from "./PhotoResultIdentity";
 import {
@@ -19,117 +24,14 @@ interface LibraryPhotoGridProps {
   onToggleSelection: (photoId: string) => void;
 }
 
-type FaceLabelSource = "human_confirmed" | "machine_applied" | "machine_suggested" | null;
-
-type FaceBBox = {
-  face_id: string;
-  person_id: string | null;
-  bbox_x: number | null;
-  bbox_y: number | null;
-  bbox_w: number | null;
-  bbox_h: number | null;
-  label_source?: FaceLabelSource;
-};
-
 type PhotoFaceDetailPayload = {
   photo_id: string;
-  faces: FaceBBox[];
-};
-
-type FaceOverlayRegion = {
-  faceId: string;
-  personId: string | null;
-  leftPercent: number;
-  topPercent: number;
-  widthPercent: number;
-  heightPercent: number;
+  faces: FaceBBoxOverlayFace[];
 };
 
 const INGEST_STATUS_LEGEND_TOOLTIP = INGEST_STATUS_LEGEND
   .map((entry) => `${entry.label}: ${entry.description}`)
   .join("\n");
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
-
-function inferFaceOverlayCoordinateSpace(
-  faces: FaceBBox[],
-  thumbnailWidth: number,
-  thumbnailHeight: number
-): { width: number; height: number } {
-  const coordinateSpace = faces.reduce(
-    (acc, face) => {
-      if (
-        face.bbox_x === null ||
-        face.bbox_y === null ||
-        face.bbox_w === null ||
-        face.bbox_h === null ||
-        face.bbox_w <= 0 ||
-        face.bbox_h <= 0
-      ) {
-        return acc;
-      }
-
-      acc.width = Math.max(acc.width, face.bbox_x + face.bbox_w);
-      acc.height = Math.max(acc.height, face.bbox_y + face.bbox_h);
-      return acc;
-    },
-    { width: thumbnailWidth, height: thumbnailHeight }
-  );
-
-  return {
-    width: Math.max(coordinateSpace.width, thumbnailWidth),
-    height: Math.max(coordinateSpace.height, thumbnailHeight)
-  };
-}
-
-function buildOverlayRegions(
-  faces: FaceBBox[],
-  thumbnailWidth: number,
-  thumbnailHeight: number
-): FaceOverlayRegion[] {
-  if (thumbnailWidth <= 0 || thumbnailHeight <= 0) {
-    return [];
-  }
-
-  const coordinateSpace = inferFaceOverlayCoordinateSpace(faces, thumbnailWidth, thumbnailHeight);
-
-  return faces
-    .map((face) => {
-      if (
-        face.bbox_x === null ||
-        face.bbox_y === null ||
-        face.bbox_w === null ||
-        face.bbox_h === null ||
-        face.bbox_w <= 0 ||
-        face.bbox_h <= 0
-      ) {
-        return null;
-      }
-
-      const left = clamp((face.bbox_x / coordinateSpace.width) * 100, 0, 100);
-      const top = clamp((face.bbox_y / coordinateSpace.height) * 100, 0, 100);
-      const right = clamp(((face.bbox_x + face.bbox_w) / coordinateSpace.width) * 100, 0, 100);
-      const bottom = clamp(((face.bbox_y + face.bbox_h) / coordinateSpace.height) * 100, 0, 100);
-      const width = right - left;
-      const height = bottom - top;
-
-      if (width <= 0 || height <= 0) {
-        return null;
-      }
-
-      return {
-        faceId: face.face_id,
-        personId: face.person_id,
-        leftPercent: left,
-        topPercent: top,
-        widthPercent: width,
-        heightPercent: height
-      };
-    })
-    .filter((region): region is FaceOverlayRegion => region !== null);
-}
 
 export function LibraryPhotoGrid({
   photos,
@@ -206,7 +108,7 @@ export function LibraryPhotoGrid({
         const detailPayload = photoFaceDetails[photo.photo_id] ?? null;
         const overlayRegions =
           showFaceBoxesForPhoto && photo.thumbnail && detailPayload
-            ? buildOverlayRegions(
+            ? buildFaceOverlayRegions(
                 detailPayload.faces,
                 photo.thumbnail.width,
                 photo.thumbnail.height
@@ -267,26 +169,10 @@ export function LibraryPhotoGrid({
                   height={photo.thumbnail.height}
                   alt={`Preview of ${photo.path}`}
                 />
-                {overlayRegions.length > 0 ? (
-                  <ol
-                    className="detail-face-overlay-list"
-                    aria-label={`Detected face regions for ${photo.photo_id}`}
-                  >
-                    {overlayRegions.map((region, index) => (
-                      <li
-                        key={region.faceId}
-                        className="detail-face-overlay"
-                        aria-label={`Face region ${index + 1}${region.personId ? ` for ${region.personId}` : ""}`}
-                        style={{
-                          left: `${region.leftPercent}%`,
-                          top: `${region.topPercent}%`,
-                          width: `${region.widthPercent}%`,
-                          height: `${region.heightPercent}%`
-                        }}
-                      />
-                    ))}
-                  </ol>
-                ) : null}
+                <FaceBBoxOverlay
+                  regions={overlayRegions}
+                  ariaLabel={`Detected face regions for ${photo.photo_id}`}
+                />
               </Link>
             ) : (
               <div className="browse-thumbnail browse-thumbnail-placeholder" aria-hidden="true">

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -627,10 +627,24 @@ body {
   text-decoration: none;
 }
 
-.detail-layout {
+.detail-workspace {
+  position: relative;
+}
+
+.detail-preview-panel {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.7rem;
+  background: #ffffff;
+  padding: 0.75rem;
   display: grid;
-  gap: 0.85rem;
-  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+  gap: 0.55rem;
+  min-height: 22rem;
+}
+
+.detail-preview-panel h2 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1rem;
 }
 
 .detail-panel {
@@ -701,6 +715,27 @@ body {
   background: #dbeafe;
 }
 
+.detail-photo-scale {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #334155;
+  font-size: 0.8rem;
+}
+
+.detail-photo-scale input {
+  width: 9rem;
+}
+
+.detail-ingest-inline {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #334155;
+  font-size: 0.8rem;
+}
+
 .detail-media-frame {
   border: 1px solid #cbd5e1;
   border-radius: 0.55rem;
@@ -718,7 +753,7 @@ body {
 
 .detail-media-stage {
   position: relative;
-  width: 100%;
+  min-width: 5rem;
 }
 
 .detail-media-image {
@@ -727,16 +762,6 @@ body {
   height: auto;
   border-radius: 0.35rem;
   background: #e2e8f0;
-}
-
-.detail-media-frame[data-mode="actual"] .detail-media-stage {
-  width: fit-content;
-  max-width: none;
-}
-
-.detail-media-frame[data-mode="actual"] .detail-media-image {
-  width: auto;
-  max-width: none;
 }
 
 .detail-face-overlay-list {
@@ -787,6 +812,129 @@ body {
   gap: 0.35rem;
   color: #334155;
   font-size: 0.8rem;
+}
+
+.detail-flyout-backdrop {
+  display: none;
+}
+
+.detail-flyout {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(27rem, 92vw);
+  height: 100vh;
+  background: #ffffff;
+  border-left: 1px solid #cbd5e1;
+  box-shadow: -8px 0 24px rgb(15 23 42 / 14%);
+  z-index: 30;
+  transform: translateX(102%);
+  transition: transform 160ms ease;
+  padding: 0.8rem;
+  display: grid;
+  align-content: start;
+  gap: 0.7rem;
+  overflow-y: auto;
+}
+
+.detail-flyout.is-open {
+  transform: translateX(0);
+}
+
+.detail-flyout-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.55rem;
+}
+
+.detail-flyout-header h2 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1rem;
+}
+
+.detail-flyout-header button {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.28rem 0.52rem;
+  font: inherit;
+}
+
+.detail-face-actions {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.7rem;
+  background: #ffffff;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.detail-face-actions h3 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 0.96rem;
+}
+
+.detail-face-action-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.detail-face-action-list button {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #334155;
+  border-radius: 999px;
+  font: inherit;
+  font-size: 0.8rem;
+  padding: 0.25rem 0.55rem;
+}
+
+.detail-face-action-list button.is-active {
+  border-color: #1d4ed8;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.detail-face-actions-body {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.detail-face-actions-body p {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #334155;
+}
+
+.detail-face-actions-body label {
+  color: #475569;
+  font-size: 0.78rem;
+}
+
+.detail-face-actions-body input,
+.detail-face-actions-body select {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  padding: 0.36rem 0.5rem;
+  font: inherit;
+}
+
+.detail-face-actions-body button {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.38rem 0.62rem;
+  font: inherit;
+  width: fit-content;
 }
 
 .detail-face-assignment {
@@ -1670,5 +1818,20 @@ body {
 
   .search-location-row {
     grid-template-columns: auto minmax(8rem, 1fr);
+  }
+
+  .detail-flyout {
+    width: 100vw;
+  }
+
+  .detail-flyout-backdrop.is-open {
+    display: block;
+    position: fixed;
+    inset: 0;
+    border: 0;
+    background: rgb(15 23 42 / 35%);
+    z-index: 20;
+    padding: 0;
+    margin: 0;
   }
 }


### PR DESCRIPTION
## Summary
- rework photo detail into a photo-first workspace with details moved into a flyout panel
- remove the ingest status legend from photo detail while keeping ingest status visible in-context
- add reusable face overlay mapping utilities with explicit coordinate-space support
- add face-badge triggered face actions with suggestion-first person selection and create-and-assign fallback
- align API/UI face bbox contracts to include optional bbox coordinate-space dimensions and cover with tests

## Why
- maximize available screen space for the photo itself
- reduce on-screen clutter by regrouping metadata/actions in a flyout
- make face assignment faster from the preview surface and support both existing and new people workflows

## Validation
- `npm --prefix apps/ui test -- PhotoDetailRoutePage.test.tsx FaceAssignmentControls.test.tsx`
- `npm --prefix apps/ui run test:coverage`
- `make test-all`

## Coverage gates
- UI coverage thresholds pass (`statements` and `lines` >= 80%)
- API coverage gate pass (`Required test coverage of 80.0% reached`)
