### PR TITLE
test(api): align face assignment photo detail expectation with suggestions field

### DIFF
--- a/apps/api/tests/test_face_assignment_api.py
+++ b/apps/api/tests/test_face_assignment_api.py
@@ -1127,6 +1127,7 @@ def test_photo_detail_api_includes_face_id_for_assignment_workflow(tmp_path, mon
             "model_version": None,
             "provenance": None,
             "label_recorded_ts": None,
+            "suggestions": [],
         }
     ]
 


### PR DESCRIPTION
## Summary
- update `test_photo_detail_api_includes_face_id_for_assignment_workflow` to include the `suggestions` field in expected face payload
- align this test with the current `PhotoDetailFace` API schema used by `/api/v1/photos/{photo_id}`

## Verification
- `uv run pytest -q apps/api/tests/test_face_assignment_api.py::test_photo_detail_api_includes_face_id_for_assignment_workflow -vv`