### PR TITLE
Add face embedding backfill and surface persisted face suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ For local operations:
 - `PHOTO_ORG_ENV_FILE=/path/to/file.env` can be added when you want a local command to load extra environment-specific settings
 - `PHOTO_ORG_ENVIRONMENT=<name> PHOTO_ORG_ENV_FILE=env/presets/face-detection-high-precision.env make compose-up` starts the selected environment with the named `high_precision` face-detection profile
 
-The default Compose file now bind-mounts `${PHOTO_ORG_PHOTO_LIBRARY_HOST_PATH}` into `${PHOTO_ORG_PHOTO_LIBRARY_CONTAINER_PATH}` for `db-service`, defaulting to `./seed-corpus` mounted at `/photos`. That runtime mount remains an internal deployment concern; watched-folder registration should stay relative to a registered source root.
+The default Compose file now bind-mounts `${PHOTO_ORG_PHOTO_LIBRARY_HOST_PATH}` into `${PHOTO_ORG_PHOTO_LIBRARY_CONTAINER_PATH}` for `db-service`, defaulting to `./seed-corpus` mounted at `/photos`. It also bind-mounts `${PHOTO_ORG_MODEL_HOST_PATH}` into `${PHOTO_ORG_MODEL_CONTAINER_PATH}`, defaulting to `/mnt/d/models` mounted at `/models` for ONNX model artifacts. That runtime mount remains an internal deployment concern; watched-folder registration should stay relative to a registered source root.
 
 The API allows cross-origin browser calls from the configured UI host origins through `PHOTO_ORG_API_CORS_ALLOWED_ORIGINS` (comma-separated origins).
 
@@ -150,6 +150,7 @@ Face detection behavior is configurable through environment variables:
 - `FACE_DETECT_MAX_AREA_RATIO` (default `1.0`)
 - `FACE_DETECT_ASPECT_RATIO_MIN` (default `0.0`)
 - `FACE_DETECT_ASPECT_RATIO_MAX` (default `100.0`)
+- `FACE_RECOGNITION_SFACE_MODEL_FILE` (default `/models/opencv/face_recognition_sface_2021dec.onnx`; set empty to disable embedding extraction)
 
 Preset files are checked in under `env/presets/` (each includes a full parameter set):
 

--- a/apps/api/app/processing/faces.py
+++ b/apps/api/app/processing/faces.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 from dataclasses import asdict, dataclass
 from io import BytesIO
 from pathlib import Path
+from typing import Protocol
 from uuid import NAMESPACE_URL, uuid5
 
 FACE_DETECT_PROFILE_ENV = "FACE_DETECT_PROFILE"
 FACE_DETECT_PROFILE_FILE_ENV = "FACE_DETECT_PROFILE_FILE"
+FACE_RECOGNITION_SFACE_MODEL_FILE_ENV = "FACE_RECOGNITION_SFACE_MODEL_FILE"
 DEFAULT_FACE_DETECT_PROFILE = "balanced"
 DEFAULT_FACE_DETECT_PROFILE_FILE = Path(__file__).with_name("face_detect_profiles.json")
 
@@ -40,6 +43,49 @@ class FaceDetection:
         return asdict(self)
 
 
+class FaceEmbeddingExtractor(Protocol):
+    def extract(self, image: object) -> list[float] | None:
+        pass
+
+    def provenance(self) -> dict[str, object]:
+        pass
+
+
+class OpenCvSFaceEmbeddingExtractor:
+    def __init__(
+        self,
+        model_file: str | Path,
+        *,
+        input_size: tuple[int, int] = (112, 112),
+    ) -> None:
+        import cv2  # type: ignore
+
+        self._cv2 = cv2
+        self._model_file = Path(model_file).expanduser()
+        self._input_size = input_size
+        if not self._model_file.is_file():
+            raise FileNotFoundError(f"SFace model file not found: {self._model_file}")
+        self._recognizer = cv2.FaceRecognizerSF_create(str(self._model_file), "")
+
+    def provenance(self) -> dict[str, object]:
+        return {
+            "extractor": "opencv-sface",
+            "model": str(self._model_file),
+            "input_size": list(self._input_size),
+        }
+
+    def extract(self, image: object) -> list[float] | None:
+        import numpy as np  # type: ignore
+
+        if hasattr(image, "convert"):
+            image = image.convert("RGB")
+        rgb = np.array(image)
+        bgr = self._cv2.cvtColor(rgb, self._cv2.COLOR_RGB2BGR)
+        resized = self._cv2.resize(bgr, self._input_size)
+        feature = self._recognizer.feature(resized)
+        return _normalize_feature_vector(feature)
+
+
 class OpenCvFaceDetector:
     def __init__(
         self,
@@ -52,6 +98,7 @@ class OpenCvFaceDetector:
         max_area_ratio: float = 1.0,
         aspect_ratio_min: float = 0.0,
         aspect_ratio_max: float = 100.0,
+        embedding_extractor: FaceEmbeddingExtractor | None = None,
     ) -> None:
         import cv2  # type: ignore
 
@@ -75,6 +122,7 @@ class OpenCvFaceDetector:
         self._max_area_ratio = max_area_ratio
         self._aspect_ratio_min = aspect_ratio_min
         self._aspect_ratio_max = aspect_ratio_max
+        self._embedding_extractor = embedding_extractor
 
         cascade_path = cv2.data.haarcascades + "haarcascade_frontalface_default.xml"
         classifier = cv2.CascadeClassifier(cascade_path)
@@ -130,6 +178,16 @@ class OpenCvFaceDetector:
                 ):
                     continue
                 crop = rgb_image.crop((max(0, x), max(0, y), min(width, x + w), min(height, y + h)))
+                embedding = None
+                provenance = {
+                    **self.detection_settings(),
+                    "bbox_space_width": width,
+                    "bbox_space_height": height,
+                }
+                if self._embedding_extractor is not None:
+                    embedding = self._embedding_extractor.extract(crop)
+                    if embedding is not None:
+                        provenance["embedding"] = self._embedding_extractor.provenance()
                 face_id = str(uuid5(NAMESPACE_URL, f"{path.resolve()}:{x}:{y}:{w}:{h}:{index}"))
                 detections.append(
                     FaceDetection(
@@ -139,12 +197,8 @@ class OpenCvFaceDetector:
                         bbox_w=int(w),
                         bbox_h=int(h),
                         bitmap=_encode_jpeg(crop),
-                        embedding=None,
-                        provenance={
-                            **self.detection_settings(),
-                            "bbox_space_width": width,
-                            "bbox_space_height": height,
-                        },
+                        embedding=embedding,
+                        provenance=provenance,
                     ).as_row()
                 )
 
@@ -191,6 +245,7 @@ def create_default_face_detector() -> OpenCvFaceDetector:
     aspect_ratio_max = _read_float(
         "FACE_DETECT_ASPECT_RATIO_MAX", default=float(profile_defaults["aspect_ratio_max"])
     )
+    embedding_extractor = _create_default_embedding_extractor()
 
     return OpenCvFaceDetector(
         scale_factor=scale_factor,
@@ -201,7 +256,32 @@ def create_default_face_detector() -> OpenCvFaceDetector:
         max_area_ratio=max_area_ratio,
         aspect_ratio_min=aspect_ratio_min,
         aspect_ratio_max=aspect_ratio_max,
+        embedding_extractor=embedding_extractor,
     )
+
+
+def _create_default_embedding_extractor() -> FaceEmbeddingExtractor | None:
+    model_file = os.getenv(FACE_RECOGNITION_SFACE_MODEL_FILE_ENV)
+    if model_file is None or model_file.strip() == "":
+        return None
+    return OpenCvSFaceEmbeddingExtractor(model_file.strip())
+
+
+def _normalize_feature_vector(value: object) -> list[float] | None:
+    if hasattr(value, "tolist"):
+        value = value.tolist()
+    if isinstance(value, list | tuple) and len(value) == 1 and isinstance(value[0], list | tuple):
+        value = value[0]
+    if not isinstance(value, list | tuple):
+        return None
+    try:
+        feature = [float(component) for component in value]
+    except (TypeError, ValueError):
+        return None
+    magnitude = math.sqrt(sum(component * component for component in feature))
+    if magnitude <= 0.0:
+        return None
+    return [component / magnitude for component in feature]
 
 
 def _read_float(name: str, *, default: float) -> float:

--- a/apps/api/app/processing/ingest_persistence.py
+++ b/apps/api/app/processing/ingest_persistence.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import base64
 import hashlib
-import math
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta, timezone
 from pathlib import Path
@@ -456,7 +455,7 @@ def _face_row(photo_id: str, detection: dict) -> dict[str, object]:
         "bbox_w": detection.get("bbox_w"),
         "bbox_h": detection.get("bbox_h"),
         "bitmap": detection.get("bitmap"),
-        "embedding": _normalize_or_generate_embedding(detection),
+        "embedding": _normalize_optional_embedding(detection),
         "provenance": detection.get("provenance", {}),
     }
 
@@ -610,44 +609,8 @@ def _normalize_embedding(value: object) -> list[float] | None:
     return embedding
 
 
-def _normalize_or_generate_embedding(detection: dict) -> list[float]:
-    existing_embedding = _normalize_embedding(detection.get("embedding"))
-    if existing_embedding is not None:
-        return existing_embedding
-    return _generate_embedding_from_detection(detection)
-
-
-def _generate_embedding_from_detection(detection: dict) -> list[float]:
-    seed_bytes = _embedding_seed_bytes(detection)
-    digest_bytes = bytearray()
-    counter = 0
-    while len(digest_bytes) < EMBEDDING_DIMENSION:
-        digest_bytes.extend(hashlib.sha256(seed_bytes + counter.to_bytes(4, "big")).digest())
-        counter += 1
-
-    raw_embedding = [component / 255.0 for component in digest_bytes[:EMBEDDING_DIMENSION]]
-    magnitude = math.sqrt(sum(component * component for component in raw_embedding))
-    if magnitude <= 0.0:
-        return raw_embedding
-    return [component / magnitude for component in raw_embedding]
-
-
-def _embedding_seed_bytes(detection: dict) -> bytes:
-    bitmap = detection.get("bitmap")
-    if isinstance(bitmap, bytes) and bitmap:
-        return bitmap
-
-    fallback_seed = "|".join(
-        [
-            str(detection.get("face_id", "")),
-            str(detection.get("bbox_x", "")),
-            str(detection.get("bbox_y", "")),
-            str(detection.get("bbox_w", "")),
-            str(detection.get("bbox_h", "")),
-            str(detection.get("person_id", "")),
-        ]
-    )
-    return fallback_seed.encode("utf-8")
+def _normalize_optional_embedding(detection: dict) -> list[float] | None:
+    return _normalize_embedding(detection.get("embedding"))
 
 
 def _format_optional_timestamp(value: datetime | None) -> str | None:

--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -813,6 +813,7 @@ class PhotosRepository:
             .where(self.faces.c.photo_id.in_(pids))
             .order_by(self.faces.c.photo_id, self.faces.c.face_id)
         ).all()
+        face_ids = sorted({str(r.face_id) for r in face_rows if r.face_id is not None})
 
         provenance_map: Dict[tuple[str, str], Dict[str, Any]] = {}
         labeled_face_keys = {
@@ -867,6 +868,47 @@ class PhotosRepository:
                     ),
                 }
 
+        suggestion_map: Dict[str, List[Dict[str, Any]]] = {face_id: [] for face_id in face_ids}
+        if face_ids:
+            suggestion_rows = (
+                self.db.execute(
+                    select(
+                        self.face_suggestions.c.face_id,
+                        self.face_suggestions.c.person_id,
+                        self.people.c.display_name,
+                        self.face_suggestions.c.rank,
+                        self.face_suggestions.c.confidence,
+                        self.face_suggestions.c.model_version,
+                        self.face_suggestions.c.provenance,
+                    )
+                    .select_from(
+                        self.face_suggestions.join(
+                            self.people,
+                            self.face_suggestions.c.person_id == self.people.c.person_id,
+                        )
+                    )
+                    .where(self.face_suggestions.c.face_id.in_(face_ids))
+                    .order_by(
+                        self.face_suggestions.c.face_id.asc(),
+                        self.face_suggestions.c.rank.asc(),
+                        self.face_suggestions.c.person_id.asc(),
+                    )
+                )
+                .mappings()
+                .all()
+            )
+            for row in suggestion_rows:
+                suggestion_map.setdefault(str(row["face_id"]), []).append(
+                    {
+                        "person_id": str(row["person_id"]),
+                        "display_name": str(row["display_name"]),
+                        "rank": int(row["rank"]),
+                        "confidence": float(row["confidence"]),
+                        "model_version": row["model_version"],
+                        "provenance": row["provenance"],
+                    }
+                )
+
         for r in face_rows:
             if r.person_id:
                 ppl_map[r.photo_id].append(r.person_id)
@@ -879,6 +921,7 @@ class PhotosRepository:
                 "person_id": r.person_id,
                 "label_source": provenance["label_source"] if provenance else None,
                 "confidence": provenance["confidence"] if provenance else None,
+                "suggestions": suggestion_map.get(str(r.face_id), []),
             }
             if include_face_regions:
                 bbox_space_width, bbox_space_height = _extract_bbox_space_dimensions(r.provenance)
@@ -896,6 +939,7 @@ class PhotosRepository:
                         "model_version": provenance["model_version"] if provenance else None,
                         "provenance": provenance["provenance"] if provenance else None,
                         "label_recorded_ts": provenance["label_recorded_ts"] if provenance else None,
+                        "suggestions": suggestion_map.get(str(r.face_id), []),
                     }
                 )
             faces_map[r.photo_id].append(face_item)

--- a/apps/api/app/routers/ingest_queue.py
+++ b/apps/api/app/routers/ingest_queue.py
@@ -1,7 +1,12 @@
-from fastapi import APIRouter, Body, Depends
+from fastapi import APIRouter, Body, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.orm import Session
 
-from app.dependencies import require_worker_role
+from app.dependencies import get_db, require_worker_role
+from app.services.face_embedding_backfill import (
+    FaceEmbeddingModelUnavailableError,
+    reembed_missing_face_embeddings,
+)
 from app.services.ingest_queue_processor import process_pending_ingest_queue
 from app.services.storage_source_polling import trigger_storage_source_polling
 
@@ -80,6 +85,58 @@ class TriggerStorageSourcePollingResponse(BaseModel):
     poll_errors: list[str] = Field(description="Detailed poll-time errors from watched-folder scans.")
 
 
+class ReembedMissingFaceEmbeddingsRequest(BaseModel):
+    """Request payload for worker-driven face embedding backfill."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Backfill embeddings for face rows that are missing vectors, using the configured "
+                "SFace model."
+            )
+        }
+    )
+
+    limit: int = Field(
+        default=1000,
+        ge=1,
+        le=10000,
+        description="Maximum missing-embedding face rows to scan in one call.",
+    )
+    refresh_related: bool = Field(
+        default=True,
+        description=(
+            "When true, refresh person representations and face suggestions for people impacted "
+            "by updated embeddings."
+        ),
+    )
+    suggestion_limit: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        description="Suggestion depth to use when refreshing impacted person scopes.",
+    )
+
+
+class ReembedMissingFaceEmbeddingsResponse(BaseModel):
+    """Aggregate result returned after face embedding backfill."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Counts of scanned rows, embedding updates, skips, and related refresh activity."
+            )
+        }
+    )
+
+    scanned: int
+    updated: int
+    skipped_missing_bitmap: int
+    skipped_extraction_failed: int
+    refreshed_people: int
+    refreshed_suggestion_scopes: int
+
+
 @router.post(
     "/internal/ingest-queue/process",
     summary="Process ingest queue",
@@ -126,3 +183,37 @@ def poll_storage_sources_endpoint(
         error_count=result.error_count,
         poll_errors=list(result.poll_errors),
     )
+
+
+@router.post(
+    "/internal/faces/reembed-missing-embeddings",
+    summary="Re-embed missing face embeddings",
+    description=(
+        "Backfill face embeddings from persisted face crops for rows missing embeddings, then "
+        "optionally refresh related person representations and suggestions."
+    ),
+    response_model=ReembedMissingFaceEmbeddingsResponse,
+    responses={
+        403: {"description": "Worker role required"},
+        409: {"description": "Face embedding model not configured or unavailable"},
+    },
+)
+def reembed_missing_face_embeddings_endpoint(
+    body: ReembedMissingFaceEmbeddingsRequest = Body(
+        default_factory=ReembedMissingFaceEmbeddingsRequest
+    ),
+    _: None = Depends(require_worker_role),
+    db: Session = Depends(get_db),
+) -> ReembedMissingFaceEmbeddingsResponse:
+    try:
+        result = reembed_missing_face_embeddings(
+            db.connection(),
+            limit=body.limit,
+            refresh_related=body.refresh_related,
+            suggestion_limit=body.suggestion_limit,
+        )
+    except FaceEmbeddingModelUnavailableError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    db.commit()
+    return ReembedMissingFaceEmbeddingsResponse.model_validate(result)

--- a/apps/api/app/schemas/photo_response.py
+++ b/apps/api/app/schemas/photo_response.py
@@ -7,6 +7,23 @@ from pydantic import BaseModel, ConfigDict, Field
 from app.schemas.search_response import OriginalAvailabilityHit, ThumbnailHit
 
 
+class PhotoDetailFaceSuggestion(BaseModel):
+    """Ranked machine suggestion attached to one detected face."""
+
+    person_id: str = Field(description="Suggested person identifier.")
+    display_name: str = Field(description="Suggested person's display name.")
+    rank: int = Field(description="Suggestion rank for this face.")
+    confidence: float = Field(description="Suggestion confidence between 0 and 1.")
+    model_version: str | None = Field(
+        default=None,
+        description="Model version attached to the suggestion.",
+    )
+    provenance: dict[str, object] | None = Field(
+        default=None,
+        description="Raw provenance payload for the suggestion.",
+    )
+
+
 class PhotoDetailFace(BaseModel):
     """Face detection bounding box attached to a photo detail response."""
 
@@ -47,6 +64,10 @@ class PhotoDetailFace(BaseModel):
     label_recorded_ts: str | None = Field(
         default=None,
         description="Timestamp of the latest matching label record.",
+    )
+    suggestions: list[PhotoDetailFaceSuggestion] = Field(
+        default_factory=list,
+        description="Ranked machine suggestions for an unassigned face.",
     )
 
 

--- a/apps/api/app/schemas/search_response.py
+++ b/apps/api/app/schemas/search_response.py
@@ -6,6 +6,7 @@ class FaceHit(BaseModel):
     person_id: Optional[str] = None
     label_source: Optional[str] = None
     confidence: Optional[float] = None
+    suggestions: List[Dict[str, Any]] = []
 
 
 class ThumbnailHit(BaseModel):

--- a/apps/api/app/services/face_candidates.py
+++ b/apps/api/app/services/face_candidates.py
@@ -64,7 +64,16 @@ def lookup_nearest_neighbor_candidates(
     top_candidate_confidence = (
         float(candidates_with_confidence[0]["confidence"]) if candidates_with_confidence else None
     )
+    second_candidate_confidence = (
+        float(candidates_with_confidence[1]["confidence"]) if len(candidates_with_confidence) > 1 else None
+    )
     if top_candidate_confidence is None:
+        suggestion_decision = SUGGESTION_DECISION_NO_SUGGESTION
+    elif (
+        second_candidate_confidence is not None
+        and top_candidate_confidence < thresholds["auto_accept_threshold"]
+        and (top_candidate_confidence - second_candidate_confidence) < thresholds["min_top_margin"]
+    ):
         suggestion_decision = SUGGESTION_DECISION_NO_SUGGESTION
     else:
         suggestion_decision = classify_suggestion_confidence(

--- a/apps/api/app/services/face_embedding_backfill.py
+++ b/apps/api/app/services/face_embedding_backfill.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import io
+import os
+from typing import Any
+
+from PIL import Image, UnidentifiedImageError
+from sqlalchemy import or_, select, update
+from sqlalchemy.engine import Connection
+
+from app.processing.faces import (
+    FACE_RECOGNITION_SFACE_MODEL_FILE_ENV,
+    OpenCvSFaceEmbeddingExtractor,
+)
+from app.services.face_suggestions import refresh_face_suggestions_for_person_scope
+from app.services.person_representations import refresh_person_representation
+from app.storage import faces
+
+
+class FaceEmbeddingModelUnavailableError(RuntimeError):
+    pass
+
+
+def reembed_missing_face_embeddings(
+    connection: Connection,
+    *,
+    limit: int = 1000,
+    refresh_related: bool = True,
+    suggestion_limit: int = 5,
+) -> dict[str, int]:
+    extractor = _build_extractor()
+
+    rows = (
+        connection.execute(
+            select(
+                faces.c.face_id,
+                faces.c.person_id,
+                faces.c.bitmap,
+            )
+            .where(_missing_embedding_predicate(connection))
+            .order_by(faces.c.face_id.asc())
+            .limit(limit)
+        )
+        .mappings()
+        .all()
+    )
+
+    scanned = len(rows)
+    updated_count = 0
+    skipped_missing_bitmap = 0
+    skipped_extraction_failed = 0
+    impacted_person_ids: set[str] = set()
+
+    for row in rows:
+        face_id = str(row["face_id"])
+        bitmap = _coerce_bitmap_bytes(row["bitmap"])
+        if bitmap is None:
+            skipped_missing_bitmap += 1
+            continue
+
+        embedding = _extract_embedding(bitmap, extractor)
+        if embedding is None:
+            skipped_extraction_failed += 1
+            continue
+
+        connection.execute(
+            update(faces)
+            .where(faces.c.face_id == face_id)
+            .values(embedding=embedding)
+        )
+        updated_count += 1
+        person_id = row["person_id"]
+        if person_id is not None:
+            impacted_person_ids.add(str(person_id))
+
+    refreshed_people = 0
+    refreshed_suggestion_scopes = 0
+    if refresh_related:
+        for person_id in sorted(impacted_person_ids):
+            refresh_person_representation(connection, person_id=person_id)
+            refreshed_people += 1
+            refresh_face_suggestions_for_person_scope(
+                connection,
+                person_id=person_id,
+                limit=suggestion_limit,
+            )
+            refreshed_suggestion_scopes += 1
+
+    return {
+        "scanned": scanned,
+        "updated": updated_count,
+        "skipped_missing_bitmap": skipped_missing_bitmap,
+        "skipped_extraction_failed": skipped_extraction_failed,
+        "refreshed_people": refreshed_people,
+        "refreshed_suggestion_scopes": refreshed_suggestion_scopes,
+    }
+
+
+def _build_extractor() -> OpenCvSFaceEmbeddingExtractor:
+    model_path = os.getenv(FACE_RECOGNITION_SFACE_MODEL_FILE_ENV, "").strip()
+    if not model_path:
+        raise FaceEmbeddingModelUnavailableError(
+            f"{FACE_RECOGNITION_SFACE_MODEL_FILE_ENV} is not configured"
+        )
+    try:
+        return OpenCvSFaceEmbeddingExtractor(model_path)
+    except FileNotFoundError as exc:
+        raise FaceEmbeddingModelUnavailableError(str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - defensive guard around model init
+        raise FaceEmbeddingModelUnavailableError(
+            f"failed to initialize SFace embedding extractor: {exc}"
+        ) from exc
+
+
+def _coerce_bitmap_bytes(value: Any) -> bytes | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        return value if value else None
+    if isinstance(value, memoryview):
+        coerced = value.tobytes()
+        return coerced if coerced else None
+    return None
+
+
+def _extract_embedding(
+    bitmap: bytes,
+    extractor: OpenCvSFaceEmbeddingExtractor,
+) -> list[float] | None:
+    try:
+        with Image.open(io.BytesIO(bitmap)) as image:
+            return extractor.extract(image)
+    except (UnidentifiedImageError, OSError, ValueError):
+        return None
+
+
+def _missing_embedding_predicate(connection: Connection):
+    if connection.dialect.name == "sqlite":
+        # SQLite JSON columns may persist Python None as JSON literal "null".
+        return or_(faces.c.embedding.is_(None), faces.c.embedding == "null")
+    return faces.c.embedding.is_(None)

--- a/apps/api/app/services/recognition_policy.py
+++ b/apps/api/app/services/recognition_policy.py
@@ -6,9 +6,11 @@ import os
 
 DEFAULT_REVIEW_THRESHOLD = 0.7
 DEFAULT_AUTO_ACCEPT_THRESHOLD = 0.9
+DEFAULT_MIN_TOP_MARGIN = 0.05
 
 REVIEW_THRESHOLD_ENV = "PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD"
 AUTO_ACCEPT_THRESHOLD_ENV = "PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD"
+MIN_TOP_MARGIN_ENV = "PHOTO_ORG_RECOGNITION_MIN_TOP_MARGIN"
 MODEL_VERSION_ENV = "PHOTO_ORG_RECOGNITION_MODEL_VERSION"
 
 DEFAULT_MODEL_VERSION = "nearest-neighbor-cosine-v1"
@@ -23,6 +25,7 @@ def resolve_suggestion_thresholds(
     *,
     review_threshold: float | None = None,
     auto_accept_threshold: float | None = None,
+    min_top_margin: float | None = None,
 ) -> dict[str, float]:
     if review_threshold is None:
         review_threshold = float(os.getenv(REVIEW_THRESHOLD_ENV, str(DEFAULT_REVIEW_THRESHOLD)))
@@ -33,15 +36,19 @@ def resolve_suggestion_thresholds(
                 str(DEFAULT_AUTO_ACCEPT_THRESHOLD),
             )
         )
+    if min_top_margin is None:
+        min_top_margin = float(os.getenv(MIN_TOP_MARGIN_ENV, str(DEFAULT_MIN_TOP_MARGIN)))
 
     _validate_threshold("review threshold", review_threshold)
     _validate_threshold("auto accept threshold", auto_accept_threshold)
+    _validate_threshold("minimum top margin", min_top_margin)
     if auto_accept_threshold < review_threshold:
         raise ValueError("auto accept threshold must be greater than or equal to review threshold")
 
     return {
         "review_threshold": review_threshold,
         "auto_accept_threshold": auto_accept_threshold,
+        "min_top_margin": min_top_margin,
     }
 
 

--- a/apps/api/tests/test_face_candidates_service.py
+++ b/apps/api/tests/test_face_candidates_service.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from app.services import face_candidates as face_candidates_service
 
 
@@ -223,4 +225,113 @@ def test_lookup_nearest_neighbor_candidates_applies_no_suggestion_policy_for_low
             "auto_accept_threshold": 0.95,
             "top_candidate_confidence": 0.8,
         },
+    }
+
+
+def test_lookup_nearest_neighbor_candidates_applies_no_suggestion_for_ambiguous_top_match(monkeypatch):
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD", "0.7")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD", "0.95")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_MIN_TOP_MARGIN", "0.05")
+    connection = _FakeConnection(dialect_name="sqlite", source_embedding=[1.0, 0.0, 0.0])
+
+    def _fake_postgresql_strategy(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("PostgreSQL strategy should not be used for SQLite")
+
+    def _fake_python_strategy(*args, **kwargs):  # noqa: ANN002, ANN003
+        return [
+            {
+                "person_id": "person-1",
+                "display_name": "Alex",
+                "matched_face_id": "match-face-1",
+                "distance": 0.21,
+            },
+            {
+                "person_id": "person-2",
+                "display_name": "Blair",
+                "matched_face_id": "match-face-2",
+                "distance": 0.23,
+            },
+        ]
+
+    monkeypatch.setattr(
+        face_candidates_service,
+        "_lookup_candidates_postgresql",
+        _fake_postgresql_strategy,
+    )
+    monkeypatch.setattr(
+        face_candidates_service,
+        "_lookup_candidates_python",
+        _fake_python_strategy,
+    )
+
+    result = face_candidates_service.lookup_nearest_neighbor_candidates(
+        connection,
+        face_id="source-face",
+        limit=7,
+    )
+
+    assert result == {
+        "face_id": "source-face",
+        "candidates": [],
+        "suggestion_policy": {
+            "decision": "no_suggestion",
+            "review_threshold": 0.7,
+            "auto_accept_threshold": 0.95,
+            "top_candidate_confidence": 0.79,
+        },
+    }
+
+
+def test_lookup_nearest_neighbor_candidates_keeps_high_confidence_ambiguous_top_match(monkeypatch):
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD", "0.7")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD", "0.9")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_MIN_TOP_MARGIN", "0.05")
+    connection = _FakeConnection(dialect_name="sqlite", source_embedding=[1.0, 0.0, 0.0])
+
+    def _fake_postgresql_strategy(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise AssertionError("PostgreSQL strategy should not be used for SQLite")
+
+    def _fake_python_strategy(*args, **kwargs):  # noqa: ANN002, ANN003
+        return [
+            {
+                "person_id": "person-1",
+                "display_name": "Alex",
+                "matched_face_id": "match-face-1",
+                "distance": 0.07,
+            },
+            {
+                "person_id": "person-2",
+                "display_name": "Blair",
+                "matched_face_id": "match-face-2",
+                "distance": 0.08,
+            },
+        ]
+
+    monkeypatch.setattr(
+        face_candidates_service,
+        "_lookup_candidates_postgresql",
+        _fake_postgresql_strategy,
+    )
+    monkeypatch.setattr(
+        face_candidates_service,
+        "_lookup_candidates_python",
+        _fake_python_strategy,
+    )
+
+    result = face_candidates_service.lookup_nearest_neighbor_candidates(
+        connection,
+        face_id="source-face",
+        limit=7,
+    )
+
+    assert result["face_id"] == "source-face"
+    assert [candidate["person_id"] for candidate in result["candidates"]] == ["person-1", "person-2"]
+    assert [candidate["display_name"] for candidate in result["candidates"]] == ["Alex", "Blair"]
+    assert [candidate["distance"] for candidate in result["candidates"]] == [0.07, 0.08]
+    assert [candidate["confidence"] for candidate in result["candidates"]] == pytest.approx([0.93, 0.92], abs=1e-6)
+    assert result["suggestion_policy"] == {
+        "decision": "review_needed",
+        "review_threshold": 0.7,
+        "auto_accept_threshold": 0.9,
+        "top_candidate_confidence": pytest.approx(0.93, abs=1e-6),
     }

--- a/apps/api/tests/test_face_embedding_backfill_service.py
+++ b/apps/api/tests/test_face_embedding_backfill_service.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import io
+from datetime import UTC, datetime
+
+from PIL import Image
+from sqlalchemy import create_engine, insert, select
+
+from app.migrations import upgrade_database
+from app.services.face_embedding_backfill import (
+    FaceEmbeddingModelUnavailableError,
+    reembed_missing_face_embeddings,
+)
+from app.storage import faces, people, photos
+
+
+def _insert_photo(connection, *, photo_id: str) -> None:
+    now = datetime(2026, 5, 4, 12, 0, tzinfo=UTC)
+    connection.execute(
+        insert(photos).values(
+            photo_id=photo_id,
+            path=f"/library/{photo_id}.jpg",
+            sha256=f"sha256-{photo_id}",
+            created_ts=now,
+            updated_ts=now,
+            modified_ts=now,
+            ext="jpg",
+            filesize=123,
+        )
+    )
+
+
+def _jpeg_bytes() -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (16, 16), color=(120, 90, 60)).save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def test_reembed_missing_face_embeddings_updates_rows_and_counts(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'face-embedding-backfill.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+
+    class _FakeExtractor:
+        def __init__(self, _model_path: str):
+            pass
+
+        def extract(self, _image):  # noqa: ANN001
+            return [0.6, 0.8] + ([0.0] * 126)
+
+    monkeypatch.setenv(
+        "FACE_RECOGNITION_SFACE_MODEL_FILE",
+        "/models/opencv/face_recognition_sface_2021dec.onnx",
+    )
+    monkeypatch.setattr(
+        "app.services.face_embedding_backfill.OpenCvSFaceEmbeddingExtractor",
+        _FakeExtractor,
+    )
+
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_photo(connection, photo_id="photo-2")
+        connection.execute(
+            insert(faces),
+            [
+                {
+                    "face_id": "face-with-bitmap",
+                    "photo_id": "photo-1",
+                    "person_id": None,
+                    "bitmap": _jpeg_bytes(),
+                    "embedding": None,
+                },
+                {
+                    "face_id": "face-no-bitmap",
+                    "photo_id": "photo-2",
+                    "person_id": None,
+                    "bitmap": None,
+                    "embedding": None,
+                },
+            ],
+        )
+
+        result = reembed_missing_face_embeddings(
+            connection,
+            limit=10,
+            refresh_related=False,
+            suggestion_limit=5,
+        )
+        embedding_row = connection.execute(
+            select(faces.c.embedding).where(faces.c.face_id == "face-with-bitmap")
+        ).scalar_one()
+
+    assert result == {
+        "scanned": 2,
+        "updated": 1,
+        "skipped_missing_bitmap": 1,
+        "skipped_extraction_failed": 0,
+        "refreshed_people": 0,
+        "refreshed_suggestion_scopes": 0,
+    }
+    assert embedding_row is not None
+    assert embedding_row[:2] == [0.6, 0.8]
+
+
+def test_reembed_missing_face_embeddings_refreshes_impacted_people(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'face-embedding-backfill-refresh.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+
+    class _FakeExtractor:
+        def __init__(self, _model_path: str):
+            pass
+
+        def extract(self, _image):  # noqa: ANN001
+            return [0.1] * 128
+
+    refresh_people_calls: list[str] = []
+    refresh_suggestion_calls: list[tuple[str, int]] = []
+
+    monkeypatch.setenv(
+        "FACE_RECOGNITION_SFACE_MODEL_FILE",
+        "/models/opencv/face_recognition_sface_2021dec.onnx",
+    )
+    monkeypatch.setattr(
+        "app.services.face_embedding_backfill.OpenCvSFaceEmbeddingExtractor",
+        _FakeExtractor,
+    )
+    monkeypatch.setattr(
+        "app.services.face_embedding_backfill.refresh_person_representation",
+        lambda connection, *, person_id: refresh_people_calls.append(person_id),
+    )
+    monkeypatch.setattr(
+        "app.services.face_embedding_backfill.refresh_face_suggestions_for_person_scope",
+        lambda connection, *, person_id, limit: refresh_suggestion_calls.append((person_id, limit)),
+    )
+
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        connection.execute(
+            insert(people).values(person_id="person-1", display_name="Olivier")
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+                bitmap=_jpeg_bytes(),
+                embedding=None,
+            )
+        )
+
+        result = reembed_missing_face_embeddings(
+            connection,
+            limit=10,
+            refresh_related=True,
+            suggestion_limit=7,
+        )
+
+    assert result["updated"] == 1
+    assert result["refreshed_people"] == 1
+    assert result["refreshed_suggestion_scopes"] == 1
+    assert refresh_people_calls == ["person-1"]
+    assert refresh_suggestion_calls == [("person-1", 7)]
+
+
+def test_reembed_missing_face_embeddings_raises_when_model_is_unset(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'face-embedding-backfill-config.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    monkeypatch.delenv("FACE_RECOGNITION_SFACE_MODEL_FILE", raising=False)
+
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+                bitmap=_jpeg_bytes(),
+                embedding=None,
+            )
+        )
+
+        try:
+            reembed_missing_face_embeddings(connection)
+            raise AssertionError("expected FaceEmbeddingModelUnavailableError")
+        except FaceEmbeddingModelUnavailableError as exc:
+            assert "FACE_RECOGNITION_SFACE_MODEL_FILE" in str(exc)

--- a/apps/api/tests/test_ingest_persistence.py
+++ b/apps/api/tests/test_ingest_persistence.py
@@ -666,10 +666,10 @@ def test_store_face_detections_rejects_embeddings_with_wrong_dimension(tmp_path)
             )
 
 
-def test_store_face_detections_generates_embedding_when_missing(tmp_path):
+def test_store_face_detections_persists_null_embedding_when_missing(tmp_path):
     from app.processing.ingest_persistence import store_face_detections
 
-    database_url = f"sqlite:///{tmp_path / 'store-faces-generate-embedding.db'}"
+    database_url = f"sqlite:///{tmp_path / 'store-faces-null-embedding.db'}"
     upgrade_database(database_url)
     engine = create_engine(database_url, future=True)
     now = datetime(2026, 3, 28, 22, 0, tzinfo=UTC)
@@ -711,6 +711,4 @@ def test_store_face_detections_generates_embedding_when_missing(tmp_path):
             select(faces.c.embedding).where(faces.c.face_id == "face-1")
         ).scalar_one()
 
-    assert isinstance(persisted_embedding, list)
-    assert len(persisted_embedding) == EMBEDDING_DIMENSION
-    assert any(component != 0.0 for component in persisted_embedding)
+    assert persisted_embedding is None

--- a/apps/api/tests/test_ingest_queue_api.py
+++ b/apps/api/tests/test_ingest_queue_api.py
@@ -10,6 +10,7 @@ from app.db.session import create_session_factory
 from app.dependencies import get_db
 from app.main import app
 from app.migrations import upgrade_database
+from app.services.face_embedding_backfill import FaceEmbeddingModelUnavailableError
 
 
 SAMPLE_PAYLOAD = {
@@ -96,6 +97,13 @@ def test_poll_storage_sources_endpoint_rejects_wrong_worker_role(client: TestCli
     assert response.json() == {"detail": "Worker role required"}
 
 
+def test_reembed_missing_face_embeddings_endpoint_rejects_missing_worker_role(client: TestClient):
+    response = client.post("/api/v1/internal/faces/reembed-missing-embeddings")
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Worker role required"}
+
+
 def test_process_queue_endpoint_forwards_limit_to_processor(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
@@ -177,6 +185,84 @@ def test_poll_storage_sources_endpoint_forwards_queue_process_limit(
         "error_count": 4,
         "poll_errors": ["marker mismatch"],
     }
+
+
+def test_reembed_missing_face_embeddings_endpoint_forwards_request_args(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, object] = {}
+
+    def fake_reembed(
+        connection,
+        *,
+        limit: int,
+        refresh_related: bool,
+        suggestion_limit: int,
+    ):
+        del connection
+        captured["limit"] = limit
+        captured["refresh_related"] = refresh_related
+        captured["suggestion_limit"] = suggestion_limit
+        return {
+            "scanned": 12,
+            "updated": 9,
+            "skipped_missing_bitmap": 2,
+            "skipped_extraction_failed": 1,
+            "refreshed_people": 3,
+            "refreshed_suggestion_scopes": 3,
+        }
+
+    monkeypatch.setattr(
+        "app.routers.ingest_queue.reembed_missing_face_embeddings",
+        fake_reembed,
+    )
+
+    response = client.post(
+        "/api/v1/internal/faces/reembed-missing-embeddings",
+        headers={"X-Worker-Role": "ingest-processor"},
+        json={
+            "limit": 321,
+            "refresh_related": False,
+            "suggestion_limit": 7,
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "limit": 321,
+        "refresh_related": False,
+        "suggestion_limit": 7,
+    }
+    assert response.json() == {
+        "scanned": 12,
+        "updated": 9,
+        "skipped_missing_bitmap": 2,
+        "skipped_extraction_failed": 1,
+        "refreshed_people": 3,
+        "refreshed_suggestion_scopes": 3,
+    }
+
+
+def test_reembed_missing_face_embeddings_endpoint_returns_409_when_model_unavailable(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def fake_reembed(*args, **kwargs):  # noqa: ANN002, ANN003
+        raise FaceEmbeddingModelUnavailableError("model not configured")
+
+    monkeypatch.setattr(
+        "app.routers.ingest_queue.reembed_missing_face_embeddings",
+        fake_reembed,
+    )
+
+    response = client.post(
+        "/api/v1/internal/faces/reembed-missing-embeddings",
+        headers={"X-Worker-Role": "ingest-processor"},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "model not configured"}
 
 
 def test_get_db_reuses_cached_session_factory_for_database_url(monkeypatch: pytest.MonkeyPatch):

--- a/apps/api/tests/test_photo_detail_api.py
+++ b/apps/api/tests/test_photo_detail_api.py
@@ -11,6 +11,7 @@ from app.main import app
 from app.migrations import upgrade_database
 from app.storage import (
     face_labels,
+    face_suggestions,
     faces,
     people,
     photo_exif_attributes,
@@ -94,6 +95,7 @@ def test_photo_detail_api_returns_projected_metadata_and_related_fields(tmp_path
             "model_version": None,
             "provenance": None,
             "label_recorded_ts": None,
+            "suggestions": [],
         }
     ]
     assert payload["thumbnail"] is None
@@ -161,6 +163,116 @@ def test_photo_detail_api_exposes_bbox_coordinate_space_dimensions(tmp_path, mon
     payload = response.json()
     assert payload["faces"][0]["bbox_space_width"] == 4000
     assert payload["faces"][0]["bbox_space_height"] == 3000
+
+
+def test_photo_detail_api_exposes_ranked_face_suggestions(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'photo-detail-api-face-suggestions.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 5, 4, 12, 0, tzinfo=UTC)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                sha256="sha-1",
+                created_ts=now,
+                updated_ts=now,
+                path="/photos/photo-1.jpg",
+                filesize=1024,
+                ext="jpg",
+                faces_count=1,
+            )
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+                bbox_x=10,
+                bbox_y=20,
+                bbox_w=30,
+                bbox_h=40,
+            )
+        )
+        connection.execute(
+            insert(people),
+            [
+                {
+                    "person_id": "person-inez",
+                    "display_name": "Inez Rivera",
+                    "created_ts": now,
+                    "updated_ts": now,
+                },
+                {
+                    "person_id": "person-mateo",
+                    "display_name": "Mateo Rivera",
+                    "created_ts": now,
+                    "updated_ts": now,
+                },
+            ],
+        )
+        connection.execute(
+            insert(face_suggestions),
+            [
+                {
+                    "face_suggestion_id": "suggestion-1",
+                    "face_id": "face-1",
+                    "person_id": "person-inez",
+                    "rank": 1,
+                    "confidence": 0.903,
+                    "centroid_distance": 0.1,
+                    "knn_distance": 0.09,
+                    "representation_version": 2,
+                    "scoring_version": "hybrid-v1",
+                    "model_version": "sface-v1",
+                    "provenance": {"source": "reembed"},
+                    "created_ts": now,
+                    "updated_ts": now,
+                },
+                {
+                    "face_suggestion_id": "suggestion-2",
+                    "face_id": "face-1",
+                    "person_id": "person-mateo",
+                    "rank": 2,
+                    "confidence": 0.294,
+                    "centroid_distance": 0.7,
+                    "knn_distance": 0.71,
+                    "representation_version": 2,
+                    "scoring_version": "hybrid-v1",
+                    "model_version": "sface-v1",
+                    "provenance": {"source": "reembed"},
+                    "created_ts": now,
+                    "updated_ts": now,
+                },
+            ],
+        )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/photos/photo-1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["faces"][0]["suggestions"] == [
+        {
+            "person_id": "person-inez",
+            "display_name": "Inez Rivera",
+            "rank": 1,
+            "confidence": 0.903,
+            "model_version": "sface-v1",
+            "provenance": {"source": "reembed"},
+        },
+        {
+            "person_id": "person-mateo",
+            "display_name": "Mateo Rivera",
+            "rank": 2,
+            "confidence": 0.294,
+            "model_version": "sface-v1",
+            "provenance": {"source": "reembed"},
+        },
+    ]
 
 
 def test_photo_detail_api_allows_missing_shot_timestamp(tmp_path, monkeypatch):
@@ -351,6 +463,7 @@ def test_photo_detail_api_returns_latest_matching_face_label_provenance(tmp_path
                 "action": "correction",
             },
             "label_recorded_ts": "2026-03-28T19:33:00Z",
+            "suggestions": [],
         }
     ]
 

--- a/apps/api/tests/test_processing_faces.py
+++ b/apps/api/tests/test_processing_faces.py
@@ -6,6 +6,7 @@ import pytest
 from app.processing.faces import (
     FaceDetection,
     OpenCvFaceDetector,
+    OpenCvSFaceEmbeddingExtractor,
     _encode_jpeg,
     create_default_face_detector,
 )
@@ -166,6 +167,84 @@ def test_detector_detect_returns_serialized_face_rows(monkeypatch, tmp_path):
         "aspect_ratio_max": 100.0,
         "bbox_space_width": 200,
         "bbox_space_height": 100,
+    }
+
+
+class _FakeEmbeddingExtractor:
+    def __init__(self):
+        self.images = []
+
+    def extract(self, image):
+        self.images.append(image)
+        return [1.0, 0.0]
+
+    def provenance(self):
+        return {"extractor": "fake-sface", "model": "fake.onnx"}
+
+
+def test_detector_detect_uses_configured_embedding_extractor(monkeypatch, tmp_path):
+    classifier = _LoadedClassifier("/fake/haarcascade_frontalface_default.xml")
+    fake_cv2 = SimpleNamespace(
+        data=SimpleNamespace(haarcascades="/fake/"),
+        COLOR_RGB2GRAY="gray",
+        CascadeClassifier=lambda _path: classifier,
+        cvtColor=lambda image, _mode: image,
+    )
+    fake_numpy = SimpleNamespace(array=lambda image: image.__array__())
+    fake_rgb_image = _FakeRgbImage()
+    fake_image_module = SimpleNamespace(open=lambda _path: _FakeImageContext(fake_rgb_image))
+    fake_image_ops = SimpleNamespace(exif_transpose=lambda image: image)
+    fake_pil = SimpleNamespace(Image=fake_image_module, ImageOps=fake_image_ops)
+    fake_heif = SimpleNamespace(register_heif_opener=lambda: None)
+    embedding_extractor = _FakeEmbeddingExtractor()
+
+    monkeypatch.setitem(__import__("sys").modules, "cv2", fake_cv2)
+    monkeypatch.setitem(__import__("sys").modules, "numpy", fake_numpy)
+    monkeypatch.setitem(__import__("sys").modules, "PIL", fake_pil)
+    monkeypatch.setitem(__import__("sys").modules, "PIL.Image", fake_image_module)
+    monkeypatch.setitem(__import__("sys").modules, "PIL.ImageOps", fake_image_ops)
+    monkeypatch.setitem(__import__("sys").modules, "pillow_heif", fake_heif)
+
+    detector = OpenCvFaceDetector(embedding_extractor=embedding_extractor)
+
+    result = detector.detect(tmp_path / "sample.jpg")
+
+    assert fake_rgb_image.crops == [(10, 20, 40, 60)]
+    assert len(embedding_extractor.images) == 1
+    assert result[0]["embedding"] == [1.0, 0.0]
+    assert result[0]["provenance"]["embedding"] == {
+        "extractor": "fake-sface",
+        "model": "fake.onnx",
+    }
+
+
+def test_sface_embedding_extractor_returns_normalized_feature(monkeypatch, tmp_path):
+    model_file = tmp_path / "sface.onnx"
+    model_file.write_bytes(b"model")
+    feature = [[3.0, 4.0, *([0.0] * 126)]]
+    recognizer = SimpleNamespace(feature=lambda _image: feature)
+    fake_cv2 = SimpleNamespace(
+        FaceRecognizerSF_create=lambda model, config: recognizer,
+        COLOR_RGB2BGR="bgr",
+        cvtColor=lambda image, _mode: image,
+        resize=lambda image, size: (image, size),
+    )
+    fake_numpy = SimpleNamespace(array=lambda image: image.__array__())
+    fake_image = _FakeRgbImage()
+
+    monkeypatch.setitem(__import__("sys").modules, "cv2", fake_cv2)
+    monkeypatch.setitem(__import__("sys").modules, "numpy", fake_numpy)
+
+    extractor = OpenCvSFaceEmbeddingExtractor(model_file)
+
+    embedding = extractor.extract(fake_image)
+    assert embedding is not None
+    assert embedding[:2] == [0.6, 0.8]
+    assert embedding[2:] == [0.0] * 126
+    assert extractor.provenance() == {
+        "extractor": "opencv-sface",
+        "model": str(model_file),
+        "input_size": [112, 112],
     }
 
 

--- a/apps/api/tests/test_recognition_policy.py
+++ b/apps/api/tests/test_recognition_policy.py
@@ -13,10 +13,15 @@ from app.services.recognition_policy import (
 def test_resolve_suggestion_thresholds_reads_environment_overrides(monkeypatch):
     monkeypatch.setenv("PHOTO_ORG_RECOGNITION_REVIEW_THRESHOLD", "0.7")
     monkeypatch.setenv("PHOTO_ORG_RECOGNITION_AUTO_ACCEPT_THRESHOLD", "0.9")
+    monkeypatch.setenv("PHOTO_ORG_RECOGNITION_MIN_TOP_MARGIN", "0.06")
 
     thresholds = resolve_suggestion_thresholds()
 
-    assert thresholds == {"review_threshold": 0.7, "auto_accept_threshold": 0.9}
+    assert thresholds == {
+        "review_threshold": 0.7,
+        "auto_accept_threshold": 0.9,
+        "min_top_margin": 0.06,
+    }
 
 
 def test_resolve_suggestion_thresholds_rejects_invalid_range(monkeypatch):

--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -27,6 +27,14 @@ interface PhotoDetailPayload {
     model_version: string | null;
     provenance: Record<string, unknown> | null;
     label_recorded_ts: string | null;
+    suggestions?: Array<{
+      person_id: string;
+      display_name: string;
+      rank: number;
+      confidence: number;
+      model_version: string | null;
+      provenance: Record<string, unknown> | null;
+    }>;
   }>;
   thumbnail: {
     mime_type: string;
@@ -656,6 +664,8 @@ describe("PhotoDetailRoutePage", () => {
 
     await user.click(await screen.findByLabelText("Face region 1 for person-1"));
     expect(await screen.findByRole("dialog", { name: "Face assignment" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Assign person")).not.toHaveAttribute("list");
+    expect(document.querySelector("#face-assignment-known-people")).toBeNull();
   });
 
   it("does not auto-assign from candidates payload and only updates on explicit save", async () => {
@@ -916,6 +926,93 @@ describe("PhotoDetailRoutePage", () => {
       "M"
     );
     expect(screen.getByText("person-2")).toBeInTheDocument();
+  });
+
+  it("shows persisted face suggestions in the assignment modal when candidate lookup is empty", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          buildPayload({
+            people: [],
+            faces: [
+              {
+                face_id: "face-1",
+                person_id: null,
+                bbox_x: 10,
+                bbox_y: 10,
+                bbox_w: 20,
+                bbox_h: 20,
+                label_source: null,
+                confidence: null,
+                model_version: null,
+                provenance: null,
+                label_recorded_ts: null,
+                suggestions: [
+                  {
+                    person_id: "person-1",
+                    display_name: "Inez",
+                    rank: 1,
+                    confidence: 0.903,
+                    model_version: "sface-v1",
+                    provenance: { source: "reembed" }
+                  },
+                  {
+                    person_id: "person-2",
+                    display_name: "Mateo",
+                    rank: 2,
+                    confidence: 0.294,
+                    model_version: "sface-v1",
+                    provenance: { source: "reembed" }
+                  }
+                ]
+              }
+            ]
+          })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            person_id: "person-1",
+            display_name: "Inez",
+            created_ts: "2026-03-28T19:30:00Z",
+            updated_ts: "2026-03-28T19:30:00Z"
+          },
+          {
+            person_id: "person-2",
+            display_name: "Mateo",
+            created_ts: "2026-03-28T19:30:00Z",
+            updated_ts: "2026-03-28T19:30:00Z"
+          }
+        ]
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          face_id: "face-1",
+          candidates: [],
+          suggestion_policy: {
+            decision: "no_suggestion",
+            review_threshold: 0.5,
+            auto_accept_threshold: 0.9,
+            top_candidate_confidence: null
+          },
+          review_needed_suggestion: null
+        })
+      } as Response);
+
+    renderDetail();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Open face assignment for face region 1" })
+    );
+
+    expect(await screen.findByRole("dialog", { name: "Face assignment" })).toBeInTheDocument();
+    expect(await screen.findByText("Inez (90.3%)")).toBeInTheDocument();
+    expect(screen.getByText("Mateo (29.4%)")).toBeInTheDocument();
   });
 
   it("creates a new person name from typed input when no exact match exists", async () => {

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -36,6 +36,14 @@ type PhotoDetailPayload = {
     model_version: string | null;
     provenance: Record<string, unknown> | null;
     label_recorded_ts: string | null;
+    suggestions?: Array<{
+      person_id: string;
+      display_name: string;
+      rank: number;
+      confidence: number;
+      model_version: string | null;
+      provenance: Record<string, unknown> | null;
+    }>;
   }>;
   thumbnail: {
     mime_type: string;

--- a/apps/ui/src/pages/PhotoFaceAssignmentModal.tsx
+++ b/apps/ui/src/pages/PhotoFaceAssignmentModal.tsx
@@ -4,6 +4,7 @@ import type { FaceOverlayRegion } from "./FaceBBoxOverlay";
 interface FaceAssignmentModalFace {
   face_id: string;
   person_id: string | null;
+  suggestions?: FaceCandidate[];
 }
 
 interface FaceAssignmentModalPerson {
@@ -164,7 +165,8 @@ export function PhotoFaceAssignmentModal({
 
     setError(null);
     setCandidateError(null);
-    setCandidates([]);
+    const persistedSuggestions = Array.isArray(face.suggestions) ? face.suggestions : [];
+    setCandidates(persistedSuggestions);
     setDraft(face.person_id ? resolvePersonName(people, face.person_id) : "");
 
     const controller = new AbortController();
@@ -181,7 +183,7 @@ export function PhotoFaceAssignmentModal({
         }
 
         const nextCandidates = Array.isArray(payload.candidates) ? payload.candidates : [];
-        setCandidates(nextCandidates);
+        setCandidates(nextCandidates.length > 0 ? nextCandidates : persistedSuggestions);
       })
       .catch((caughtError: unknown) => {
         if (!controller.signal.aborted) {
@@ -349,7 +351,6 @@ export function PhotoFaceAssignmentModal({
             <input
               id="face-assignment-person-input"
               aria-label="Assign person"
-              list="face-assignment-known-people"
               value={draft}
               disabled={isBusy}
               onChange={(event) => {
@@ -357,11 +358,6 @@ export function PhotoFaceAssignmentModal({
                 setError(null);
               }}
             />
-            <datalist id="face-assignment-known-people">
-              {peopleByName.map((person) => (
-                <option key={person.person_id} value={person.display_name} />
-              ))}
-            </datalist>
 
             <div className="face-assignment-modal-actions">
               <button type="button" onClick={onClose} disabled={isBusy}>

--- a/apps/ui/src/pages/library/LibraryPhotoGrid.tsx
+++ b/apps/ui/src/pages/library/LibraryPhotoGrid.tsx
@@ -48,7 +48,10 @@ function summarizePhotoFaces(photo: LibraryPhoto): {
     if (face.label_source === "human_confirmed" && face.person_id) {
       humanPeople.add(face.person_id);
     }
-    if (face.label_source === "machine_suggested" && typeof face.confidence === "number") {
+    if (
+      (face.label_source === "machine_suggested" && typeof face.confidence === "number") ||
+      (face.suggestions?.length ?? 0) > 0
+    ) {
       machineSuggestedFaces += 1;
     }
   });

--- a/apps/ui/src/pages/library/libraryRouteTypes.ts
+++ b/apps/ui/src/pages/library/libraryRouteTypes.ts
@@ -14,6 +14,14 @@ export type LibraryPhoto = {
     person_id: string | null;
     label_source?: "human_confirmed" | "machine_suggested" | null;
     confidence?: number | null;
+    suggestions?: Array<{
+      person_id: string;
+      display_name: string;
+      rank: number;
+      confidence: number;
+      model_version: string | null;
+      provenance: Record<string, unknown> | null;
+    }>;
   }>;
   thumbnail?: {
     mime_type: string;

--- a/compose.yaml
+++ b/compose.yaml
@@ -35,10 +35,15 @@ services:
       FACE_DETECT_MAX_AREA_RATIO: ${FACE_DETECT_MAX_AREA_RATIO:-1.0}
       FACE_DETECT_ASPECT_RATIO_MIN: ${FACE_DETECT_ASPECT_RATIO_MIN:-0.0}
       FACE_DETECT_ASPECT_RATIO_MAX: ${FACE_DETECT_ASPECT_RATIO_MAX:-100.0}
+      FACE_RECOGNITION_SFACE_MODEL_FILE: ${FACE_RECOGNITION_SFACE_MODEL_FILE:-/models/opencv/face_recognition_sface_2021dec.onnx}
     volumes:
       - type: bind
         source: ${PHOTO_ORG_PHOTO_LIBRARY_HOST_PATH:-./seed-corpus}
         target: ${PHOTO_ORG_PHOTO_LIBRARY_CONTAINER_PATH:-/photos}
+      - type: bind
+        source: ${PHOTO_ORG_MODEL_HOST_PATH:-/mnt/d/models}
+        target: ${PHOTO_ORG_MODEL_CONTAINER_PATH:-/models}
+        read_only: true
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- add a worker-facing API flow to re-embed faces missing embeddings and optionally refresh impacted person representations and suggestion scopes
- add the `face_embedding_backfill` service with model initialization guards, bitmap extraction handling, and update/skip counters
- tighten recognition suggestion policy to suppress ambiguous top matches below auto-accept threshold using `PHOTO_ORG_RECOGNITION_MIN_TOP_MARGIN`
- surface persisted `face_suggestions` on photo face payloads and show them in the face assignment modal when live candidate lookup is empty
- update library metrics to count persisted suggestion-backed faces

## API and behavior changes
- new endpoint: `POST /api/v1/internal/faces/reembed-missing-embeddings`
- new request/response models for re-embed backfill operation
- photo detail/search face payloads now include `suggestions` for ranked machine suggestions

## Tests
- add unit coverage for face embedding backfill service
- extend ingest queue API and persistence tests for re-embed path
- extend recognition policy/candidate tests for top-margin ambiguity behavior
- add API and UI regression coverage for persisted suggestion visibility in face assignment flow
