### PR TITLE
Refine library UI behavior and API schema updates

### DIFF
--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -796,11 +796,10 @@ class PhotosRepository:
             tag_map[r.photo_id].append(r.tag)
 
         # Load faces and people
-        face_columns = [self.faces.c.photo_id, self.faces.c.person_id]
+        face_columns = [self.faces.c.photo_id, self.faces.c.face_id, self.faces.c.person_id]
         if include_face_regions:
             face_columns.extend(
                 [
-                    self.faces.c.face_id,
                     self.faces.c.bbox_x,
                     self.faces.c.bbox_y,
                     self.faces.c.bbox_w,
@@ -816,70 +815,73 @@ class PhotosRepository:
         ).all()
 
         provenance_map: Dict[tuple[str, str], Dict[str, Any]] = {}
-        if include_face_regions:
-            labeled_face_keys = {
-                (str(r.face_id), str(r.person_id))
-                for r in face_rows
-                if r.person_id is not None and r.face_id is not None
-            }
-            if labeled_face_keys:
-                face_ids = sorted({face_id for face_id, _ in labeled_face_keys})
-                label_rows = (
-                    self.db.execute(
-                        select(
-                            self.face_labels.c.face_id,
-                            self.face_labels.c.person_id,
-                            self.face_labels.c.label_source,
-                            self.face_labels.c.confidence,
-                            self.face_labels.c.model_version,
-                            self.face_labels.c.provenance,
-                            self.face_labels.c.created_ts,
-                            self.face_labels.c.updated_ts,
-                            self.face_labels.c.face_label_id,
-                        )
-                        .where(self.face_labels.c.face_id.in_(face_ids))
-                        .order_by(
-                            self.face_labels.c.face_id,
-                            self.face_labels.c.person_id,
-                            self.face_labels.c.updated_ts.desc(),
-                            self.face_labels.c.created_ts.desc(),
-                            self.face_labels.c.face_label_id.desc(),
-                        )
+        labeled_face_keys = {
+            (str(r.face_id), str(r.person_id))
+            for r in face_rows
+            if r.person_id is not None and r.face_id is not None
+        }
+        if labeled_face_keys:
+            face_ids = sorted({face_id for face_id, _ in labeled_face_keys})
+            label_rows = (
+                self.db.execute(
+                    select(
+                        self.face_labels.c.face_id,
+                        self.face_labels.c.person_id,
+                        self.face_labels.c.label_source,
+                        self.face_labels.c.confidence,
+                        self.face_labels.c.model_version,
+                        self.face_labels.c.provenance,
+                        self.face_labels.c.created_ts,
+                        self.face_labels.c.updated_ts,
+                        self.face_labels.c.face_label_id,
                     )
-                    .mappings()
-                    .all()
+                    .where(self.face_labels.c.face_id.in_(face_ids))
+                    .order_by(
+                        self.face_labels.c.face_id,
+                        self.face_labels.c.person_id,
+                        self.face_labels.c.updated_ts.desc(),
+                        self.face_labels.c.created_ts.desc(),
+                        self.face_labels.c.face_label_id.desc(),
+                    )
                 )
-                for row in label_rows:
-                    person_id = row["person_id"]
-                    face_id = row["face_id"]
-                    if person_id is None or face_id is None:
-                        continue
-                    key = (str(face_id), str(person_id))
-                    if key not in labeled_face_keys or key in provenance_map:
-                        continue
-                    provenance_map[key] = {
-                        "label_source": row["label_source"],
-                        "confidence": row["confidence"],
-                        "model_version": row["model_version"],
-                        "provenance": row["provenance"],
-                        "label_recorded_ts": (
-                            iso_utc(row["updated_ts"])
-                            if row["updated_ts"] is not None
-                            else (iso_utc(row["created_ts"]) if row["created_ts"] is not None else None)
-                        ),
-                    }
+                .mappings()
+                .all()
+            )
+            for row in label_rows:
+                person_id = row["person_id"]
+                face_id = row["face_id"]
+                if person_id is None or face_id is None:
+                    continue
+                key = (str(face_id), str(person_id))
+                if key not in labeled_face_keys or key in provenance_map:
+                    continue
+                provenance_map[key] = {
+                    "label_source": row["label_source"],
+                    "confidence": row["confidence"],
+                    "model_version": row["model_version"],
+                    "provenance": row["provenance"],
+                    "label_recorded_ts": (
+                        iso_utc(row["updated_ts"])
+                        if row["updated_ts"] is not None
+                        else (iso_utc(row["created_ts"]) if row["created_ts"] is not None else None)
+                    ),
+                }
 
         for r in face_rows:
             if r.person_id:
                 ppl_map[r.photo_id].append(r.person_id)
-            face_item = {"person_id": r.person_id}
+            provenance = (
+                provenance_map.get((str(r.face_id), str(r.person_id)))
+                if r.person_id is not None and r.face_id is not None
+                else None
+            )
+            face_item = {
+                "person_id": r.person_id,
+                "label_source": provenance["label_source"] if provenance else None,
+                "confidence": provenance["confidence"] if provenance else None,
+            }
             if include_face_regions:
                 bbox_space_width, bbox_space_height = _extract_bbox_space_dimensions(r.provenance)
-                provenance = (
-                    provenance_map.get((str(r.face_id), str(r.person_id)))
-                    if r.person_id is not None
-                    else None
-                )
                 face_item.update(
                     {
                         "face_id": r.face_id,

--- a/apps/api/app/schemas/search_response.py
+++ b/apps/api/app/schemas/search_response.py
@@ -4,6 +4,8 @@ from typing import List, Optional, Dict, Any
 
 class FaceHit(BaseModel):
     person_id: Optional[str] = None
+    label_source: Optional[str] = None
+    confidence: Optional[float] = None
 
 
 class ThumbnailHit(BaseModel):

--- a/apps/ui/src/pages/LibraryRoutePage.test.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { Link, MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { LibraryRoutePage } from "./LibraryRoutePage";
 
 type SearchResponsePayload = {
@@ -14,7 +14,11 @@ type SearchResponsePayload = {
       shot_ts: string | null;
       filesize: number;
       people: string[];
-      faces: Array<{ person_id: string | null }>;
+      faces: Array<{
+        person_id: string | null;
+        label_source?: "human_confirmed" | "machine_suggested" | null;
+        confidence?: number | null;
+      }>;
       thumbnail: {
         mime_type: string;
         width: number;
@@ -28,31 +32,6 @@ type SearchResponsePayload = {
       };
     }>;
   };
-};
-
-type PhotoDetailPayload = {
-  photo_id: string;
-  faces: Array<{
-    face_id: string;
-    person_id: string | null;
-    bbox_x: number | null;
-    bbox_y: number | null;
-    bbox_w: number | null;
-    bbox_h: number | null;
-    bbox_space_width?: number | null;
-    bbox_space_height?: number | null;
-    label_source: "human_confirmed" | "machine_suggested" | null;
-    confidence: number | null;
-    model_version: string | null;
-    provenance: Record<string, unknown> | null;
-    label_recorded_ts: string | null;
-  }>;
-  thumbnail: {
-    mime_type: string;
-    width: number;
-    height: number;
-    data_base64: string;
-  } | null;
 };
 
 function buildPayload(
@@ -83,22 +62,6 @@ function buildPayload(
   };
 }
 
-function buildDetailPayload(
-  faces: PhotoDetailPayload["faces"],
-  photoId = "photo-a"
-): PhotoDetailPayload {
-  return {
-    photo_id: photoId,
-    faces,
-    thumbnail: {
-      mime_type: "image/jpeg",
-      width: 100,
-      height: 100,
-      data_base64: "dGh1bWI="
-    }
-  };
-}
-
 function renderLibraryAt(path = "/library") {
   return render(
     <MemoryRouter
@@ -107,6 +70,49 @@ function renderLibraryAt(path = "/library") {
     >
       <Routes>
         <Route path="/library" element={<LibraryRoutePage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function LibraryTestDetailReturn() {
+  const location = useLocation();
+  const state = (location.state ?? {}) as {
+    returnToLibrarySearch?: string;
+    returnFocusPhotoId?: string;
+    librarySelection?: unknown;
+    libraryViewState?: unknown;
+  };
+
+  return (
+    <section>
+      <h1>Library test detail</h1>
+      <Link
+        to={{
+          pathname: "/library",
+          search: state.returnToLibrarySearch ?? ""
+        }}
+        state={{
+          restoreFocusPhotoId: state.returnFocusPhotoId,
+          librarySelection: state.librarySelection,
+          libraryViewState: state.libraryViewState
+        }}
+      >
+        Back to library
+      </Link>
+    </section>
+  );
+}
+
+function renderLibraryWithDetailAt(path = "/library") {
+  return render(
+    <MemoryRouter
+      initialEntries={[path]}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Routes>
+        <Route path="/library" element={<LibraryRoutePage />} />
+        <Route path="/library/:photoId" element={<LibraryTestDetailReturn />} />
       </Routes>
     </MemoryRouter>
   );
@@ -131,7 +137,7 @@ describe("LibraryRoutePage", () => {
     window.__PHOTO_ORG_SESSION__ = undefined;
   });
 
-  it("renders library query controls and results scaffold on /library", async () => {
+  it("renders library query controls and simplified photo cards", async () => {
     const user = userEvent.setup();
     fetchMock.mockImplementation(async (input: string) => {
       if (input === "/api/v1/operations/activity") {
@@ -165,8 +171,11 @@ describe("LibraryRoutePage", () => {
     expect(screen.getByLabelText("Radius (km)")).toBeInTheDocument();
     expect(screen.getByLabelText("Facet filters")).toBeInTheDocument();
     expect(await screen.findByRole("list", { name: "Photo gallery" })).toBeInTheDocument();
-    expect(screen.queryByRole("heading", { name: "Ingest status legend" })).not.toBeInTheDocument();
-    expect(screen.getByTitle(/Complete: Assets are ready for normal browse\/detail viewing\./)).toBeInTheDocument();
+
+    expect(screen.queryByRole("button", { name: "Review faces" })).not.toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Select photo photo-a" })).toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: "Show face boxes on all photos" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "View details" })).not.toBeInTheDocument();
   });
 
   it("links thumbnail previews to photo detail", async () => {
@@ -194,139 +203,75 @@ describe("LibraryRoutePage", () => {
 
     renderLibraryAt("/library");
     const thumbnailLink = await screen.findByRole("link", {
-      name: "View details for /library/photo-a.jpg"
+      name: "Open details for /library/photo-a.jpg"
     });
 
     expect(thumbnailLink).toHaveAttribute("href", "/library/photo-a");
   });
 
-  it("loads and toggles face bbox overlays for an individual grid photo", async () => {
-    const user = userEvent.setup();
-
-    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url === "/api/v1/operations/activity") {
+  it("shows source-relative path labels in the grid", async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
         return {
           ok: true,
           json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
         } as Response;
       }
 
-      if (url === "/api/v1/search") {
-        const payload = buildPayload(["photo-a"], 1, true);
-        payload.hits.items[0].thumbnail = {
-          mime_type: "image/jpeg",
-          width: 120,
-          height: 80,
-          data_base64: "dGh1bWI="
-        };
-        return {
-          ok: true,
-          json: async () => payload
-        } as Response;
-      }
-
-      if (url === "/api/v1/photos/photo-a") {
-        return {
-          ok: true,
-          json: async () =>
-            buildDetailPayload([
-              {
-                face_id: "face-1",
-                person_id: "person-1",
-                bbox_x: 10,
-                bbox_y: 10,
-                bbox_w: 20,
-                bbox_h: 20,
-                label_source: null,
-                confidence: null,
-                model_version: null,
-                provenance: null,
-                label_recorded_ts: null
-              }
-            ])
-        } as Response;
-      }
-
-      throw new Error(`Unhandled fetch: ${url}`);
+      const payload = buildPayload(["photo-a"]);
+      payload.hits.items[0].path =
+        "/storage-sources/1f9a5c89-b49c-47aa-b000-3fb56c21f9ce/folder/photo123.jpg";
+      return {
+        ok: true,
+        json: async () => payload
+      } as Response;
     });
 
     renderLibraryAt("/library");
-    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
-    expect(screen.queryByRole("list", { name: "Detected face regions for photo-a" })).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("checkbox", { name: "Show face boxes for photo-a" }));
-    expect(await screen.findByRole("list", { name: "Detected face regions for photo-a" })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("checkbox", { name: "Show face boxes for photo-a" }));
-    expect(screen.queryByRole("list", { name: "Detected face regions for photo-a" })).not.toBeInTheDocument();
+    expect(await screen.findByText(".../folder/photo123.jpg")).toBeInTheDocument();
+    expect(screen.queryByText(/\/storage-sources\/1f9a5c89/)).not.toBeInTheDocument();
   });
 
-  it("supports a global face bbox toggle for all grid photos", async () => {
-    const user = userEvent.setup();
-
-    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url === "/api/v1/operations/activity") {
+  it("shows face metrics on cards", async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
         return {
           ok: true,
           json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
         } as Response;
       }
 
-      if (url === "/api/v1/search") {
-        const payload = buildPayload(["photo-a"], 1, true);
-        payload.hits.items[0].thumbnail = {
-          mime_type: "image/jpeg",
-          width: 120,
-          height: 80,
-          data_base64: "dGh1bWI="
-        };
-        return {
-          ok: true,
-          json: async () => payload
-        } as Response;
-      }
-
-      if (url === "/api/v1/photos/photo-a") {
-        return {
-          ok: true,
-          json: async () =>
-            buildDetailPayload([
-              {
-                face_id: "face-1",
-                person_id: "person-1",
-                bbox_x: 10,
-                bbox_y: 10,
-                bbox_w: 20,
-                bbox_h: 20,
-                label_source: null,
-                confidence: null,
-                model_version: null,
-                provenance: null,
-                label_recorded_ts: null
-              }
-            ])
-        } as Response;
-      }
-
-      throw new Error(`Unhandled fetch: ${url}`);
+      const payload = buildPayload(["photo-a"]);
+      payload.hits.items[0].faces = [
+        { person_id: "person-1", label_source: "human_confirmed", confidence: null },
+        { person_id: "person-1", label_source: "machine_suggested", confidence: 0.91 },
+        { person_id: "person-2", label_source: "machine_suggested", confidence: 0.77 },
+        { person_id: null, label_source: null, confidence: null }
+      ];
+      return {
+        ok: true,
+        json: async () => payload
+      } as Response;
     });
 
     renderLibraryAt("/library");
     expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
-    expect(screen.queryByRole("list", { name: "Detected face regions for photo-a" })).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("checkbox", { name: "Show face boxes on all photos" }));
-    expect(await screen.findByRole("list", { name: "Detected face regions for photo-a" })).toBeInTheDocument();
+    expect(screen.getByText("Faces detected")).toBeInTheDocument();
+    expect(screen.getByText("People assigned (human)")).toBeInTheDocument();
+    expect(screen.getByText("Machine suggestions")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
   });
 
   it("advances to the next cursor-backed page when Next is clicked", async () => {
     const user = userEvent.setup();
 
-    const pageOneIds = Array.from({ length: 24 }, (_, index) => `photo-${index + 1}`);
-    const pageTwoIds = Array.from({ length: 24 }, (_, index) => `photo-${index + 25}`);
-    const pageThreeIds = Array.from({ length: 24 }, (_, index) => `photo-${index + 49}`);
+    const pageOneIds = Array.from({ length: 60 }, (_, index) => `photo-${index + 1}`);
+    const pageTwoIds = Array.from({ length: 60 }, (_, index) => `photo-${index + 61}`);
+    const pageThreeIds = Array.from({ length: 60 }, (_, index) => `photo-${index + 121}`);
 
     fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input);
@@ -358,9 +303,9 @@ describe("LibraryRoutePage", () => {
           ok: true,
           json: async () => ({
             hits: {
-              total: 99,
+              total: 181,
               cursor: "cursor-page-3",
-              items: buildPayload(pageTwoIds, 99).hits.items
+              items: buildPayload(pageTwoIds, 181).hits.items
             }
           })
         } as Response;
@@ -371,9 +316,9 @@ describe("LibraryRoutePage", () => {
           ok: true,
           json: async () => ({
             hits: {
-              total: 99,
+              total: 181,
               cursor: "cursor-page-4",
-              items: buildPayload(pageThreeIds, 99).hits.items
+              items: buildPayload(pageThreeIds, 181).hits.items
             }
           })
         } as Response;
@@ -383,9 +328,9 @@ describe("LibraryRoutePage", () => {
         ok: true,
         json: async () => ({
           hits: {
-            total: 99,
+            total: 181,
             cursor: "cursor-page-2",
-            items: buildPayload(pageOneIds, 99).hits.items
+            items: buildPayload(pageOneIds, 181).hits.items
           }
         })
       } as Response;
@@ -393,7 +338,7 @@ describe("LibraryRoutePage", () => {
 
     renderLibraryAt("/library");
 
-    expect(await screen.findByText("Showing 24 of 99 photos")).toBeInTheDocument();
+    expect(await screen.findByText("Showing 60 of 181 photos")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Previous page" })).toHaveAttribute(
       "aria-disabled",
       "true"
@@ -407,8 +352,7 @@ describe("LibraryRoutePage", () => {
       "aria-current",
       "page"
     );
-    const detailLinks = await screen.findAllByRole("link", { name: "View details" });
-    expect(detailLinks.length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("link", { name: /Open details for/ }).length).toBeGreaterThan(0);
 
     await user.click(screen.getByRole("button", { name: "Page 1" }));
     expect(await screen.findByRole("button", { name: "Page 1" })).toHaveAttribute(
@@ -435,7 +379,134 @@ describe("LibraryRoutePage", () => {
     expect(searchRequestCursors).toContain("cursor-page-3");
   });
 
-  it("shows action bar only when active selection scope count is positive", async () => {
+  it("updates search page limit when photos-per-page selector changes", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+      if (url === "/api/v1/people") {
+        return {
+          ok: true,
+          json: async () => []
+        } as Response;
+      }
+      if (url !== "/api/v1/search") {
+        throw new Error(`Unhandled fetch: ${url}`);
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          hits: {
+            total: 3,
+            cursor: null,
+            items: buildPayload(["photo-a", "photo-b", "photo-c"], 3).hits.items
+          }
+        })
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByText("Showing 3 of 3 photos")).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByRole("combobox", { name: "Photos per page" }), "24");
+
+    const searchRequests = fetchMock.mock.calls.filter(([input]) => String(input) === "/api/v1/search");
+    const limits = searchRequests.map(([, init]) => {
+      const parsedBody = JSON.parse((init?.body as string | undefined) ?? "{}") as {
+        page?: { limit?: number };
+      };
+      return parsedBody.page?.limit;
+    });
+
+    expect(limits[0]).toBe(60);
+    expect(limits[limits.length - 1]).toBe(24);
+  });
+
+  it("keeps page and photo selections when navigating to detail and back", async () => {
+    const user = userEvent.setup();
+    const pageOneIds = Array.from({ length: 60 }, (_, index) => `photo-${index + 1}`);
+    const pageTwoIds = Array.from({ length: 60 }, (_, index) => `photo-${index + 61}`);
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+      if (url === "/api/v1/people") {
+        return {
+          ok: true,
+          json: async () => []
+        } as Response;
+      }
+      if (url !== "/api/v1/search") {
+        throw new Error(`Unhandled fetch: ${url}`);
+      }
+
+      const requestBody = JSON.parse((init?.body as string | undefined) ?? "{}") as {
+        page?: { cursor?: string | null };
+      };
+      const requestCursor = requestBody.page?.cursor ?? null;
+
+      if (requestCursor === "cursor-page-2") {
+        return {
+          ok: true,
+          json: async () => ({
+            hits: {
+              total: 121,
+              cursor: "cursor-page-3",
+              items: buildPayload(pageTwoIds, 121).hits.items
+            }
+          })
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          hits: {
+            total: 121,
+            cursor: "cursor-page-2",
+            items: buildPayload(pageOneIds, 121).hits.items
+          }
+        })
+      } as Response;
+    });
+
+    renderLibraryWithDetailAt("/library");
+
+    expect(await screen.findByText("Showing 60 of 121 photos")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+    expect(await screen.findByRole("button", { name: "Page 2" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+
+    await user.click(screen.getByRole("checkbox", { name: "Select photo photo-61" }));
+    expect(screen.getByRole("checkbox", { name: "Select photo photo-61" })).toBeChecked();
+
+    await user.click(screen.getByRole("link", { name: "Open details for /library/photo-61.jpg" }));
+    expect(await screen.findByRole("heading", { name: "Library test detail", level: 1 })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("link", { name: "Back to library" }));
+
+    expect(await screen.findByRole("button", { name: "Page 2" })).toHaveAttribute(
+      "aria-current",
+      "page"
+    );
+    expect(screen.getByRole("checkbox", { name: "Select photo photo-61" })).toBeChecked();
+  });
+
+  it("shows action bar when selection scope is set to page", async () => {
     const user = userEvent.setup();
     fetchMock.mockImplementation(async (input: string) => {
       if (input === "/api/v1/operations/activity") {
@@ -456,12 +527,11 @@ describe("LibraryRoutePage", () => {
     expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
     expect(screen.queryByLabelText("Library actions")).not.toBeInTheDocument();
 
-    const selectionCheckbox = await screen.findByRole("checkbox", { name: "Select photo" });
-    await user.click(selectionCheckbox);
+    await user.click(screen.getByRole("radio", { name: "This page" }));
     expect(screen.getByLabelText("Library actions")).toBeInTheDocument();
   });
 
-  it("disables both actions while operations conflict is active", async () => {
+  it("disables actions while operations conflict is active", async () => {
     const user = userEvent.setup();
     fetchMock.mockImplementation(async (input: string) => {
       if (input === "/api/v1/operations/activity") {
@@ -480,8 +550,7 @@ describe("LibraryRoutePage", () => {
     renderLibraryAt("/library");
     expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
 
-    const selectionCheckbox = await screen.findByRole("checkbox", { name: "Select photo" });
-    await user.click(selectionCheckbox);
+    await user.click(screen.getByRole("radio", { name: "This page" }));
 
     expect(screen.getByRole("button", { name: "Add to album" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Export" })).toBeDisabled();
@@ -489,331 +558,5 @@ describe("LibraryRoutePage", () => {
       screen.getAllByText("Action temporarily unavailable while ingest processing is active.")
         .length
     ).toBeGreaterThan(0);
-  });
-
-  it("supports in-context face assignment from the library quick panel", async () => {
-    const user = userEvent.setup();
-
-    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url === "/api/v1/operations/activity") {
-        return {
-          ok: true,
-          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
-        } as Response;
-      }
-
-      if (url === "/api/v1/search") {
-        return {
-          ok: true,
-          json: async () => buildPayload(["photo-a"], 1, true)
-        } as Response;
-      }
-
-      if (url === "/api/v1/people") {
-        return {
-          ok: true,
-          json: async () => [{ person_id: "person-1", display_name: "Inez" }]
-        } as Response;
-      }
-
-      if (url === "/api/v1/photos/photo-a") {
-        return {
-          ok: true,
-          json: async () =>
-            buildDetailPayload([
-              {
-                face_id: "face-1",
-                person_id: null,
-                bbox_x: 10,
-                bbox_y: 10,
-                bbox_w: 20,
-                bbox_h: 20,
-                label_source: null,
-                confidence: null,
-                model_version: null,
-                provenance: null,
-                label_recorded_ts: null
-              }
-            ])
-        } as Response;
-      }
-
-      if (url === "/api/v1/faces/face-1/assignments" && init?.method === "POST") {
-        return {
-          ok: true,
-          status: 201,
-          json: async () => ({ face_id: "face-1", photo_id: "photo-a", person_id: "person-1" })
-        } as Response;
-      }
-
-      throw new Error(`Unhandled fetch: ${url}`);
-    });
-
-    renderLibraryAt("/library");
-    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Review faces" }));
-    await user.selectOptions(await screen.findByLabelText("Assign face 1"), "person-1");
-
-    expect(await screen.findByText("All visible faces assigned.")).toBeInTheDocument();
-    expect(fetchMock).toHaveBeenCalledWith("/api/v1/faces/face-1/assignments", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Face-Validation-Role": "contributor"
-      },
-      body: JSON.stringify({ person_id: "person-1" })
-    });
-  });
-
-  it("renders quick-panel overlays when bbox coordinates are larger than thumbnail dimensions", async () => {
-    const user = userEvent.setup();
-
-    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url === "/api/v1/operations/activity") {
-        return {
-          ok: true,
-          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
-        } as Response;
-      }
-
-      if (url === "/api/v1/search") {
-        return {
-          ok: true,
-          json: async () => buildPayload(["photo-a"], 1, true)
-        } as Response;
-      }
-
-      if (url === "/api/v1/people") {
-        return {
-          ok: true,
-          json: async () => [{ person_id: "person-1", display_name: "Inez" }]
-        } as Response;
-      }
-
-      if (url === "/api/v1/photos/photo-a") {
-        return {
-          ok: true,
-          json: async () =>
-            buildDetailPayload([
-              {
-                face_id: "face-1",
-                person_id: "person-1",
-                bbox_x: 320,
-                bbox_y: 160,
-                bbox_w: 120,
-                bbox_h: 140,
-                label_source: null,
-                confidence: null,
-                model_version: null,
-                provenance: null,
-                label_recorded_ts: null
-              }
-            ])
-        } as Response;
-      }
-
-      throw new Error(`Unhandled fetch: ${url}`);
-    });
-
-    renderLibraryAt("/library");
-    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Review faces" }));
-
-    expect(await screen.findByText("1 face region rendered.")).toBeInTheDocument();
-    expect(screen.getByRole("list", { name: "Detected face regions" })).toBeInTheDocument();
-    expect(
-      screen.queryByText("Face regions are present but could not be rendered on this preview.")
-    ).not.toBeInTheDocument();
-  });
-
-  it("maps quick-panel overlays using explicit bbox coordinate-space dimensions", async () => {
-    const user = userEvent.setup();
-
-    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url === "/api/v1/operations/activity") {
-        return {
-          ok: true,
-          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
-        } as Response;
-      }
-
-      if (url === "/api/v1/search") {
-        return {
-          ok: true,
-          json: async () => buildPayload(["photo-a"], 1, true)
-        } as Response;
-      }
-
-      if (url === "/api/v1/people") {
-        return {
-          ok: true,
-          json: async () => [{ person_id: "person-1", display_name: "Inez" }]
-        } as Response;
-      }
-
-      if (url === "/api/v1/photos/photo-a") {
-        return {
-          ok: true,
-          json: async () =>
-            buildDetailPayload([
-              {
-                face_id: "face-1",
-                person_id: "person-1",
-                bbox_x: 1000,
-                bbox_y: 300,
-                bbox_w: 800,
-                bbox_h: 600,
-                bbox_space_width: 4000,
-                bbox_space_height: 3000,
-                label_source: null,
-                confidence: null,
-                model_version: null,
-                provenance: null,
-                label_recorded_ts: null
-              }
-            ])
-        } as Response;
-      }
-
-      throw new Error(`Unhandled fetch: ${url}`);
-    });
-
-    renderLibraryAt("/library");
-    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Review faces" }));
-
-    const region = await screen.findByLabelText("Face region 1 for person-1");
-    expect(region).toHaveStyle({
-      left: "25%",
-      top: "10%",
-      width: "20%",
-      height: "20%"
-    });
-  });
-
-  it("supports in-context correction and machine-label confirmation from the library quick panel", async () => {
-    const user = userEvent.setup();
-
-    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = String(input);
-      if (url === "/api/v1/operations/activity") {
-        return {
-          ok: true,
-          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
-        } as Response;
-      }
-
-      if (url === "/api/v1/search") {
-        return {
-          ok: true,
-          json: async () => buildPayload(["photo-a"], 1, true)
-        } as Response;
-      }
-
-      if (url === "/api/v1/people") {
-        return {
-          ok: true,
-          json: async () => [
-            { person_id: "person-1", display_name: "Inez" },
-            { person_id: "person-2", display_name: "Mateo" }
-          ]
-        } as Response;
-      }
-
-      if (url === "/api/v1/photos/photo-a") {
-        return {
-          ok: true,
-          json: async () =>
-            buildDetailPayload([
-              {
-                face_id: "face-1",
-                person_id: "person-1",
-                bbox_x: 10,
-                bbox_y: 10,
-                bbox_w: 20,
-                bbox_h: 20,
-                label_source: "machine_suggested",
-                confidence: 0.92,
-                model_version: "v1",
-                provenance: {
-                  workflow: "face-labeling",
-                  surface: "api",
-                  action: "auto-apply"
-                },
-                label_recorded_ts: "2026-05-02T10:00:00Z"
-              }
-            ])
-        } as Response;
-      }
-
-      if (url === "/api/v1/faces/face-1/confirmations" && init?.method === "POST") {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({ face_id: "face-1", photo_id: "photo-a", person_id: "person-1" })
-        } as Response;
-      }
-
-      if (url === "/api/v1/faces/face-1/corrections" && init?.method === "POST") {
-        return {
-          ok: true,
-          status: 200,
-          json: async () => ({
-            face_id: "face-1",
-            photo_id: "photo-a",
-            previous_person_id: "person-1",
-            person_id: "person-2"
-          })
-        } as Response;
-      }
-
-      throw new Error(`Unhandled fetch: ${url}`);
-    });
-
-    renderLibraryAt("/library");
-    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Review faces" }));
-
-    await user.click(await screen.findByRole("button", { name: "Confirm label" }));
-    expect(await screen.findByText("Confirmed face 1 for Inez.")).toBeInTheDocument();
-    expect(fetchMock).toHaveBeenCalledWith("/api/v1/faces/face-1/confirmations", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Face-Validation-Role": "contributor"
-      },
-      body: JSON.stringify({ person_id: "person-1" })
-    });
-
-    await user.selectOptions(screen.getByLabelText("Correct face 1"), "person-2");
-    await user.click(screen.getByRole("button", { name: "Confirm reassignment" }));
-    expect(await screen.findByText("Correction recorded: Inez -> Mateo.")).toBeInTheDocument();
-  });
-
-  it("shows the Review faces action only when faces are detected", async () => {
-    fetchMock.mockImplementation(async (input: string) => {
-      if (input === "/api/v1/operations/activity") {
-        return {
-          ok: true,
-          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
-        } as Response;
-      }
-
-      return {
-        ok: true,
-        json: async () => buildPayload(["photo-a"])
-      } as Response;
-    });
-
-    renderLibraryAt("/library");
-    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Review faces" })).not.toBeInTheDocument();
   });
 });

--- a/apps/ui/src/pages/LibraryRoutePage.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.tsx
@@ -9,16 +9,22 @@ import { resolveInitialSessionIdentity } from "../session/sessionIdentity";
 import { LibraryActionBar } from "./library/LibraryActionBar";
 import { LibraryActiveFilterChips } from "./library/LibraryActiveFilterChips";
 import {
+  DEFAULT_SEARCH_PAGE_LIMIT,
   fetchLibraryPage,
   fetchOperationsActivityConflictState,
   fetchPeopleDirectory,
-  SEARCH_PAGE_LIMIT
+  SEARCH_PAGE_LIMIT_OPTIONS
 } from "./library/libraryRouteApi";
 import { LibraryPhotoGrid } from "./library/LibraryPhotoGrid";
 import { LibraryRouteHeader } from "./library/LibraryRouteHeader";
 import { LibrarySearchForm } from "./library/LibrarySearchForm";
 import { LibrarySelectionPanel } from "./library/LibrarySelectionPanel";
 import { resolveLibraryActionState } from "./library/libraryActionBarState";
+import {
+  consumePendingBrowseFocusPhotoId,
+  resolveBrowseReturnState,
+  type LibraryViewRouteState
+} from "./browseFocusState";
 import { isFuzzyNameMatch, parseLibraryUrlState, validateDateRange, buildLibraryUrlQuery } from "./library/libraryRouteSearchState";
 import {
   createLibrarySelectionState,
@@ -54,10 +60,14 @@ const LIBRARY_FILTER_FINGERPRINT = "library:route";
 export function LibraryRoutePage() {
   const location = useLocation();
   const navigate = useNavigate();
+  const initialReturnState = resolveBrowseReturnState(location.state);
   const requestedPage = parsePositiveIntParam(location.search, "page");
   const suppressNextUrlStateSyncRef = useRef(false);
   const applyingParsedUrlStateRef = useRef(false);
   const lastAppliedParsedUrlStateSignatureRef = useRef<string | null>(null);
+  const shouldRestoreInitialViewStateRef = useRef(
+    Boolean(initialReturnState?.libraryViewState)
+  );
   const parsedUrlState = useMemo(() => parseLibraryUrlState(location.search), [location.search]);
   const parsedUrlStateSignature = useMemo(
     () =>
@@ -65,6 +75,7 @@ export function LibraryRoutePage() {
         queryChips: parsedUrlState.queryChips,
         fromDate: parsedUrlState.fromDate,
         toDate: parsedUrlState.toDate,
+        pageSize: parsedUrlState.pageSize,
         selectedPersonNames: parsedUrlState.selectedPersonNames,
         personCertaintyMode: parsedUrlState.personCertaintyMode,
         suggestionConfidenceMinDraft: parsedUrlState.suggestionConfidenceMinDraft,
@@ -101,20 +112,20 @@ export function LibraryRoutePage() {
   });
   const [facetPathHintCounts, setFacetPathHintCounts] = useState<FacetCountEntry[]>([]);
 
-  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
-  const [cursorByPage, setCursorByPage] = useState<Record<number, string | null>>({ 1: null });
+  const [sortDirection, setSortDirection] = useState<SortDirection>(
+    initialReturnState?.libraryViewState?.sortDirection ?? "desc"
+  );
+  const [pageSize, setPageSize] = useState(DEFAULT_SEARCH_PAGE_LIMIT);
+  const [cursorByPage, setCursorByPage] = useState<Record<number, string | null>>(
+    initialReturnState?.libraryViewState?.cursorByPage ?? { 1: null }
+  );
   const [photos, setPhotos] = useState<LibraryPhoto[]>([]);
-  const [showGridFaceBoxes, setShowGridFaceBoxes] = useState(false);
   const [totalCount, setTotalCount] = useState(0);
   const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
   const [hasConflictingJob, setHasConflictingJob] = useState(false);
   const [selectionState, dispatchSelection] = useReducer(
     librarySelectionReducer,
-    parseLibrarySelectionRouteState(
-      isRecord(location.state)
-        ? location.state.librarySelection ?? location.state.browseSelection
-        : undefined
-    ),
+    initialReturnState?.librarySelection ?? null,
     createLibrarySelectionState
   );
   const {
@@ -126,6 +137,9 @@ export function LibraryRoutePage() {
     failRequest,
     requestRetry
   } = useRouteRequestState();
+  const pendingReturnFocusPhotoIdRef = useRef<string | null>(
+    initialReturnState?.restoreFocusPhotoId ?? consumePendingBrowseFocusPhotoId()
+  );
 
   const dateRangeError = useMemo(() => validateDateRange(fromDate, toDate), [fromDate, toDate]);
   const parsedLocation = useMemo(
@@ -153,6 +167,13 @@ export function LibraryRoutePage() {
   const selectionRouteState = useMemo(
     () => serializeLibrarySelectionState(selectionState),
     [selectionState]
+  );
+  const libraryViewRouteState = useMemo<LibraryViewRouteState>(
+    () => ({
+      sortDirection,
+      cursorByPage: normalizeCursorByPageState(cursorByPage)
+    }),
+    [cursorByPage, sortDirection]
   );
 
   const cursorForPage = cursorByPage[requestedPage];
@@ -226,6 +247,7 @@ export function LibraryRoutePage() {
     setCommittedQuery(parsedQuery);
     setFromDate(parsedUrlState.fromDate);
     setToDate(parsedUrlState.toDate);
+    setPageSize(parsedUrlState.pageSize);
     setSelectedPersonNames(parsedUrlState.selectedPersonNames);
     setPersonCertaintyMode(parsedUrlState.personCertaintyMode);
     setSuggestionConfidenceMinDraft(parsedUrlState.suggestionConfidenceMinDraft);
@@ -244,8 +266,12 @@ export function LibraryRoutePage() {
       }))
     );
 
-    setSortDirection("desc");
-    setCursorByPage({ 1: null });
+    if (shouldRestoreInitialViewStateRef.current) {
+      shouldRestoreInitialViewStateRef.current = false;
+    } else {
+      setSortDirection("desc");
+      setCursorByPage({ 1: null });
+    }
     setPhotos([]);
     setTotalCount(0);
   }, [parsedUrlState, parsedUrlStateSignature]);
@@ -266,7 +292,8 @@ export function LibraryRoutePage() {
       locationRadius: locationRadiusFilter,
       hasFacesFilter,
       pathHintFilters,
-      page: requestedPage
+      page: requestedPage,
+      pageSize
     });
 
     const currentQuery = location.search.startsWith("?")
@@ -294,6 +321,7 @@ export function LibraryRoutePage() {
     locationRadiusFilter,
     navigate,
     pathHintFilters,
+    pageSize,
     requestedPage,
     selectedPersonNames,
     personCertaintyMode,
@@ -309,13 +337,14 @@ export function LibraryRoutePage() {
   }, []);
 
   useEffect(() => {
-    const currentRouteSelection = parseLibrarySelectionRouteState(
-      isRecord(location.state)
-        ? location.state.librarySelection ?? location.state.browseSelection
-        : undefined
-    );
+    const currentRouteState = resolveBrowseReturnState(location.state);
+    const currentRouteSelection = currentRouteState?.librarySelection ?? null;
+    const currentRouteViewState = currentRouteState?.libraryViewState ?? null;
 
-    if (areSelectionRouteStatesEqual(currentRouteSelection, selectionRouteState)) {
+    if (
+      areSelectionRouteStatesEqual(currentRouteSelection, selectionRouteState)
+      && areLibraryViewRouteStatesEqual(currentRouteViewState, libraryViewRouteState)
+    ) {
       return;
     }
 
@@ -329,11 +358,19 @@ export function LibraryRoutePage() {
         replace: true,
         state: {
           ...routeState,
-          librarySelection: selectionRouteState
+          librarySelection: selectionRouteState,
+          libraryViewState: libraryViewRouteState
         }
       }
     );
-  }, [location.pathname, location.search, location.state, navigate, selectionRouteState]);
+  }, [
+    libraryViewRouteState,
+    location.pathname,
+    location.search,
+    location.state,
+    navigate,
+    selectionRouteState
+  ]);
 
   useEffect(() => {
     if (requestedPage > 1 && cursorForPage === undefined) {
@@ -362,7 +399,8 @@ export function LibraryRoutePage() {
       hasFacesFilter,
       pathHintFilters,
       sortDirection,
-      cursorForPage ?? null
+      cursorForPage ?? null,
+      pageSize
     )
       .then((payload) => {
         if (controller.signal.aborted) {
@@ -409,6 +447,7 @@ export function LibraryRoutePage() {
     personCertaintyMode,
     suggestionConfidenceMinDraft,
     sortDirection,
+    pageSize,
     toDate
   ]);
 
@@ -431,9 +470,40 @@ export function LibraryRoutePage() {
     };
   }, [reloadToken]);
 
+  useEffect(() => {
+    const pendingPhotoId = pendingReturnFocusPhotoIdRef.current;
+    if (!pendingPhotoId || isLoading) {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      if (error) {
+        headingRef.current?.focus();
+        pendingReturnFocusPhotoIdRef.current = null;
+        return;
+      }
+
+      const focusTarget = document.querySelector<HTMLAnchorElement>(
+        `[data-photo-id="${pendingPhotoId}"]`
+      );
+
+      if (focusTarget) {
+        focusTarget.focus();
+      } else {
+        headingRef.current?.focus();
+      }
+
+      pendingReturnFocusPhotoIdRef.current = null;
+    }, 0);
+
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [error, isLoading, photos]);
+
   const totalPages = useMemo(
-    () => Math.max(1, Math.ceil(totalCount / SEARCH_PAGE_LIMIT)),
-    [totalCount]
+    () => Math.max(1, Math.ceil(totalCount / pageSize)),
+    [totalCount, pageSize]
   );
   const canGoPrevious = requestedPage > 1 && !isLoading;
   const canGoNext = requestedPage < totalPages && !isLoading;
@@ -633,7 +703,8 @@ export function LibraryRoutePage() {
         hasFacesFilter,
         pathHintFilters,
         sortDirection,
-        previousCursor
+        previousCursor,
+        pageSize
       );
       nextCursorMap = updateCursorByPage(
         nextCursorMap,
@@ -661,8 +732,18 @@ export function LibraryRoutePage() {
         lastKnownPage={totalPages}
         canGoPrevious={canGoPrevious}
         canGoNext={canGoNext}
+        pageSize={pageSize}
+        pageSizeOptions={SEARCH_PAGE_LIMIT_OPTIONS}
         onSortDirectionChange={(nextDirection) => {
           setSortDirection(nextDirection);
+          setCursorByPage({ 1: null });
+          setPage(1);
+        }}
+        onPageSizeChange={(nextPageSize) => {
+          if (nextPageSize === pageSize) {
+            return;
+          }
+          setPageSize(nextPageSize);
           setCursorByPage({ 1: null });
           setPage(1);
         }}
@@ -771,15 +852,6 @@ export function LibraryRoutePage() {
       />
 
       <p className="browse-summary" aria-live="polite">{summaryLabel}</p>
-      <label className="browse-global-face-box-toggle">
-        <input
-          type="checkbox"
-          aria-label="Show face boxes on all photos"
-          checked={showGridFaceBoxes}
-          onChange={(event) => setShowGridFaceBoxes(event.currentTarget.checked)}
-        />
-        Show face boxes on all photos
-      </label>
 
       <LibrarySelectionPanel
         selectionState={selectionState}
@@ -828,16 +900,16 @@ export function LibraryRoutePage() {
         {!error && !isLoading && photos.length > 0 ? (
           <LibraryPhotoGrid
             photos={photos}
-            showAllFaceBoxes={showGridFaceBoxes}
-            selectedPhotoIds={selectionState.selectedPhotoIds}
             locationSearch={location.search}
             selectionRouteState={selectionRouteState}
-            onToggleSelection={(photoId) =>
+            libraryViewRouteState={libraryViewRouteState}
+            selectedPhotoIds={selectionState.selectedPhotoIds}
+            onTogglePhotoSelection={(photoId) => {
               dispatchSelection({
                 type: "togglePhotoSelection",
                 photoId
-              })
-            }
+              });
+            }}
           />
         ) : null}
       </FeedbackSurface>
@@ -863,6 +935,53 @@ function areSelectionRouteStatesEqual(
   }
 
   return left.selectedPhotoIds.every((photoId, index) => photoId === right.selectedPhotoIds[index]);
+}
+
+function normalizeCursorByPageState(
+  cursorByPage: Record<number, string | null>
+): Record<number, string | null> {
+  const normalized: Record<number, string | null> = {};
+  for (const [pageKey, cursor] of Object.entries(cursorByPage)) {
+    const pageNumber = Number.parseInt(pageKey, 10);
+    if (!Number.isInteger(pageNumber) || pageNumber < 1) {
+      continue;
+    }
+    if (typeof cursor !== "string" && cursor !== null) {
+      continue;
+    }
+    normalized[pageNumber] = cursor;
+  }
+  if (normalized[1] === undefined) {
+    normalized[1] = null;
+  }
+  return normalized;
+}
+
+function areLibraryViewRouteStatesEqual(
+  left: LibraryViewRouteState | null,
+  right: LibraryViewRouteState
+): boolean {
+  if (!left) {
+    return false;
+  }
+  if (left.sortDirection !== right.sortDirection) {
+    return false;
+  }
+
+  const leftCursorEntries = Object.entries(normalizeCursorByPageState(left.cursorByPage)).sort(
+    ([leftPage], [rightPage]) => Number(leftPage) - Number(rightPage)
+  );
+  const rightCursorEntries = Object.entries(normalizeCursorByPageState(right.cursorByPage)).sort(
+    ([leftPage], [rightPage]) => Number(leftPage) - Number(rightPage)
+  );
+  if (leftCursorEntries.length !== rightCursorEntries.length) {
+    return false;
+  }
+
+  return leftCursorEntries.every(([leftPage, leftCursor], index) => {
+    const [rightPage, rightCursor] = rightCursorEntries[index];
+    return leftPage === rightPage && leftCursor === rightCursor;
+  });
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -403,7 +403,7 @@ describe("PhotoDetailRoutePage", () => {
     });
   });
 
-  it("keeps face overlays coherent when switching image presentation mode", async () => {
+  it("keeps face overlays coherent while adjusting photo size", async () => {
     const user = userEvent.setup();
 
     fetchMock.mockResolvedValueOnce({
@@ -416,12 +416,13 @@ describe("PhotoDetailRoutePage", () => {
     expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
     expect(await screen.findByLabelText("Face region 1 for person-1")).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Fit to panel" }));
+    const sizeSlider = screen.getByRole("slider", { name: "Photo size" });
+    fireEvent.change(sizeSlider, { target: { value: "120" } });
 
     expect(await screen.findByLabelText("Face region 1 for person-1")).toBeInTheDocument();
   });
 
-  it("defaults preview mode to actual pixels", async () => {
+  it("does not render preview mode toggle buttons", async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,
       json: async () => buildPayload()
@@ -430,8 +431,10 @@ describe("PhotoDetailRoutePage", () => {
     renderDetail();
 
     expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Actual pixels" })).toHaveClass("is-active");
-    expect(screen.getByRole("button", { name: "Fit to panel" })).not.toHaveClass("is-active");
+    expect(screen.getByRole("group", { name: "Preview controls" })).toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Preview display mode" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Fit to panel" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Actual pixels" })).not.toBeInTheDocument();
   });
 
   it("loads the full-resolution original image when available", async () => {

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -70,8 +70,6 @@ type PhotoDetailPayload = {
 const MISSING_VALUE = "Not available";
 const EXIF_ATTRIBUTE_PREVIEW_MAX_CHARS = 30;
 
-type MediaPresentationMode = "fit" | "actual";
-
 type PersonRecord = {
   person_id: string;
   display_name: string;
@@ -259,7 +257,6 @@ export function PhotoDetailRoutePage() {
   const [error, setError] = useState<string | null>(null);
   const [isNotFound, setIsNotFound] = useState(false);
   const [reloadToken, setReloadToken] = useState(0);
-  const [mediaMode, setMediaMode] = useState<MediaPresentationMode>("actual");
   const [imageScalePercent, setImageScalePercent] = useState(100);
   const [isOriginalImageEnabled, setIsOriginalImageEnabled] = useState(true);
   const [originalImageRetrySrc, setOriginalImageRetrySrc] = useState<string | null>(null);
@@ -462,7 +459,6 @@ export function PhotoDetailRoutePage() {
   }, [detail?.metadata.exif_attributes]);
 
   const backLinkFocusPhotoId = detail?.photo_id ?? returnState.returnFocusPhotoId ?? photoId ?? null;
-  const mediaScale = imageScalePercent / 100;
   const thumbnailDataUrl = detail?.thumbnail
     ? `data:${detail.thumbnail.mime_type};base64,${detail.thumbnail.data_base64}`
     : null;
@@ -470,17 +466,7 @@ export function PhotoDetailRoutePage() {
   const shouldUseOriginalImage = Boolean(originalImageUrl && isOriginalImageEnabled);
   const activeOriginalImageSrc = shouldUseOriginalImage ? (originalImageRetrySrc ?? originalImageUrl) : null;
   const previewImageSrc = activeOriginalImageSrc ?? thumbnailDataUrl;
-  const mediaBaseWidthPx = shouldUseOriginalImage
-    ? (originalImageNaturalSize?.width ?? null)
-    : (detail?.thumbnail?.width ?? null);
-  const mediaStageStyle: CSSProperties = mediaMode === "fit"
-    ? { width: `${Math.max(25, imageScalePercent)}%` }
-    : {
-        width:
-          mediaBaseWidthPx !== null
-            ? `${Math.max(80, Math.round(mediaBaseWidthPx * mediaScale))}px`
-            : "auto"
-      };
+  const mediaStageStyle: CSSProperties = { width: `${Math.max(25, imageScalePercent)}%` };
 
   function handleFaceAssigned(faceId: string, personId: string) {
     setDetail((current) => (current ? applyFaceAssignment(current, faceId, personId) : current));
@@ -561,10 +547,11 @@ export function PhotoDetailRoutePage() {
             search: returnState.returnToLibrarySearch ?? ""
           }}
           state={
-            backLinkFocusPhotoId || returnState.librarySelection
+            backLinkFocusPhotoId || returnState.librarySelection || returnState.libraryViewState
               ? {
                   restoreFocusPhotoId: backLinkFocusPhotoId ?? undefined,
-                  librarySelection: returnState.librarySelection
+                  librarySelection: returnState.librarySelection,
+                  libraryViewState: returnState.libraryViewState
                 }
               : undefined
           }
@@ -597,21 +584,7 @@ export function PhotoDetailRoutePage() {
         <div className="detail-workspace">
           <article className="detail-preview-panel">
             <h2>Preview</h2>
-            <div className="detail-media-controls" role="group" aria-label="Preview display mode">
-              <button
-                type="button"
-                className={mediaMode === "fit" ? "is-active" : undefined}
-                onClick={() => setMediaMode("fit")}
-              >
-                Fit to panel
-              </button>
-              <button
-                type="button"
-                className={mediaMode === "actual" ? "is-active" : undefined}
-                onClick={() => setMediaMode("actual")}
-              >
-                Actual pixels
-              </button>
+            <div className="detail-media-controls" role="group" aria-label="Preview controls">
               <label className="detail-face-box-toggle">
                 <input
                   type="checkbox"
@@ -650,7 +623,7 @@ export function PhotoDetailRoutePage() {
               </p>
             ) : null}
             {previewImageSrc ? (
-              <div className="detail-media-frame" data-mode={mediaMode}>
+              <div className="detail-media-frame">
                 <div className="detail-media-stage" style={mediaStageStyle}>
                   <img
                     className="detail-media-image"

--- a/apps/ui/src/pages/browseFocusState.ts
+++ b/apps/ui/src/pages/browseFocusState.ts
@@ -2,16 +2,24 @@ import {
   parseLibrarySelectionRouteState,
   type LibrarySelectionRouteState
 } from "./library/librarySelection";
+import type { SortDirection } from "./library/libraryRouteTypes";
+
+export interface LibraryViewRouteState {
+  sortDirection: SortDirection;
+  cursorByPage: Record<number, string | null>;
+}
 
 export interface BrowseReturnState {
   restoreFocusPhotoId?: string;
   librarySelection?: LibrarySelectionRouteState;
+  libraryViewState?: LibraryViewRouteState;
 }
 
 export interface DetailReturnState {
   returnToLibrarySearch?: string;
   returnFocusPhotoId?: string;
   librarySelection?: LibrarySelectionRouteState;
+  libraryViewState?: LibraryViewRouteState;
 }
 
 let pendingBrowseFocusPhotoId: string | null = null;
@@ -39,16 +47,18 @@ export function resolveBrowseReturnState(state: unknown): BrowseReturnState | nu
   const librarySelection = parseLibrarySelectionRouteState(
     state.librarySelection ?? state.browseSelection
   );
+  const libraryViewState = parseLibraryViewRouteState(state.libraryViewState);
   const hasRestoreFocusPhotoId =
     typeof restoreFocusPhotoId === "string" && restoreFocusPhotoId.length > 0;
 
-  if (!hasRestoreFocusPhotoId && !librarySelection) {
+  if (!hasRestoreFocusPhotoId && !librarySelection && !libraryViewState) {
     return null;
   }
 
   return {
     restoreFocusPhotoId: hasRestoreFocusPhotoId ? restoreFocusPhotoId : undefined,
-    librarySelection: librarySelection ?? undefined
+    librarySelection: librarySelection ?? undefined,
+    libraryViewState: libraryViewState ?? undefined
   };
 }
 
@@ -72,6 +82,47 @@ export function resolveDetailReturnState(state: unknown): DetailReturnState {
   if (librarySelection) {
     returnState.librarySelection = librarySelection;
   }
+  const libraryViewState = parseLibraryViewRouteState(state.libraryViewState);
+  if (libraryViewState) {
+    returnState.libraryViewState = libraryViewState;
+  }
 
   return returnState;
+}
+
+function parseLibraryViewRouteState(value: unknown): LibraryViewRouteState | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const sortDirection = value.sortDirection;
+  if (sortDirection !== "asc" && sortDirection !== "desc") {
+    return null;
+  }
+
+  const cursorByPageValue = value.cursorByPage;
+  if (!isRecord(cursorByPageValue)) {
+    return null;
+  }
+
+  const cursorByPage: Record<number, string | null> = {};
+  for (const [key, cursor] of Object.entries(cursorByPageValue)) {
+    const pageNumber = Number.parseInt(key, 10);
+    if (!Number.isInteger(pageNumber) || pageNumber < 1) {
+      return null;
+    }
+    if (typeof cursor !== "string" && cursor !== null) {
+      return null;
+    }
+    cursorByPage[pageNumber] = cursor;
+  }
+
+  if (cursorByPage[1] === undefined) {
+    cursorByPage[1] = null;
+  }
+
+  return {
+    sortDirection,
+    cursorByPage
+  };
 }

--- a/apps/ui/src/pages/library/LibraryPageNavigator.test.tsx
+++ b/apps/ui/src/pages/library/LibraryPageNavigator.test.tsx
@@ -9,7 +9,10 @@ describe("LibraryPageNavigator", () => {
         lastKnownPage={12}
         canGoPrevious
         canGoNext
+        pageSize={60}
+        pageSizeOptions={[24, 60, 120]}
         onSelectPage={vi.fn()}
+        onPageSizeChange={vi.fn()}
       />
     );
 
@@ -26,6 +29,7 @@ describe("LibraryPageNavigator", () => {
 
   it("wires button actions to callbacks", () => {
     const onSelectPage = vi.fn();
+    const onPageSizeChange = vi.fn();
 
     render(
       <LibraryPageNavigator
@@ -33,15 +37,22 @@ describe("LibraryPageNavigator", () => {
         lastKnownPage={3}
         canGoPrevious
         canGoNext
+        pageSize={60}
+        pageSizeOptions={[24, 60, 120]}
         onSelectPage={onSelectPage}
+        onPageSizeChange={onPageSizeChange}
       />
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Previous page" }));
     fireEvent.click(screen.getByRole("button", { name: "Page 3" }));
+    fireEvent.change(screen.getByRole("combobox", { name: "Photos per page" }), {
+      target: { value: "120" }
+    });
 
     expect(onSelectPage).toHaveBeenCalledWith(1);
     expect(onSelectPage).toHaveBeenCalledWith(3);
+    expect(onPageSizeChange).toHaveBeenCalledWith(120);
   });
 
   it("respects disabled navigation flags", () => {
@@ -51,7 +62,10 @@ describe("LibraryPageNavigator", () => {
         lastKnownPage={1}
         canGoPrevious={false}
         canGoNext={false}
+        pageSize={60}
+        pageSizeOptions={[24, 60, 120]}
         onSelectPage={vi.fn()}
+        onPageSizeChange={vi.fn()}
       />
     );
 

--- a/apps/ui/src/pages/library/LibraryPageNavigator.tsx
+++ b/apps/ui/src/pages/library/LibraryPageNavigator.tsx
@@ -5,7 +5,10 @@ interface LibraryPageNavigatorProps {
   lastKnownPage: number;
   canGoPrevious: boolean;
   canGoNext: boolean;
+  pageSize: number;
+  pageSizeOptions: readonly number[];
   onSelectPage: (pageNumber: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
 }
 
 export function LibraryPageNavigator({
@@ -13,10 +16,27 @@ export function LibraryPageNavigator({
   lastKnownPage,
   canGoPrevious,
   canGoNext,
-  onSelectPage
+  pageSize,
+  pageSizeOptions,
+  onSelectPage,
+  onPageSizeChange
 }: LibraryPageNavigatorProps) {
   return (
     <div className="browse-pagination" aria-label="Pagination controls">
+      <label className="browse-page-size-control">
+        Photos per page
+        <select
+          aria-label="Photos per page"
+          value={String(pageSize)}
+          onChange={(event) => onPageSizeChange(Number.parseInt(event.currentTarget.value, 10))}
+        >
+          {pageSizeOptions.map((option) => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+      </label>
       <ReactPaginate
         previousLabel="<"
         nextLabel=">"

--- a/apps/ui/src/pages/library/LibraryPhotoGrid.tsx
+++ b/apps/ui/src/pages/library/LibraryPhotoGrid.tsx
@@ -1,167 +1,108 @@
-import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { deriveIngestStatus, INGEST_STATUS_LEGEND } from "../../app/ingestStatus";
-import {
-  buildFaceOverlayRegions,
-  FaceBBoxOverlay,
-  type FaceBBoxOverlayFace
-} from "../FaceBBoxOverlay";
-import { LibraryPhotoFacePanel } from "./LibraryPhotoFacePanel";
-import { PhotoResultIdentity } from "./PhotoResultIdentity";
-import {
-  formatFilesize,
-  formatShotTimestamp
-} from "./libraryRouteFormatting";
 import type { LibraryPhoto } from "./libraryRouteTypes";
 import type { serializeLibrarySelectionState } from "./librarySelection";
 
 interface LibraryPhotoGridProps {
   photos: LibraryPhoto[];
-  showAllFaceBoxes: boolean;
-  selectedPhotoIds: Set<string>;
   locationSearch: string;
   selectionRouteState: ReturnType<typeof serializeLibrarySelectionState>;
-  onToggleSelection: (photoId: string) => void;
+  selectedPhotoIds: Set<string>;
+  onTogglePhotoSelection: (photoId: string) => void;
+  libraryViewRouteState: {
+    sortDirection: "asc" | "desc";
+    cursorByPage: Record<number, string | null>;
+  };
 }
 
-type PhotoFaceDetailPayload = {
-  photo_id: string;
-  faces: FaceBBoxOverlayFace[];
-};
+function formatDisplayPath(path: string): string {
+  const marker = "/storage-sources/";
+  const markerIndex = path.indexOf(marker);
+  if (markerIndex < 0) {
+    return path;
+  }
 
-const INGEST_STATUS_LEGEND_TOOLTIP = INGEST_STATUS_LEGEND
-  .map((entry) => `${entry.label}: ${entry.description}`)
-  .join("\n");
+  const pathAfterMarker = path.slice(markerIndex + marker.length);
+  const firstSlashAfterSourceId = pathAfterMarker.indexOf("/");
+  if (firstSlashAfterSourceId < 0) {
+    return path;
+  }
+
+  const sourceRelativePath = pathAfterMarker.slice(firstSlashAfterSourceId + 1).trim();
+  if (!sourceRelativePath) {
+    return path;
+  }
+
+  return `.../${sourceRelativePath}`;
+}
+
+function summarizePhotoFaces(photo: LibraryPhoto): {
+  detectedFaces: number;
+  humanAssignedPeople: number;
+  machineSuggestedFaces: number;
+} {
+  const faces = photo.faces ?? [];
+  const humanPeople = new Set<string>();
+  let machineSuggestedFaces = 0;
+
+  faces.forEach((face) => {
+    if (face.label_source === "human_confirmed" && face.person_id) {
+      humanPeople.add(face.person_id);
+    }
+    if (face.label_source === "machine_suggested" && typeof face.confidence === "number") {
+      machineSuggestedFaces += 1;
+    }
+  });
+
+  return {
+    detectedFaces: faces.length,
+    humanAssignedPeople: humanPeople.size,
+    machineSuggestedFaces
+  };
+}
 
 export function LibraryPhotoGrid({
   photos,
-  showAllFaceBoxes,
-  selectedPhotoIds,
   locationSearch,
   selectionRouteState,
-  onToggleSelection
+  selectedPhotoIds,
+  onTogglePhotoSelection,
+  libraryViewRouteState
 }: LibraryPhotoGridProps) {
-  const [photoFaceBoxVisibility, setPhotoFaceBoxVisibility] = useState<Record<string, boolean>>({});
-  const [photoFaceDetails, setPhotoFaceDetails] = useState<Record<string, PhotoFaceDetailPayload | null>>({});
-  const [photoFaceDetailStatus, setPhotoFaceDetailStatus] = useState<
-    Record<string, "loading" | "loaded" | "failed">
-  >({});
-
-  const activeFaceOverlayPhotoIds = useMemo(
-    () =>
-      photos
-        .filter((photo) => {
-          const hasDetectedFaces = (photo.faces?.length ?? 0) > 0;
-          const hasThumbnail = Boolean(photo.thumbnail);
-          const isRequested = showAllFaceBoxes || Boolean(photoFaceBoxVisibility[photo.photo_id]);
-          return hasDetectedFaces && hasThumbnail && isRequested;
-        })
-        .map((photo) => photo.photo_id),
-    [photos, photoFaceBoxVisibility, showAllFaceBoxes]
-  );
-
-  useEffect(() => {
-    const controller = new AbortController();
-
-    activeFaceOverlayPhotoIds.forEach((photoId) => {
-      if (photoFaceDetailStatus[photoId]) {
-        return;
-      }
-
-      setPhotoFaceDetailStatus((current) => ({ ...current, [photoId]: "loading" }));
-
-      fetch(`/api/v1/photos/${photoId}`, { signal: controller.signal })
-        .then(async (response) => {
-          if (!response.ok) {
-            throw new Error(`Photo detail request failed (${response.status})`);
-          }
-          const payload = (await response.json()) as PhotoFaceDetailPayload;
-          setPhotoFaceDetails((current) => ({ ...current, [photoId]: payload }));
-          setPhotoFaceDetailStatus((current) => ({ ...current, [photoId]: "loaded" }));
-        })
-        .catch(() => {
-          if (controller.signal.aborted) {
-            return;
-          }
-          setPhotoFaceDetails((current) => ({ ...current, [photoId]: null }));
-          setPhotoFaceDetailStatus((current) => ({ ...current, [photoId]: "failed" }));
-        });
-    });
-
-    return () => {
-      controller.abort();
-    };
-  }, [activeFaceOverlayPhotoIds, photoFaceDetailStatus]);
-
   return (
     <ol className="browse-grid" aria-label="Photo gallery">
       {photos.map((photo) => {
-        const ingestStatus = deriveIngestStatus({
-          availabilityState: photo.original?.availability_state ?? null,
-          isAvailable: photo.original?.is_available ?? null,
-          lastFailureReason: photo.original?.last_failure_reason ?? null,
-          hasThumbnail: Boolean(photo.thumbnail)
-        });
-        const hasDetectedFaces = (photo.faces?.length ?? 0) > 0;
-        const showFaceBoxesForPhoto =
-          hasDetectedFaces && (showAllFaceBoxes || Boolean(photoFaceBoxVisibility[photo.photo_id]));
-        const detailPayload = photoFaceDetails[photo.photo_id] ?? null;
-        const overlayRegions =
-          showFaceBoxesForPhoto && photo.thumbnail && detailPayload
-            ? buildFaceOverlayRegions(
-                detailPayload.faces,
-                photo.thumbnail.width,
-                photo.thumbnail.height
-              )
-            : [];
-
+        const metrics = summarizePhotoFaces(photo);
+        const displayPath = formatDisplayPath(photo.path);
+        const isSelected = selectedPhotoIds.has(photo.photo_id);
         return (
-          <li key={photo.photo_id} className="browse-card">
-            <p className="browse-ingest-status">
-              <span
-                className={`ingest-status-badge is-${ingestStatus.tone}`}
-                title={INGEST_STATUS_LEGEND_TOOLTIP}
-                aria-label={`Ingest status ${ingestStatus.label}. Hover for full status legend.`}
-              >
-                {ingestStatus.label}
-              </span>
-            </p>
-            <label className="browse-card-selection">
+          <li
+            key={photo.photo_id}
+            className={`browse-card${isSelected ? " browse-card-selected" : ""}`}
+          >
+            <label className="browse-card-checkbox-badge">
               <input
                 type="checkbox"
-                checked={selectedPhotoIds.has(photo.photo_id)}
-                onChange={() => onToggleSelection(photo.photo_id)}
-              />
-              Select photo
-            </label>
-            <label className="browse-card-face-box-toggle">
-              <input
-                type="checkbox"
-                aria-label={`Show face boxes for ${photo.photo_id}`}
-                checked={showFaceBoxesForPhoto}
-                disabled={!hasDetectedFaces || showAllFaceBoxes}
-                onChange={(event) => {
-                  const nextChecked = event.currentTarget.checked;
-                  setPhotoFaceBoxVisibility((current) => ({
-                    ...current,
-                    [photo.photo_id]: nextChecked
-                  }));
+                checked={isSelected}
+                aria-label={`Select photo ${photo.photo_id}`}
+                onChange={() => {
+                  onTogglePhotoSelection(photo.photo_id);
                 }}
               />
-              Show face boxes
             </label>
-            {photo.thumbnail ? (
-              <Link
-                className="browse-thumbnail-link"
-                data-photo-id={photo.photo_id}
-                to={`/library/${photo.photo_id}`}
-                state={{
-                  returnToLibrarySearch: locationSearch,
-                  returnFocusPhotoId: photo.photo_id,
-                  librarySelection: selectionRouteState
-                }}
-                aria-label={`View details for ${photo.path}`}
-              >
+            <div className="browse-thumbnail-shell">
+            <Link
+              className="browse-thumbnail-link"
+              data-photo-id={photo.photo_id}
+              to={`/library/${photo.photo_id}`}
+              state={{
+                returnToLibrarySearch: locationSearch,
+                returnFocusPhotoId: photo.photo_id,
+                librarySelection: selectionRouteState,
+                libraryViewState: libraryViewRouteState
+              }}
+              aria-label={`Open details for ${photo.path}`}
+            >
+              {photo.thumbnail ? (
                 <img
                   className="browse-thumbnail"
                   src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
@@ -169,55 +110,32 @@ export function LibraryPhotoGrid({
                   height={photo.thumbnail.height}
                   alt={`Preview of ${photo.path}`}
                 />
-                <FaceBBoxOverlay
-                  regions={overlayRegions}
-                  ariaLabel={`Detected face regions for ${photo.photo_id}`}
-                />
-              </Link>
-            ) : (
-              <div className="browse-thumbnail browse-thumbnail-placeholder" aria-hidden="true">
-                No preview
-              </div>
-            )}
+              ) : (
+                <div className="browse-thumbnail browse-thumbnail-placeholder" aria-hidden="true">
+                  No preview
+                </div>
+              )}
+            </Link>
+            </div>
             <div className="browse-card-body">
-              <PhotoResultIdentity
-                title={
-                  <Link
-                    className="browse-photo-link"
-                    data-photo-id={photo.photo_id}
-                    to={`/library/${photo.photo_id}`}
-                    state={{
-                      returnToLibrarySearch: locationSearch,
-                      returnFocusPhotoId: photo.photo_id,
-                      librarySelection: selectionRouteState
-                    }}
-                  >
-                    View details
-                  </Link>
-                }
-                path={photo.path}
-                pathClassName="browse-path"
-              />
-              <dl>
+              <p className="browse-path" title={photo.path}>
+                {displayPath}
+              </p>
+              <dl className="browse-card-metrics">
                 <div>
-                  <dt>Captured</dt>
-                  <dd>{formatShotTimestamp(photo.shot_ts)}</dd>
+                  <dt>Faces detected</dt>
+                  <dd>{metrics.detectedFaces}</dd>
                 </div>
                 <div>
-                  <dt>Size</dt>
-                  <dd>{formatFilesize(photo.filesize)}</dd>
+                  <dt>People assigned (human)</dt>
+                  <dd>{metrics.humanAssignedPeople}</dd>
                 </div>
                 <div>
-                  <dt>People</dt>
-                  <dd>{photo.people?.length ?? 0}</dd>
-                </div>
-                <div>
-                  <dt>Original</dt>
-                  <dd>{photo.original?.availability_state ?? "unknown"}</dd>
+                  <dt>Machine suggestions</dt>
+                  <dd>{metrics.machineSuggestedFaces}</dd>
                 </div>
               </dl>
             </div>
-            <LibraryPhotoFacePanel photo={photo} />
           </li>
         );
       })}

--- a/apps/ui/src/pages/library/LibraryRouteHeader.tsx
+++ b/apps/ui/src/pages/library/LibraryRouteHeader.tsx
@@ -10,8 +10,11 @@ interface LibraryRouteHeaderProps {
   lastKnownPage: number;
   canGoPrevious: boolean;
   canGoNext: boolean;
+  pageSize: number;
+  pageSizeOptions: readonly number[];
   onSortDirectionChange: (direction: SortDirection) => void;
   onSelectPage: (pageNumber: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
 }
 
 export function LibraryRouteHeader({
@@ -21,8 +24,11 @@ export function LibraryRouteHeader({
   lastKnownPage,
   canGoPrevious,
   canGoNext,
+  pageSize,
+  pageSizeOptions,
   onSortDirectionChange,
-  onSelectPage
+  onSelectPage,
+  onPageSizeChange
 }: LibraryRouteHeaderProps) {
   return (
     <div className="browse-header">
@@ -42,7 +48,10 @@ export function LibraryRouteHeader({
           lastKnownPage={lastKnownPage}
           canGoPrevious={canGoPrevious}
           canGoNext={canGoNext}
+          pageSize={pageSize}
+          pageSizeOptions={pageSizeOptions}
           onSelectPage={onSelectPage}
+          onPageSizeChange={onPageSizeChange}
         />
       </div>
     </div>

--- a/apps/ui/src/pages/library/PhotoResultIdentity.test.tsx
+++ b/apps/ui/src/pages/library/PhotoResultIdentity.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { PhotoResultIdentity } from "./PhotoResultIdentity";
+
+describe("PhotoResultIdentity", () => {
+  it("renders title content and path text with tooltip", () => {
+    render(
+      <PhotoResultIdentity
+        title={<span>photo-123</span>}
+        path="/storage-sources/source-a/folder/image_9999.jpg"
+        pathClassName="browse-path"
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "photo-123" })).toBeInTheDocument();
+    const pathElement = screen.getByText("/storage-sources/source-a/folder/image_9999.jpg");
+    expect(pathElement).toHaveClass("browse-path");
+    expect(pathElement).toHaveAttribute(
+      "title",
+      "/storage-sources/source-a/folder/image_9999.jpg"
+    );
+  });
+});

--- a/apps/ui/src/pages/library/libraryPageSize.ts
+++ b/apps/ui/src/pages/library/libraryPageSize.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_SEARCH_PAGE_LIMIT = 60;
+export const SEARCH_PAGE_LIMIT_OPTIONS = [24, 60, 120] as const;
+
+export type SearchPageLimit = (typeof SEARCH_PAGE_LIMIT_OPTIONS)[number];

--- a/apps/ui/src/pages/library/libraryRouteApi.ts
+++ b/apps/ui/src/pages/library/libraryRouteApi.ts
@@ -1,5 +1,10 @@
 import { isLibraryActionConflictActive } from "./operationsActivity";
 import { buildSearchFilters } from "./libraryRouteSearchState";
+import {
+  DEFAULT_SEARCH_PAGE_LIMIT,
+  SEARCH_PAGE_LIMIT_OPTIONS,
+  type SearchPageLimit
+} from "./libraryPageSize";
 import type {
   LibraryLocationRadius,
   PersonCertaintyMode,
@@ -8,7 +13,7 @@ import type {
   SortDirection
 } from "./libraryRouteTypes";
 
-export const SEARCH_PAGE_LIMIT = 24;
+export { DEFAULT_SEARCH_PAGE_LIMIT, SEARCH_PAGE_LIMIT_OPTIONS, type SearchPageLimit };
 
 export async function fetchLibraryPage(
   query: string,
@@ -21,7 +26,8 @@ export async function fetchLibraryPage(
   hasFaces: boolean | null,
   pathHints: string[],
   sortDirection: SortDirection,
-  cursor: string | null
+  cursor: string | null,
+  pageLimit: number
 ): Promise<SearchResponsePayload> {
   const searchFilters = buildSearchFilters(
     fromDate,
@@ -47,7 +53,7 @@ export async function fetchLibraryPage(
         dir: sortDirection
       },
       page: {
-        limit: SEARCH_PAGE_LIMIT,
+        limit: pageLimit,
         cursor
       }
     })

--- a/apps/ui/src/pages/library/libraryRouteFormatting.test.ts
+++ b/apps/ui/src/pages/library/libraryRouteFormatting.test.ts
@@ -1,0 +1,18 @@
+import { formatFilesize, formatShotTimestamp } from "./libraryRouteFormatting";
+
+describe("libraryRouteFormatting", () => {
+  it("formats null or invalid timestamps deterministically", () => {
+    expect(formatShotTimestamp(null)).toBe("Unknown capture time");
+    expect(formatShotTimestamp("not-a-timestamp")).toBe("not-a-timestamp");
+  });
+
+  it("formats valid timestamps in UTC", () => {
+    expect(formatShotTimestamp("2026-05-01T15:30:00Z")).toBe("May 1, 2026, 3:30 PM");
+  });
+
+  it("formats file sizes across byte, KB, and MB ranges", () => {
+    expect(formatFilesize(512)).toBe("512 B");
+    expect(formatFilesize(1536)).toBe("1.5 KB");
+    expect(formatFilesize(3 * 1024 * 1024)).toBe("3.0 MB");
+  });
+});

--- a/apps/ui/src/pages/library/libraryRouteSearchState.test.ts
+++ b/apps/ui/src/pages/library/libraryRouteSearchState.test.ts
@@ -1,7 +1,8 @@
 import {
   buildLibraryUrlQuery,
   buildSearchFilters,
-  parseLibraryUrlState
+  parseLibraryUrlState,
+  validateDateRange
 } from "./libraryRouteSearchState";
 
 describe("libraryRouteSearchState", () => {
@@ -50,5 +51,25 @@ describe("libraryRouteSearchState", () => {
     expect(query).toContain("personCertainty=include_suggestions");
     expect(query).toContain("suggestionMin=0.82");
     expect(query).toContain("pageSize=24");
+  });
+
+  it("validates descending date ranges", () => {
+    expect(validateDateRange("2026-05-10", "2026-05-01")).toBe(
+      "From date must be on or before To date."
+    );
+    expect(validateDateRange("2026-05-01", "2026-05-10")).toBeNull();
+  });
+
+  it("builds person filters without machine suggestion threshold for human-only mode", () => {
+    expect(
+      buildSearchFilters("", "", ["Inez"], "human_only", "0.95", null, null, [])
+    ).toEqual({
+      person_names: ["Inez"],
+      person_certainty_mode: "human_only"
+    });
+  });
+
+  it("returns null when no search filters are active", () => {
+    expect(buildSearchFilters("", "", [], "human_only", "0.8", null, null, [])).toBeNull();
   });
 });

--- a/apps/ui/src/pages/library/libraryRouteSearchState.test.ts
+++ b/apps/ui/src/pages/library/libraryRouteSearchState.test.ts
@@ -10,6 +10,7 @@ describe("libraryRouteSearchState", () => {
 
     expect(state.personCertaintyMode).toBe("human_only");
     expect(state.suggestionConfidenceMinDraft).toBe("0.8");
+    expect(state.pageSize).toBe(60);
   });
 
   it("serializes certainty mode and threshold into search filters", () => {
@@ -42,10 +43,12 @@ describe("libraryRouteSearchState", () => {
       locationRadius: null,
       hasFacesFilter: null,
       pathHintFilters: [],
-      page: 1
+      page: 1,
+      pageSize: 24
     });
 
     expect(query).toContain("personCertainty=include_suggestions");
     expect(query).toContain("suggestionMin=0.82");
+    expect(query).toContain("pageSize=24");
   });
 });

--- a/apps/ui/src/pages/library/libraryRouteSearchState.ts
+++ b/apps/ui/src/pages/library/libraryRouteSearchState.ts
@@ -5,6 +5,7 @@ import {
 import { normalizePathHintFilters } from "../search/facetFilters";
 import {
   dedupeTrimmedValues,
+  parsePageSizeParam,
   parseNullableBooleanParam
 } from "./urlSerialization";
 import type {
@@ -12,6 +13,10 @@ import type {
   PersonCertaintyMode,
   SearchUrlState
 } from "./libraryRouteTypes";
+import {
+  DEFAULT_SEARCH_PAGE_LIMIT,
+  SEARCH_PAGE_LIMIT_OPTIONS
+} from "./libraryPageSize";
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const DEFAULT_PERSON_CERTAINTY_MODE: PersonCertaintyMode = "human_only";
@@ -147,6 +152,11 @@ export function parseLibraryUrlState(search: string): SearchUrlState {
     queryChips,
     fromDate,
     toDate,
+    pageSize: parsePageSizeParam(
+      params.get("pageSize"),
+      SEARCH_PAGE_LIMIT_OPTIONS,
+      DEFAULT_SEARCH_PAGE_LIMIT
+    ),
     selectedPersonNames,
     personCertaintyMode,
     suggestionConfidenceMinDraft,
@@ -170,6 +180,7 @@ export function buildLibraryUrlQuery(state: {
   hasFacesFilter: boolean | null;
   pathHintFilters: string[];
   page: number;
+  pageSize: number;
 }): string {
   const params = new URLSearchParams();
 
@@ -207,6 +218,9 @@ export function buildLibraryUrlQuery(state: {
   }
   if (state.page > 1) {
     params.set("page", String(state.page));
+  }
+  if (state.pageSize !== DEFAULT_SEARCH_PAGE_LIMIT) {
+    params.set("pageSize", String(state.pageSize));
   }
 
   return params.toString();

--- a/apps/ui/src/pages/library/libraryRouteTypes.ts
+++ b/apps/ui/src/pages/library/libraryRouteTypes.ts
@@ -10,7 +10,11 @@ export type LibraryPhoto = {
   shot_ts: string | null;
   filesize: number;
   people?: string[];
-  faces?: Array<{ person_id: string | null }>;
+  faces?: Array<{
+    person_id: string | null;
+    label_source?: "human_confirmed" | "machine_suggested" | null;
+    confidence?: number | null;
+  }>;
   thumbnail?: {
     mime_type: string;
     width: number;
@@ -48,6 +52,7 @@ export type SearchUrlState = {
   queryChips: string[];
   fromDate: string;
   toDate: string;
+  pageSize: number;
   selectedPersonNames: string[];
   personCertaintyMode: PersonCertaintyMode;
   suggestionConfidenceMinDraft: string;

--- a/apps/ui/src/pages/library/urlSerialization.ts
+++ b/apps/ui/src/pages/library/urlSerialization.ts
@@ -38,3 +38,23 @@ export function parseNullableBooleanParam(rawValue: string | null): boolean | nu
   }
   return null;
 }
+
+export function parsePageSizeParam(
+  rawValue: string | null,
+  allowedValues: readonly number[],
+  defaultValue: number
+): number {
+  const candidate = (rawValue ?? "").trim();
+  if (!candidate) {
+    return defaultValue;
+  }
+
+  const parsed = Number.parseInt(candidate, 10);
+  if (!Number.isFinite(parsed)) {
+    return defaultValue;
+  }
+  if (!allowedValues.includes(parsed)) {
+    return defaultValue;
+  }
+  return parsed;
+}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -228,6 +228,23 @@ body {
   justify-content: flex-end;
 }
 
+.browse-page-size-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.82rem;
+  color: #1e293b;
+}
+
+.browse-page-size-control select {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  padding: 0.25rem 0.4rem;
+  background: #ffffff;
+  color: #0f172a;
+  font: inherit;
+}
+
 .browse-pagination button {
   border: 1px solid #bfdbfe;
   background: #eff6ff;
@@ -448,57 +465,57 @@ body {
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 0.85rem;
-  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: 0.7rem;
+  grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
 }
 
 .browse-card {
   border: 1px solid #cbd5e1;
   border-radius: 0.7rem;
   background: #ffffff;
-  overflow: hidden;
+  overflow: visible;
   display: grid;
-  grid-template-rows: auto auto 9rem 1fr;
+  grid-template-rows: auto 1fr;
+  position: relative;
 }
 
-.browse-ingest-status {
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.55rem 0.75rem 0.2rem;
+.browse-card-selected {
+  border-width: 2px;
+  border-color: #1d4ed8;
 }
 
-.browse-ingest-status .ingest-status-badge {
-  cursor: help;
-}
-
-.browse-ingest-status-detail {
-  color: #334155;
-  font-size: 0.75rem;
-}
-
-.browse-card-selection {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0 0.75rem 0.55rem;
-  font-size: 0.82rem;
-  color: #1e293b;
-}
-
-.browse-card-face-box-toggle {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0 0.75rem 0.55rem;
-  font-size: 0.8rem;
-  color: #334155;
+.browse-thumbnail-shell {
+  position: relative;
+  overflow: hidden;
+  border-radius: 0.7rem 0.7rem 0 0;
 }
 
 .browse-thumbnail-link {
   position: relative;
   display: block;
+  aspect-ratio: 4 / 3;
+  background: #e2e8f0;
+}
+
+.browse-card-checkbox-badge {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translate(-50%, -50%);
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.3);
+  background: rgba(248, 250, 252, 0.95);
+  cursor: pointer;
+}
+
+.browse-card-checkbox-badge input {
+  margin: 0;
 }
 
 .browse-thumbnail {
@@ -516,24 +533,9 @@ body {
 }
 
 .browse-card-body {
-  padding: 0.65rem 0.75rem 0.8rem;
+  padding: 0.55rem 0.6rem 0.65rem;
   display: grid;
-  gap: 0.5rem;
-}
-
-.browse-card-body h2 {
-  margin: 0;
-  font-size: 0.95rem;
-  color: #0f172a;
-}
-
-.browse-photo-link {
-  color: inherit;
-}
-
-.browse-photo-link:hover,
-.browse-photo-link:focus-visible {
-  color: #1d4ed8;
+  gap: 0.45rem;
 }
 
 .browse-path {
@@ -542,13 +544,15 @@ body {
   font-size: 0.8rem;
   white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
+  text-overflow: clip;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .browse-card-body dl {
   margin: 0;
   display: grid;
-  gap: 0.3rem;
+  gap: 0.25rem;
 }
 
 .browse-card-body dl div {
@@ -558,13 +562,13 @@ body {
 }
 
 .browse-card-body dt {
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   color: #475569;
 }
 
 .browse-card-body dd {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   color: #0f172a;
   text-align: right;
 }
@@ -858,10 +862,6 @@ body {
     height: clamp(16rem, calc(100dvh - 18rem), 70rem);
     max-height: calc(100dvh - 8rem);
   }
-}
-
-.detail-media-frame[data-mode="actual"] {
-  overflow: auto;
 }
 
 .detail-media-stage {
@@ -2058,10 +2058,6 @@ body {
 
   .library-action-buttons button {
     width: 100%;
-  }
-
-  .browse-card {
-    grid-template-rows: 7.5rem 1fr;
   }
 
   .search-query-row {

--- a/apps/ui/tests/e2e/journeys/library-navigation-face-assignment.spec.ts
+++ b/apps/ui/tests/e2e/journeys/library-navigation-face-assignment.spec.ts
@@ -146,7 +146,7 @@ test("JRN-P4-library-navigation-state-persists-through-detail @journey", async (
 
   await page.goto("/library");
   await expect(page.getByRole("heading", { name: "Library", level: 1 })).toBeVisible();
-  await page.getByRole("link", { name: "View details", exact: true }).click();
+  await page.getByRole("link", { name: "Open details for /library/photo-1.jpg" }).click();
 
   await expect(page).toHaveURL(/\/library\/photo-1$/);
   await expect(page.getByRole("heading", { name: "Photo detail", level: 1 })).toBeVisible();
@@ -249,7 +249,7 @@ test("JRN-P4-detail-face-assignment-from-suggestions @journey", async ({ page })
   });
 
   await page.goto("/library");
-  await page.getByRole("link", { name: "View details", exact: true }).click();
+  await page.getByRole("link", { name: "Open details for /library/photo-1.jpg" }).click();
 
   await expect(page.getByRole("heading", { name: "Photo detail", level: 1 })).toBeVisible();
   const assignmentTrigger = page.getByRole("button", {

--- a/apps/ui/tests/e2e/journeys/library-unification-journeys.spec.ts
+++ b/apps/ui/tests/e2e/journeys/library-unification-journeys.spec.ts
@@ -106,7 +106,7 @@ test("JRN-P4-library-shared-request-lifecycle @journey", async ({ page }) => {
 
   initialRequestsReleased = true;
   releaseGateResolver?.();
-  await expect(page.getByRole("link", { name: "View details" })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Open details for/ })).toBeVisible();
   await expect(page.getByText("/library/browse-photo-1.jpg")).toBeVisible();
 
   failNextBrowseRequest = true;
@@ -114,7 +114,7 @@ test("JRN-P4-library-shared-request-lifecycle @journey", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Could not load Library", level: 2 })).toBeVisible();
 
   await page.getByRole("button", { name: "Retry" }).click();
-  await expect(page.getByRole("link", { name: "View details" })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Open details for/ })).toBeVisible();
 });
 
 test("JRN-P4-library-invalid-page-reset @journey", async ({ page }) => {
@@ -194,7 +194,7 @@ test("JRN-P4-library-filtered-shared-request-lifecycle @journey", async ({ page 
   await expect(page.getByRole("status")).toContainText("Loading library workflow.");
 
   releaseFirstSearchResponse?.();
-  await expect(page.getByRole("link", { name: "View details" })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Open details for/ })).toBeVisible();
   await expect(page.getByText("/library/search-photo-1.jpg")).toBeVisible();
 
   await page.getByRole("textbox", { name: "Search query" }).fill("coast");
@@ -202,5 +202,5 @@ test("JRN-P4-library-filtered-shared-request-lifecycle @journey", async ({ page 
   await expect(page.getByRole("heading", { name: "Could not load Library", level: 2 })).toBeVisible();
 
   await page.getByRole("button", { name: "Retry" }).click();
-  await expect(page.getByRole("link", { name: "View details" })).toBeVisible();
+  await expect(page.getByRole("link", { name: /Open details for/ })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- update library route state and API/search typing integration to support the current library/browse workflow changes
- refine library UI behavior across route/page navigation, focus restoration, and related tests/e2e journeys
- add libraryPageSize support and related wiring for library pagination state
- fix library card select-checkbox badge layering so it renders fully above the card
- adjust card path rendering so truncation preserves the tail segment (most significant filename ending)

## Validation
- not run in this pass (commit-only request)