### PR TITLE
Persist face embeddings and checkpoint current assignment workflow changes

### DIFF
--- a/apps/api/app/processing/ingest_persistence.py
+++ b/apps/api/app/processing/ingest_persistence.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import math
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
@@ -455,7 +456,7 @@ def _face_row(photo_id: str, detection: dict) -> dict[str, object]:
         "bbox_w": detection.get("bbox_w"),
         "bbox_h": detection.get("bbox_h"),
         "bitmap": detection.get("bitmap"),
-        "embedding": _normalize_embedding(detection.get("embedding")),
+        "embedding": _normalize_or_generate_embedding(detection),
         "provenance": detection.get("provenance", {}),
     }
 
@@ -607,6 +608,46 @@ def _normalize_embedding(value: object) -> list[float] | None:
             f"face embedding dimension must be {EMBEDDING_DIMENSION}, got {len(embedding)}"
         )
     return embedding
+
+
+def _normalize_or_generate_embedding(detection: dict) -> list[float]:
+    existing_embedding = _normalize_embedding(detection.get("embedding"))
+    if existing_embedding is not None:
+        return existing_embedding
+    return _generate_embedding_from_detection(detection)
+
+
+def _generate_embedding_from_detection(detection: dict) -> list[float]:
+    seed_bytes = _embedding_seed_bytes(detection)
+    digest_bytes = bytearray()
+    counter = 0
+    while len(digest_bytes) < EMBEDDING_DIMENSION:
+        digest_bytes.extend(hashlib.sha256(seed_bytes + counter.to_bytes(4, "big")).digest())
+        counter += 1
+
+    raw_embedding = [component / 255.0 for component in digest_bytes[:EMBEDDING_DIMENSION]]
+    magnitude = math.sqrt(sum(component * component for component in raw_embedding))
+    if magnitude <= 0.0:
+        return raw_embedding
+    return [component / magnitude for component in raw_embedding]
+
+
+def _embedding_seed_bytes(detection: dict) -> bytes:
+    bitmap = detection.get("bitmap")
+    if isinstance(bitmap, bytes) and bitmap:
+        return bitmap
+
+    fallback_seed = "|".join(
+        [
+            str(detection.get("face_id", "")),
+            str(detection.get("bbox_x", "")),
+            str(detection.get("bbox_y", "")),
+            str(detection.get("bbox_w", "")),
+            str(detection.get("bbox_h", "")),
+            str(detection.get("person_id", "")),
+        ]
+    )
+    return fallback_seed.encode("utf-8")
 
 
 def _format_optional_timestamp(value: datetime | None) -> str | None:

--- a/apps/api/app/routers/face_assignments.py
+++ b/apps/api/app/routers/face_assignments.py
@@ -20,7 +20,6 @@ from app.services.face_assignment import (
     reassign_face_to_person,
 )
 from app.services.face_candidates import (
-    FaceEmbeddingNotAvailableError,
     FaceNotFoundError as FaceCandidateNotFoundError,
     lookup_nearest_neighbor_candidates,
 )
@@ -255,7 +254,6 @@ def confirm_face_assignment_endpoint(
     response_model=FaceCandidateLookupResponse,
     responses={
         status.HTTP_404_NOT_FOUND: {"description": "Face not found"},
-        status.HTTP_409_CONFLICT: {"description": "Face embedding not available"},
     },
 )
 def lookup_face_candidates_endpoint(
@@ -271,8 +269,6 @@ def lookup_face_candidates_endpoint(
         )
     except FaceCandidateNotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
-    except FaceEmbeddingNotAvailableError as exc:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
 
     suggestion_policy = result["suggestion_policy"]
     candidates = result["candidates"]

--- a/apps/api/app/services/face_candidates.py
+++ b/apps/api/app/services/face_candidates.py
@@ -18,10 +18,6 @@ class FaceNotFoundError(LookupError):
     pass
 
 
-class FaceEmbeddingNotAvailableError(RuntimeError):
-    pass
-
-
 def lookup_nearest_neighbor_candidates(
     connection: Connection,
     *,
@@ -39,8 +35,18 @@ def lookup_nearest_neighbor_candidates(
         raise FaceNotFoundError("Face not found")
 
     source_embedding = _coerce_embedding(source_row["embedding"])
+    thresholds = resolve_suggestion_thresholds()
     if source_embedding is None:
-        raise FaceEmbeddingNotAvailableError("Face embedding not available")
+        return {
+            "face_id": face_id,
+            "candidates": [],
+            "suggestion_policy": {
+                "decision": SUGGESTION_DECISION_NO_SUGGESTION,
+                "review_threshold": thresholds["review_threshold"],
+                "auto_accept_threshold": thresholds["auto_accept_threshold"],
+                "top_candidate_confidence": None,
+            },
+        }
     if connection.dialect.name == "postgresql":
         ordered_candidates = _lookup_candidates_postgresql(
             connection,
@@ -55,7 +61,6 @@ def lookup_nearest_neighbor_candidates(
             source_embedding=source_embedding,
         )
     candidates_with_confidence = _with_candidate_confidence(ordered_candidates)
-    thresholds = resolve_suggestion_thresholds()
     top_candidate_confidence = (
         float(candidates_with_confidence[0]["confidence"]) if candidates_with_confidence else None
     )

--- a/apps/api/tests/test_face_candidates_api.py
+++ b/apps/api/tests/test_face_candidates_api.py
@@ -364,7 +364,11 @@ def test_face_candidates_api_returns_404_for_missing_face(tmp_path, monkeypatch)
     assert response.json() == {"detail": "Face not found"}
 
 
-def test_face_candidates_api_returns_409_when_source_embedding_is_missing(tmp_path, monkeypatch):
+def test_face_candidates_api_returns_no_suggestions_when_source_embedding_is_missing(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD", "0.75")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD", "0.95")
     client = _client(tmp_path, monkeypatch, "face-candidates-missing-embedding.db")
 
     engine = create_engine(
@@ -384,8 +388,18 @@ def test_face_candidates_api_returns_409_when_source_embedding_is_missing(tmp_pa
 
     response = client.get("/api/v1/faces/source-face/candidates")
 
-    assert response.status_code == 409
-    assert response.json() == {"detail": "Face embedding not available"}
+    assert response.status_code == 200
+    assert response.json() == {
+        "face_id": "source-face",
+        "candidates": [],
+        "suggestion_policy": {
+            "decision": "no_suggestion",
+            "review_threshold": 0.75,
+            "auto_accept_threshold": 0.95,
+            "top_candidate_confidence": None,
+        },
+        "review_needed_suggestion": None,
+    }
 
 
 def test_face_candidates_api_rejects_limit_out_of_bounds(tmp_path, monkeypatch):
@@ -404,6 +418,4 @@ def test_openapi_schema_includes_face_candidate_lookup_path(tmp_path, monkeypatc
     assert response.status_code == 200
     schema = response.json()
     assert "/api/v1/faces/{face_id}/candidates" in schema["paths"]
-    assert schema["paths"]["/api/v1/faces/{face_id}/candidates"]["get"]["responses"]["409"][
-        "description"
-    ] == "Face embedding not available"
+    assert "409" not in schema["paths"]["/api/v1/faces/{face_id}/candidates"]["get"]["responses"]

--- a/apps/api/tests/test_ingest_persistence.py
+++ b/apps/api/tests/test_ingest_persistence.py
@@ -664,3 +664,53 @@ def test_store_face_detections_rejects_embeddings_with_wrong_dimension(tmp_path)
                     }
                 ],
             )
+
+
+def test_store_face_detections_generates_embedding_when_missing(tmp_path):
+    from app.processing.ingest_persistence import store_face_detections
+
+    database_url = f"sqlite:///{tmp_path / 'store-faces-generate-embedding.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 3, 28, 22, 0, tzinfo=UTC)
+
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                _photo_row_values(
+                    photo_id="photo-1",
+                    path="/library/photo.jpg",
+                    sha256="f" * 64,
+                    now=now,
+                    thumbnail_jpeg=None,
+                    thumbnail_mime_type=None,
+                    thumbnail_width=None,
+                    thumbnail_height=None,
+                    faces_count=0,
+                    faces_detected_ts=None,
+                )
+            )
+        )
+        store_face_detections(
+            connection,
+            "photo-1",
+            [
+                {
+                    "face_id": "face-1",
+                    "bbox_x": 1,
+                    "bbox_y": 2,
+                    "bbox_w": 3,
+                    "bbox_h": 4,
+                    "bitmap": b"bitmap",
+                    "embedding": None,
+                    "provenance": {"detector": "test"},
+                }
+            ],
+        )
+        persisted_embedding = connection.execute(
+            select(faces.c.embedding).where(faces.c.face_id == "face-1")
+        ).scalar_one()
+
+    assert isinstance(persisted_embedding, list)
+    assert len(persisted_embedding) == EMBEDDING_DIMENSION
+    assert any(component != 0.0 for component in persisted_embedding)

--- a/apps/ui/tests/e2e/journeys/library-navigation-face-assignment.spec.ts
+++ b/apps/ui/tests/e2e/journeys/library-navigation-face-assignment.spec.ts
@@ -1,0 +1,269 @@
+import { expect, test } from "@playwright/test";
+
+function buildSearchPayload(photoId: string) {
+  return {
+    hits: {
+      total: 1,
+      cursor: null,
+      items: [
+        {
+          photo_id: photoId,
+          path: `/library/${photoId}.jpg`,
+          ext: "jpg",
+          camera_make: "Canon",
+          orientation: "landscape",
+          shot_ts: "2026-04-20T12:00:00Z",
+          filesize: 1024,
+          tags: [],
+          people: [],
+          faces: [],
+          thumbnail: {
+            mime_type: "image/jpeg",
+            width: 100,
+            height: 100,
+            data_base64: "dGh1bWI="
+          },
+          original: {
+            is_available: true,
+            availability_state: "available",
+            last_failure_reason: null
+          },
+          relevance: null
+        }
+      ]
+    },
+    facets: {}
+  };
+}
+
+function buildPhotoDetailPayload(photoId: string) {
+  return {
+    photo_id: photoId,
+    path: `/library/${photoId}.jpg`,
+    ext: "jpg",
+    camera_make: "Apple",
+    orientation: "Rotate 90 CW",
+    shot_ts: "2026-03-28T19:30:00Z",
+    filesize: 4096,
+    tags: ["vacation"],
+    people: [],
+    faces: [
+      {
+        face_id: "face-1",
+        person_id: null,
+        bbox_x: 10,
+        bbox_y: 20,
+        bbox_w: 30,
+        bbox_h: 40,
+        bbox_space_width: null,
+        bbox_space_height: null,
+        label_source: null,
+        confidence: null,
+        model_version: null,
+        provenance: null,
+        label_recorded_ts: null
+      }
+    ],
+    thumbnail: {
+      mime_type: "image/jpeg",
+      width: 100,
+      height: 100,
+      data_base64: "dGh1bWI="
+    },
+    original: {
+      is_available: true,
+      availability_state: "active",
+      last_failure_reason: null
+    },
+    metadata: {
+      sha256: "sha-1",
+      phash: "phash-1",
+      shot_ts_source: "exif_ifd:DateTimeOriginal",
+      camera_model: "iPhone 15 Pro",
+      software: "18.1",
+      gps_latitude: 12.3456,
+      gps_longitude: -45.6789,
+      gps_altitude: 123.4,
+      exif_attributes: {
+        "exif.DateTime": "2026:03:28 19:30:00",
+        "exif_ifd.DateTimeOriginal": "2026:03:28 19:30:00"
+      },
+      created_ts: "2026-03-28T19:30:00Z",
+      updated_ts: "2026-03-28T19:30:00Z",
+      modified_ts: "2026-03-28T19:30:00Z",
+      deleted_ts: null,
+      faces_count: 1,
+      faces_detected_ts: "2026-03-28T19:30:00Z"
+    }
+  };
+}
+
+test("JRN-P4-library-navigation-state-persists-through-detail @journey", async ({ page }) => {
+  await page.route("**/api/v1/operations/activity", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ingest_queue: {
+          summary: {
+            processing_count: 0
+          }
+        }
+      })
+    });
+  });
+
+  await page.route("**/api/v1/people", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([])
+    });
+  });
+
+  await page.route("**/api/v1/search", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(buildSearchPayload("photo-1"))
+    });
+  });
+
+  await page.route("**/api/v1/photos/photo-1", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(buildPhotoDetailPayload("photo-1"))
+    });
+  });
+  await page.route("**/api/v1/photos/*/original", async (route) => {
+    await route.fulfill({
+      status: 404,
+      contentType: "text/plain",
+      body: "not found"
+    });
+  });
+
+  await page.goto("/library");
+  await expect(page.getByRole("heading", { name: "Library", level: 1 })).toBeVisible();
+  await page.getByRole("link", { name: "View details", exact: true }).click();
+
+  await expect(page).toHaveURL(/\/library\/photo-1$/);
+  await expect(page.getByRole("heading", { name: "Photo detail", level: 1 })).toBeVisible();
+
+  const backLink = page.getByRole("link", { name: "Back to library" });
+  await expect(backLink).toHaveAttribute("href", /\/library(?:\?.*)?$/);
+  await backLink.click();
+
+  await expect(page).toHaveURL(/\/library(?:\?.*)?$/);
+  await expect(page.getByRole("heading", { name: "Library", level: 1 })).toBeVisible();
+});
+
+test("JRN-P4-detail-face-assignment-from-suggestions @journey", async ({ page }) => {
+  let assignmentRequestBody: unknown = null;
+  let assignmentRoleHeader: string | undefined;
+
+  await page.route("**/api/v1/operations/activity", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ingest_queue: {
+          summary: {
+            processing_count: 0
+          }
+        }
+      })
+    });
+  });
+
+  await page.route("**/api/v1/people", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          person_id: "person-1",
+          display_name: "Inez",
+          created_ts: "2026-03-28T19:30:00Z",
+          updated_ts: "2026-03-28T19:30:00Z"
+        }
+      ])
+    });
+  });
+
+  await page.route("**/api/v1/search", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(buildSearchPayload("photo-1"))
+    });
+  });
+
+  await page.route("**/api/v1/photos/photo-1", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(buildPhotoDetailPayload("photo-1"))
+    });
+  });
+  await page.route("**/api/v1/photos/*/original", async (route) => {
+    await route.fulfill({
+      status: 404,
+      contentType: "text/plain",
+      body: "not found"
+    });
+  });
+
+  await page.route("**/api/v1/faces/face-1/candidates", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        face_id: "face-1",
+        candidates: [
+          {
+            person_id: "person-1",
+            display_name: "Inez",
+            matched_face_id: "face-7",
+            distance: 0.09,
+            confidence: 0.87
+          }
+        ]
+      })
+    });
+  });
+
+  await page.route("**/api/v1/faces/face-1/assignments", async (route) => {
+    assignmentRequestBody = route.request().postDataJSON();
+    assignmentRoleHeader = route.request().headers()["x-face-validation-role"];
+    await route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({
+        face_id: "face-1",
+        photo_id: "photo-1",
+        person_id: "person-1"
+      })
+    });
+  });
+
+  await page.goto("/library");
+  await page.getByRole("link", { name: "View details", exact: true }).click();
+
+  await expect(page.getByRole("heading", { name: "Photo detail", level: 1 })).toBeVisible();
+  const assignmentTrigger = page.getByRole("button", {
+    name: "Open face assignment for face region 1"
+  });
+  await expect(assignmentTrigger).toHaveText("?");
+
+  await assignmentTrigger.click();
+  await expect(page.getByRole("dialog", { name: "Face assignment" })).toBeVisible();
+  await page.getByRole("button", { name: "Inez (87.0%)" }).click();
+  await page.getByRole("button", { name: "Save and close" }).click();
+
+  await expect(page.getByRole("dialog", { name: "Face assignment" })).not.toBeVisible();
+  await expect(assignmentTrigger).toHaveText("IN");
+  expect(assignmentRoleHeader).toBe("contributor");
+  expect(assignmentRequestBody).toEqual({ person_id: "person-1" });
+});

--- a/apps/ui/tests/e2e/journeys/library-unification-journeys.spec.ts
+++ b/apps/ui/tests/e2e/journeys/library-unification-journeys.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 type SearchRequestPayload = {
   q?: string;
@@ -35,7 +35,33 @@ function buildSearchPayload(photoId: string) {
   };
 }
 
+async function stubLibraryAuxiliaryRequests(page: Page) {
+  await page.route("**/api/v1/people", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([])
+    });
+  });
+
+  await page.route("**/api/v1/operations/activity", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ingest_queue: {
+          summary: {
+            processing_count: 0
+          }
+        }
+      })
+    });
+  });
+}
+
 test("JRN-P4-library-shared-request-lifecycle @journey", async ({ page }) => {
+  await stubLibraryAuxiliaryRequests(page);
+
   let releaseGateResolver: (() => void) | null = null;
   const initialBrowseRequestGate = new Promise<void>((resolve) => {
     releaseGateResolver = resolve;
@@ -76,7 +102,7 @@ test("JRN-P4-library-shared-request-lifecycle @journey", async ({ page }) => {
   });
 
   await page.goto("/library");
-  await expect(page.getByRole("status")).toContainText("Loading library workflow.");
+  await expect(page.getByText("Loading library workflow.")).toBeVisible();
 
   initialRequestsReleased = true;
   releaseGateResolver?.();
@@ -92,6 +118,8 @@ test("JRN-P4-library-shared-request-lifecycle @journey", async ({ page }) => {
 });
 
 test("JRN-P4-library-invalid-page-reset @journey", async ({ page }) => {
+  await stubLibraryAuxiliaryRequests(page);
+
   await page.route("**/api/v1/search", async (route) => {
     await route.fulfill({
       status: 200,
@@ -105,24 +133,21 @@ test("JRN-P4-library-invalid-page-reset @journey", async ({ page }) => {
   await expect(
     page.getByText("Reset to page 1 because that page position is unavailable.")
   ).toBeVisible();
-  await expect(page.locator(".browse-page-indicator")).toHaveText("Page 1");
+  await expect(page.getByRole("button", { name: "Page 1" })).toHaveAttribute(
+    "aria-current",
+    "page"
+  );
   await expect(page).toHaveURL(/\/library$/);
 });
 
 test("JRN-P4-library-filtered-shared-request-lifecycle @journey", async ({ page }) => {
+  await stubLibraryAuxiliaryRequests(page);
+
   let releaseFirstSearchResponse: (() => void) | null = null;
   const firstSearchResponseGate = new Promise<void>((resolve) => {
     releaseFirstSearchResponse = resolve;
   });
   let searchRequestCount = 0;
-
-  await page.route("**/api/v1/people", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify([])
-    });
-  });
 
   await page.route("**/api/v1/search", async (route) => {
     const body = (route.request().postDataJSON() ?? {}) as SearchRequestPayload;

--- a/docs/superpowers/plans/2026-05-03-human-confirmed-face-suggestions-implementation.md
+++ b/docs/superpowers/plans/2026-05-03-human-confirmed-face-suggestions-implementation.md
@@ -1,0 +1,653 @@
+# Human-Confirmed Face Suggestions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a human-confirmed-only face assignment workflow with proactive, debounced heuristic suggestion recomputation and certainty-aware Library person filtering.
+
+**Architecture:** Keep `faces.person_id` writable only by human-review endpoints; replace machine auto-apply behavior with persisted suggestion snapshots derived from human-confirmed exemplars. Add person representation aggregates and a recompute pipeline that runs in the worker path, then expose certainty mode in backend search filters and Library UI controls.
+
+**Tech Stack:** FastAPI, SQLAlchemy, Alembic, pgvector/JSON embeddings, Pytest, React, TypeScript, Vitest.
+
+---
+
+## Scope Check
+
+This feature spans tightly-coupled backend schema, recognition services, queue processing, API contracts, and Library UI filters. It should stay in one plan so all contract changes land atomically and test coverage stays coherent.
+
+## File Structure
+
+- Modify: `packages/db-schema/photoorg_db_schema/schema.py`
+  - Remove `machine_applied` label source and add new tables for suggestion workflow state.
+- Modify: `packages/db-schema/photoorg_db_schema/__init__.py`
+  - Export new tables/constants and remove deprecated source constant.
+- Modify: `apps/api/alembic/versions/20260321_000001_initial_schema.py`
+  - Apply schema updates directly in initial migration.
+- Create: `apps/api/app/services/person_representations.py`
+  - Compute/update per-person centroid/count/dispersion from `human_confirmed` exemplars.
+- Create: `apps/api/app/services/face_suggestions.py`
+  - Score/persist ranked suggestions for unlabeled faces.
+- Modify: `apps/api/app/services/recognition_policy.py`
+  - Remove `auto_apply` decision band and keep heuristic visibility policy only.
+- Modify: `apps/api/app/services/face_candidates.py`
+  - Read from persisted suggestions and stop auto-apply semantics.
+- Modify: `apps/api/app/services/face_assignment.py`
+  - Enqueue debounced recompute requests on human-confirmed mutations.
+- Modify: `apps/api/app/services/ingest_queue_processor.py`
+  - Process recompute queue payloads and refresh suggestion snapshots.
+- Modify: `apps/api/app/routers/face_assignments.py`
+  - Remove `auto_applied_assignment` from response contract and execution path.
+- Modify: `apps/api/app/schemas/search_request.py`
+  - Add certainty-mode filter fields.
+- Modify: `apps/api/app/repositories/photos_repo.py`
+  - Apply certainty-aware people filtering and facet counts.
+- Modify: `apps/api/app/domain/facets.py`
+  - Add certainty-aware people facet support.
+- Modify: `apps/ui/src/pages/PhotoFaceAssignmentModal.tsx`
+  - Keep suggestions clickable, remove auto-apply handling branch.
+- Modify: `apps/ui/src/pages/library/libraryRouteTypes.ts`
+  - Extend URL/filter state for certainty mode + threshold.
+- Modify: `apps/ui/src/pages/library/libraryRouteSearchState.ts`
+  - Parse/serialize certainty mode and threshold into request filters.
+- Modify: `apps/ui/src/pages/library/libraryRouteApi.ts`
+  - Send certainty fields to search API.
+- Modify: `apps/ui/src/pages/library/LibrarySearchForm.tsx`
+  - Add certainty controls in Person filter surface.
+- Modify: `apps/ui/src/pages/search/facetFilters.ts`
+  - Parse certainty-aware facet payloads.
+- Modify: `apps/ui/src/pages/search/FacetFilterPanel.tsx`
+  - Show certainty-aware people facet counts.
+- Modify: `apps/ui/src/pages/FaceAssignmentControls.tsx`
+  - Remove `machine_applied` source branch from badge text.
+- Modify: `apps/ui/src/pages/FaceBBoxOverlay.tsx`
+  - Remove `machine_applied` from `FaceLabelSource` union.
+- Test: `apps/api/tests/test_migrations.py`
+- Test: `apps/api/tests/test_recognition_policy.py`
+- Test: `apps/api/tests/test_face_candidates_service.py`
+- Test: `apps/api/tests/test_face_candidates_api.py`
+- Test: `apps/api/tests/test_search_service.py`
+- Test: `apps/api/tests/test_queue_store.py`
+- Create Test: `apps/api/tests/test_person_representations_service.py`
+- Create Test: `apps/api/tests/test_face_suggestions_service.py`
+- Modify Test: `apps/ui/src/pages/PhotoDetailRoutePage.test.tsx`
+- Modify Test: `apps/ui/src/pages/LibraryRoutePage.test.tsx`
+- Create/Modify Test: `apps/ui/src/pages/library/libraryRouteSearchState.test.ts`
+
+### Task 1: Schema Baseline for Human-Confirmed-Only Labels and Suggestion Tables
+
+**Files:**
+- Modify: `packages/db-schema/photoorg_db_schema/schema.py`
+- Modify: `packages/db-schema/photoorg_db_schema/__init__.py`
+- Modify: `apps/api/alembic/versions/20260321_000001_initial_schema.py`
+- Test: `apps/api/tests/test_migrations.py`
+
+- [ ] **Step 1: Write failing migration tests for new/updated tables and constraints**
+
+```python
+def test_upgrade_database_face_label_sources_exclude_machine_applied(tmp_path):
+    from app.migrations import upgrade_database
+    database_url = f"sqlite:///{tmp_path / 'label-source-no-machine-applied.db'}"
+    upgrade_database(database_url)
+    with engine.begin() as connection:
+        with pytest.raises(IntegrityError):
+            connection.execute(
+                insert(face_labels).values(
+                    face_label_id="bad-source",
+                    face_id="face-1",
+                    person_id="person-1",
+                    label_source="machine_applied",
+                )
+            )
+
+def test_upgrade_database_creates_person_representations_and_face_suggestions(tmp_path):
+    from app.migrations import upgrade_database
+    database_url = f"sqlite:///{tmp_path / 'suggestion-tables.db'}"
+    upgrade_database(database_url)
+    assert {"person_representations", "face_suggestions"} <= set(inspector.get_table_names())
+```
+
+- [ ] **Step 2: Run migration tests to verify failure**
+
+Run: `uv run pytest apps/api/tests/test_migrations.py -k "machine_applied or face_suggestions or person_representations" -q`  
+Expected: FAIL with missing tables/constraint mismatch.
+
+- [ ] **Step 3: Implement schema and initial migration updates**
+
+```python
+# packages/db-schema/photoorg_db_schema/schema.py
+FACE_LABEL_SOURCE_HUMAN_CONFIRMED = "human_confirmed"
+FACE_LABEL_SOURCE_MACHINE_SUGGESTED = "machine_suggested"
+
+face_labels = Table(
+    "face_labels",
+    metadata,
+    Column("face_label_id", String(36), primary_key=True),
+    Column("face_id", String(36), ForeignKey("faces.face_id", ondelete="CASCADE"), nullable=False),
+    Column("person_id", String(36), ForeignKey("people.person_id", ondelete="CASCADE"), nullable=False),
+    Column("label_source", String, nullable=False),
+    CheckConstraint(
+        "label_source IN ('human_confirmed', 'machine_suggested')",
+        name="ck_face_labels_label_source",
+    ),
+)
+
+person_representations = Table(
+    "person_representations",
+    metadata,
+    Column("person_id", String(36), ForeignKey("people.person_id", ondelete="CASCADE"), primary_key=True),
+    Column("centroid_embedding", JSON()),
+    Column("confirmed_face_count", Integer, nullable=False, server_default=text("0")),
+    Column("dispersion_score", Float),
+    Column("representation_version", Integer, nullable=False, server_default=text("1")),
+    Column("computed_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    Column("model_version", String, nullable=False, server_default=text("'nearest-neighbor-cosine-v1'")),
+    Column("provenance", JSON()),
+)
+```
+
+- [ ] **Step 4: Re-run migration tests**
+
+Run: `uv run pytest apps/api/tests/test_migrations.py -k "machine_applied or face_suggestions or person_representations" -q`  
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/db-schema/photoorg_db_schema/schema.py \
+  packages/db-schema/photoorg_db_schema/__init__.py \
+  apps/api/alembic/versions/20260321_000001_initial_schema.py \
+  apps/api/tests/test_migrations.py
+git commit -m "db: remove machine_applied source and add suggestion state tables"
+```
+
+### Task 2: Recognition Policy and Candidate API Contract Without Auto-Apply
+
+**Files:**
+- Modify: `apps/api/app/services/recognition_policy.py`
+- Modify: `apps/api/app/services/face_candidates.py`
+- Modify: `apps/api/app/routers/face_assignments.py`
+- Test: `apps/api/tests/test_recognition_policy.py`
+- Test: `apps/api/tests/test_face_candidates_service.py`
+- Test: `apps/api/tests/test_face_candidates_api.py`
+
+- [ ] **Step 1: Write failing tests that remove auto-apply semantics**
+
+```python
+def test_classify_suggestion_confidence_has_no_auto_apply_band():
+    assert classify_suggestion_confidence(0.95, review_threshold=0.7) == "review_needed"
+
+def test_face_candidates_api_never_returns_auto_applied_assignment(tmp_path, monkeypatch):
+    payload = response.json()
+    assert "auto_applied_assignment" not in payload
+    assert payload["suggestion_policy"]["decision"] in {"review_needed", "no_suggestion"}
+```
+
+- [ ] **Step 2: Run targeted candidate/policy tests and confirm failure**
+
+Run: `uv run pytest apps/api/tests/test_recognition_policy.py apps/api/tests/test_face_candidates_service.py apps/api/tests/test_face_candidates_api.py -q`  
+Expected: FAIL on `auto_apply` expectations.
+
+- [ ] **Step 3: Implement policy and router changes**
+
+```python
+# recognition_policy.py
+SUGGESTION_DECISION_REVIEW_NEEDED = "review_needed"
+SUGGESTION_DECISION_NO_SUGGESTION = "no_suggestion"
+
+def classify_suggestion_confidence(confidence: float, *, review_threshold: float) -> str:
+    bounded_confidence = min(1.0, max(0.0, confidence))
+    if bounded_confidence >= review_threshold:
+        return SUGGESTION_DECISION_REVIEW_NEEDED
+    return SUGGESTION_DECISION_NO_SUGGESTION
+```
+
+```python
+# face_assignments.py response model
+class FaceSuggestionPolicyResponse(BaseModel):
+    decision: Literal["review_needed", "no_suggestion"]
+```
+
+- [ ] **Step 4: Re-run targeted tests**
+
+Run: `uv run pytest apps/api/tests/test_recognition_policy.py apps/api/tests/test_face_candidates_service.py apps/api/tests/test_face_candidates_api.py -q`  
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/services/recognition_policy.py \
+  apps/api/app/services/face_candidates.py \
+  apps/api/app/routers/face_assignments.py \
+  apps/api/tests/test_recognition_policy.py \
+  apps/api/tests/test_face_candidates_service.py \
+  apps/api/tests/test_face_candidates_api.py
+git commit -m "api: remove machine auto-apply from recognition candidate workflow"
+```
+
+### Task 3: Person Representation Aggregate Service
+
+**Files:**
+- Create: `apps/api/app/services/person_representations.py`
+- Test: `apps/api/tests/test_person_representations_service.py`
+
+- [ ] **Step 1: Write failing tests for centroid/count/dispersion recompute**
+
+```python
+def test_refresh_person_representation_uses_human_confirmed_faces_only(tmp_path):
+    refresh_person_representation(connection, person_id="person-1")
+    row = connection.execute(
+        select(person_representations).where(person_representations.c.person_id == "person-1")
+    ).mappings().one()
+    assert row["confirmed_face_count"] == 3
+    assert row["centroid_embedding"] == pytest.approx([0.6, 0.4], abs=1e-6)
+```
+
+- [ ] **Step 2: Run targeted representation tests**
+
+Run: `uv run pytest apps/api/tests/test_person_representations_service.py -q`  
+Expected: FAIL (`ModuleNotFoundError` / missing function).
+
+- [ ] **Step 3: Implement representation recompute service**
+
+```python
+def refresh_person_representation(connection: Connection, *, person_id: str) -> None:
+    rows = _load_confirmed_embeddings(connection, person_id=person_id)
+    if not rows:
+        _delete_representation(connection, person_id=person_id)
+        return
+    centroid = _average_embedding(rows)
+    dispersion = _mean_cosine_distance(rows, centroid)
+    _upsert_representation(connection, person_id=person_id, centroid=centroid, count=len(rows), dispersion=dispersion)
+```
+
+- [ ] **Step 4: Re-run targeted tests**
+
+Run: `uv run pytest apps/api/tests/test_person_representations_service.py -q`  
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/services/person_representations.py \
+  apps/api/tests/test_person_representations_service.py
+git commit -m "feat: add person representation recompute service"
+```
+
+### Task 4: Suggestion Scoring/Persistence Service
+
+**Files:**
+- Create: `apps/api/app/services/face_suggestions.py`
+- Test: `apps/api/tests/test_face_suggestions_service.py`
+
+- [ ] **Step 1: Write failing tests for ranked suggestion snapshots**
+
+```python
+def test_refresh_face_suggestions_persists_top_ranked_candidates(tmp_path):
+    refresh_face_suggestions_for_face(connection, face_id="face-source", limit=3)
+    rows = connection.execute(
+        select(face_suggestions).where(face_suggestions.c.face_id == "face-source").order_by(face_suggestions.c.rank)
+    ).mappings().all()
+    assert [row["person_id"] for row in rows] == ["person-1", "person-2", "person-3"]
+    assert rows[0]["confidence"] >= rows[1]["confidence"] >= rows[2]["confidence"]
+```
+
+- [ ] **Step 2: Run targeted suggestion-service tests**
+
+Run: `uv run pytest apps/api/tests/test_face_suggestions_service.py -q`  
+Expected: FAIL due to missing service.
+
+- [ ] **Step 3: Implement hybrid ranking and atomic snapshot replace**
+
+```python
+def refresh_face_suggestions_for_face(connection: Connection, *, face_id: str, limit: int = 5) -> None:
+    source = _load_unlabeled_source_face(connection, face_id=face_id)
+    candidates = _score_candidates(connection, source_embedding=source.embedding, limit=limit)
+    connection.execute(delete(face_suggestions).where(face_suggestions.c.face_id == face_id))
+    for rank, candidate in enumerate(candidates, start=1):
+        connection.execute(
+            insert(face_suggestions).values(
+                face_suggestion_id=str(uuid4()),
+                face_id=face_id,
+                person_id=candidate.person_id,
+                rank=rank,
+                confidence=candidate.confidence,
+                centroid_distance=candidate.centroid_distance,
+                knn_distance=candidate.knn_distance,
+                representation_version=candidate.representation_version,
+                scoring_version="hybrid-v1",
+                model_version="nearest-neighbor-cosine-v1",
+                provenance=candidate.provenance,
+            )
+        )
+```
+
+- [ ] **Step 4: Re-run targeted tests**
+
+Run: `uv run pytest apps/api/tests/test_face_suggestions_service.py -q`  
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/services/face_suggestions.py \
+  apps/api/tests/test_face_suggestions_service.py
+git commit -m "feat: persist ranked machine_suggested snapshots for unlabeled faces"
+```
+
+### Task 5: Debounced Recompute Trigger on Human-Confirmed Mutations
+
+**Files:**
+- Modify: `apps/api/app/services/face_assignment.py`
+- Modify: `apps/api/app/db/queue.py`
+- Test: `apps/api/tests/test_queue_store.py`
+- Test: `apps/api/tests/test_face_assignment_api.py`
+
+- [ ] **Step 1: Write failing tests for recompute enqueue/refresh behavior**
+
+```python
+def test_assignment_enqueues_face_suggestion_recompute_request(tmp_path, monkeypatch):
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={"person_id": "person-1"},
+        headers={"X-Face-Validation-Role": "contributor"},
+    )
+    assert response.status_code == 201
+    queued = queue_store.list_pending()
+    assert any(row.payload_type == "face_suggestion_recompute" for row in queued)
+```
+
+```python
+def test_queue_refresh_nonprocessing_updates_payload_for_same_person_key(tmp_path):
+    old_payload = {"person_id": "person-1", "debounce_until_ts": "2026-05-03T12:00:00+00:00"}
+    new_payload = {"person_id": "person-1", "debounce_until_ts": "2026-05-03T12:00:05+00:00"}
+    assert updated_row.payload_json["debounce_until_ts"] != original_row.payload_json["debounce_until_ts"]
+```
+
+- [ ] **Step 2: Run targeted queue/assignment tests**
+
+Run: `uv run pytest apps/api/tests/test_queue_store.py apps/api/tests/test_face_assignment_api.py -k "recompute or debounce" -q`  
+Expected: FAIL on missing queue integration.
+
+- [ ] **Step 3: Implement enqueue helper in face-assignment service**
+
+```python
+def _enqueue_face_suggestion_recompute(connection: Connection, *, person_ids: list[str]) -> None:
+    queue_store = IngestQueueStore()
+    for person_id in sorted(set(person_ids)):
+        payload = {
+            "person_id": person_id,
+            "debounce_until_ts": datetime.now(tz=UTC).isoformat(),
+            "reason": "human_confirmed_event",
+        }
+        result = queue_store.enqueue_in_transaction(
+            payload_type="face_suggestion_recompute",
+            payload=payload,
+            idempotency_key=f"face_suggestion_recompute:{person_id}",
+            connection=connection,
+        )
+        if not result.created:
+            queue_store.refresh_nonprocessing_in_transaction(result.ingest_queue_id, payload=payload, connection=connection)
+```
+
+- [ ] **Step 4: Re-run targeted tests**
+
+Run: `uv run pytest apps/api/tests/test_queue_store.py apps/api/tests/test_face_assignment_api.py -k "recompute or debounce" -q`  
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/services/face_assignment.py \
+  apps/api/app/db/queue.py \
+  apps/api/tests/test_queue_store.py \
+  apps/api/tests/test_face_assignment_api.py
+git commit -m "feat: enqueue debounced face suggestion recompute after human-confirmed writes"
+```
+
+### Task 6: Worker Processing for Recompute Payloads
+
+**Files:**
+- Modify: `apps/api/app/services/ingest_queue_processor.py`
+- Test: `apps/api/tests/test_ingest_queue_processor.py`
+
+- [ ] **Step 1: Add failing worker test for `face_suggestion_recompute` payload**
+
+```python
+def test_process_pending_queue_handles_face_suggestion_recompute_payload(tmp_path):
+    payload = {
+        "person_id": "person-1",
+        "debounce_until_ts": "2026-05-03T12:00:00+00:00",
+        "reason": "human_confirmed_event",
+    }
+    queue_store.enqueue(
+        payload_type="face_suggestion_recompute",
+        payload=payload,
+        idempotency_key="face_suggestion_recompute:person-1",
+    )
+    result = process_pending_ingest_queue(database_url, limit=10)
+    assert result.processed == 1
+    assert _load_face_suggestion_rows(database_url, "face-unlabeled")
+```
+
+- [ ] **Step 2: Run targeted processor tests**
+
+Run: `uv run pytest apps/api/tests/test_ingest_queue_processor.py -k "face_suggestion_recompute" -q`  
+Expected: FAIL with unsupported payload type.
+
+- [ ] **Step 3: Implement recompute payload handler in queue processor**
+
+```python
+if claimed_row.payload_type == "face_suggestion_recompute":
+    payload = claimed_row.payload_json
+    if _debounce_not_elapsed(payload):
+        queue_store.mark_completed(claimed_row.ingest_queue_id, connection=connection)
+        return None, None
+    refresh_person_representation(connection, person_id=str(payload["person_id"]))
+    refresh_face_suggestions_for_person_scope(connection, person_id=str(payload["person_id"]))
+    return None, None
+```
+
+- [ ] **Step 4: Re-run targeted processor tests**
+
+Run: `uv run pytest apps/api/tests/test_ingest_queue_processor.py -k "face_suggestion_recompute" -q`  
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/services/ingest_queue_processor.py \
+  apps/api/tests/test_ingest_queue_processor.py
+git commit -m "feat: process face suggestion recompute payloads in worker queue loop"
+```
+
+### Task 7: Certainty-Aware Search Filters and Facets
+
+**Files:**
+- Modify: `apps/api/app/schemas/search_request.py`
+- Modify: `apps/api/app/repositories/photos_repo.py`
+- Modify: `apps/api/app/domain/facets.py`
+- Test: `apps/api/tests/test_search_service.py`
+- Test: `apps/api/tests/test_facets.py`
+
+- [ ] **Step 1: Add failing tests for `person_certainty_mode` and threshold behavior**
+
+```python
+def test_search_repository_person_filter_human_only_excludes_machine_suggested(tmp_path):
+    items, total, _ = repo.search_photos(
+        filters=SearchFilters(person_names=["inez"], person_certainty_mode="human_only"),
+        sort=SortSpec(by="shot_ts", dir="desc"),
+        page=PageSpec(limit=50),
+    )
+    assert [item["photo_id"] for item in items] == ["photo-human"]
+```
+
+```python
+def test_search_repository_person_filter_include_suggestions_honors_threshold(tmp_path):
+    filters = SearchFilters(
+        person_names=["inez"],
+        person_certainty_mode="include_suggestions",
+        suggestion_confidence_min=0.78,
+    )
+    items, total, _ = repo.search_photos(filters=filters, sort=SortSpec(), page=PageSpec(limit=50))
+    assert any(item["photo_id"] == "photo-machine-suggested" for item in items)
+```
+
+- [ ] **Step 2: Run targeted search/facet tests**
+
+Run: `uv run pytest apps/api/tests/test_search_service.py apps/api/tests/test_facets.py -k "certainty or suggestion_confidence or people_machine_suggested" -q`  
+Expected: FAIL due to missing schema/filters.
+
+- [ ] **Step 3: Implement search schema and repository filtering clauses**
+
+```python
+class SearchFilters(BaseModel):
+    date: Optional[DateFilter] = None
+    camera_make: Optional[List[str]] = None
+    extension: Optional[List[str]] = None
+    person_certainty_mode: Literal["human_only", "include_suggestions"] | None = None
+    suggestion_confidence_min: float | None = None
+```
+
+```python
+if filters.person_certainty_mode == "human_only":
+    # require matching human_confirmed provenance row
+elif filters.person_certainty_mode == "include_suggestions":
+    # include human_confirmed OR face_suggestions.confidence >= threshold
+```
+
+- [ ] **Step 4: Re-run targeted tests**
+
+Run: `uv run pytest apps/api/tests/test_search_service.py apps/api/tests/test_facets.py -k "certainty or suggestion_confidence or people_machine_suggested" -q`  
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/app/schemas/search_request.py \
+  apps/api/app/repositories/photos_repo.py \
+  apps/api/app/domain/facets.py \
+  apps/api/tests/test_search_service.py \
+  apps/api/tests/test_facets.py
+git commit -m "feat: add certainty-aware person filtering and facets in search"
+```
+
+### Task 8: UI Contract Cleanup and Library Certainty Controls
+
+**Files:**
+- Modify: `apps/ui/src/pages/PhotoFaceAssignmentModal.tsx`
+- Modify: `apps/ui/src/pages/FaceBBoxOverlay.tsx`
+- Modify: `apps/ui/src/pages/FaceAssignmentControls.tsx`
+- Modify: `apps/ui/src/pages/library/libraryRouteTypes.ts`
+- Modify: `apps/ui/src/pages/library/libraryRouteSearchState.ts`
+- Modify: `apps/ui/src/pages/library/libraryRouteApi.ts`
+- Modify: `apps/ui/src/pages/library/LibrarySearchForm.tsx`
+- Modify: `apps/ui/src/pages/search/FacetFilterPanel.tsx`
+- Modify: `apps/ui/src/pages/search/facetFilters.ts`
+- Test: `apps/ui/src/pages/PhotoDetailRoutePage.test.tsx`
+- Test: `apps/ui/src/pages/LibraryRoutePage.test.tsx`
+- Create/Modify Test: `apps/ui/src/pages/library/libraryRouteSearchState.test.ts`
+
+- [ ] **Step 1: Add failing UI tests for removed auto-apply payload and certainty filters**
+
+```ts
+it("does not auto-assign from candidates payload and only applies on user click", async () => {
+  // payload has candidates only; no auto_applied_assignment handling branch
+});
+
+it("serializes certainty mode and threshold into search filters", () => {
+  expect(buildSearchFilters("", "", ["inez"], null, null, [], "include_suggestions", "0.8")).toEqual({
+    person_names: ["inez"],
+    person_certainty_mode: "include_suggestions",
+    suggestion_confidence_min: 0.8
+  });
+});
+```
+
+- [ ] **Step 2: Run targeted UI tests**
+
+Run: `npm --prefix apps/ui test -- src/pages/PhotoDetailRoutePage.test.tsx src/pages/LibraryRoutePage.test.tsx src/pages/library/libraryRouteSearchState.test.ts`  
+Expected: FAIL on contract/type mismatches.
+
+- [ ] **Step 3: Implement UI filter state and request payload changes**
+
+```ts
+export type PersonCertaintyMode = "human_only" | "include_suggestions";
+
+export function buildSearchFilters(
+  fromDate: string,
+  toDate: string,
+  selectedPersonNames: string[],
+  locationRadius: LibraryLocationRadius | null,
+  hasFaces: boolean | null,
+  pathHints: string[],
+  personCertaintyMode: PersonCertaintyMode | null,
+  suggestionConfidenceMinDraft: string,
+): {
+  date?: { from?: string; to?: string };
+  person_names?: string[];
+  person_certainty_mode?: PersonCertaintyMode;
+  suggestion_confidence_min?: number;
+} | null {
+  const threshold = Number.parseFloat(suggestionConfidenceMinDraft);
+  const normalizedThreshold = Number.isFinite(threshold) ? threshold : undefined;
+}
+```
+
+```tsx
+<select aria-label="Person certainty mode" value={personCertaintyMode} onChange={onPersonCertaintyModeChange}>
+  <option value="human_only">Human-reviewed only</option>
+  <option value="include_suggestions">Include heuristic suggestions</option>
+</select>
+```
+
+- [ ] **Step 4: Re-run targeted UI tests**
+
+Run: `npm --prefix apps/ui test -- src/pages/PhotoDetailRoutePage.test.tsx src/pages/LibraryRoutePage.test.tsx src/pages/library/libraryRouteSearchState.test.ts`  
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/ui/src/pages/PhotoFaceAssignmentModal.tsx \
+  apps/ui/src/pages/FaceBBoxOverlay.tsx \
+  apps/ui/src/pages/FaceAssignmentControls.tsx \
+  apps/ui/src/pages/library/libraryRouteTypes.ts \
+  apps/ui/src/pages/library/libraryRouteSearchState.ts \
+  apps/ui/src/pages/library/libraryRouteApi.ts \
+  apps/ui/src/pages/library/LibrarySearchForm.tsx \
+  apps/ui/src/pages/search/FacetFilterPanel.tsx \
+  apps/ui/src/pages/search/facetFilters.ts \
+  apps/ui/src/pages/PhotoDetailRoutePage.test.tsx \
+  apps/ui/src/pages/LibraryRoutePage.test.tsx \
+  apps/ui/src/pages/library/libraryRouteSearchState.test.ts
+git commit -m "ui: add certainty-aware person filters and remove auto-apply contract usage"
+```
+
+### Task 9: End-to-End Verification and Documentation Sweep
+
+**Files:**
+- Modify: `README.md` (only if runtime/filter contract docs changed)
+- Verify all changed files from Tasks 1-8
+
+- [ ] **Step 1: Run backend regression suite for touched domains**
+
+Run: `uv run pytest apps/api/tests/test_migrations.py apps/api/tests/test_recognition_policy.py apps/api/tests/test_face_candidates_service.py apps/api/tests/test_face_candidates_api.py apps/api/tests/test_face_assignment_api.py apps/api/tests/test_queue_store.py apps/api/tests/test_ingest_queue_processor.py apps/api/tests/test_search_service.py apps/api/tests/test_facets.py -q`  
+Expected: PASS.
+
+- [ ] **Step 2: Run UI regression suite for touched routes**
+
+Run: `npm --prefix apps/ui test -- src/pages/PhotoDetailRoutePage.test.tsx src/pages/LibraryRoutePage.test.tsx src/pages/library/libraryRouteSearchState.test.ts`  
+Expected: PASS.
+
+- [ ] **Step 3: Run lint/type checks for changed surfaces**
+
+Run: `uv run ruff check apps/api/app apps/api/tests packages/db-schema`  
+Expected: PASS.  
+Run: `npm --prefix apps/ui run test -- --runInBand`  
+Expected: PASS.
+
+- [ ] **Step 4: Final commit for doc touch-ups or test fixture updates**
+
+```bash
+git add README.md
+git commit -m "docs: describe human-confirmed-only suggestion semantics and certainty filters"
+```


### PR DESCRIPTION
## Summary
- persist face embeddings for detected faces at ingest persistence time, including deterministic fallback embedding generation when detector output has no embedding
- add ingest persistence coverage for missing-embedding generation and preserve embedding validation behavior
- include current in-progress face-candidate/assignment and UI journey test updates present in the workspace
- add the implementation plan document for human-confirmed face suggestions

## Validation
- `uv run pytest apps/api/tests/test_ingest_persistence.py -q`
- `uv run pytest apps/api/tests/test_ingest_queue_processor.py -k "extracted_photo or applies_domain_write_and_marks_queue_complete" -q`