### PR TITLE
Add stale unassigned face suggestion recompute endpoint

### DIFF
--- a/apps/api/alembic/versions/20260321_000001_initial_schema.py
+++ b/apps/api/alembic/versions/20260321_000001_initial_schema.py
@@ -285,6 +285,8 @@ def upgrade() -> None:
         sa.Column("detector_name", sa.String(), nullable=True),
         sa.Column("detector_version", sa.String(), nullable=True),
         sa.Column("provenance", sa.JSON(), nullable=True),
+        sa.Column("dismissed_ts", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("dismissal_provenance", sa.JSON(), nullable=True),
         sa.Column("created_ts", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
     )
     op.create_index("idx_faces_photo_id", "faces", ["photo_id"], unique=False)

--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -327,7 +327,7 @@ class PhotosRepository:
             "updated_ts": row.updated_ts,
             "modified_ts": row.modified_ts,
             "deleted_ts": row.deleted_ts,
-            "faces_count": int(row.faces_count or 0),
+            "faces_count": len(item["faces"]),
             "faces_detected_ts": row.faces_detected_ts,
         }
         return item
@@ -812,7 +812,10 @@ class PhotosRepository:
 
         face_rows = self.db.execute(
             select(*face_columns)
-            .where(self.faces.c.photo_id.in_(pids))
+            .where(
+                self.faces.c.photo_id.in_(pids),
+                self.faces.c.dismissed_ts.is_(None),
+            )
             .order_by(self.faces.c.photo_id, self.faces.c.face_id)
         ).all()
         face_ids = sorted({str(r.face_id) for r in face_rows if r.face_id is not None})

--- a/apps/api/app/routers/face_assignments.py
+++ b/apps/api/app/routers/face_assignments.py
@@ -9,12 +9,14 @@ from sqlalchemy.orm import Session
 from app.dependencies import get_db, require_face_validation_role
 from app.services.face_assignment import (
     FaceAlreadyAssignedError,
+    FaceAlreadyDismissedError,
     FaceAlreadyAssignedToPersonError,
     FaceAssignedToDifferentPersonError,
     FaceNotAssignedError,
     FaceNotFoundError,
     PersonNotFoundError,
     confirm_face_assignment,
+    dismiss_false_positive_face,
     record_review_needed_face_suggestion,
     assign_face_to_person,
     reassign_face_to_person,
@@ -23,7 +25,9 @@ from app.services.face_candidates import (
     FaceNotFoundError as FaceCandidateNotFoundError,
     lookup_nearest_neighbor_candidates,
 )
+from app.services.face_suggestions import persist_face_suggestions_from_live_candidates
 from app.services.recognition_policy import (
+    resolve_prediction_metadata,
     SUGGESTION_DECISION_REVIEW_NEEDED,
 )
 
@@ -84,6 +88,18 @@ class FaceConfirmationResponse(BaseModel):
     face_id: str
     photo_id: str
     person_id: str
+
+
+class FaceDismissalResponse(BaseModel):
+    """Dismissal result for one face detected as a false positive."""
+
+    model_config = ConfigDict(
+        json_schema_extra={"description": "Resolved face dismissal details."}
+    )
+
+    face_id: str
+    photo_id: str
+    dismissed_ts: str
 
 
 class FaceCandidateResponse(BaseModel):
@@ -247,6 +263,38 @@ def confirm_face_assignment_endpoint(
     return FaceConfirmationResponse.model_validate(confirmation)
 
 
+@router.post(
+    "/{face_id}/dismissals",
+    summary="Dismiss false-positive face detection",
+    description="Persistently dismiss an unassigned detected face that does not correspond to a real face.",
+    response_model=FaceDismissalResponse,
+    responses={
+        status.HTTP_403_FORBIDDEN: {"description": "Face validation role required"},
+        status.HTTP_404_NOT_FOUND: {"description": "Face not found"},
+        status.HTTP_409_CONFLICT: {"description": "Face already assigned or already dismissed"},
+    },
+)
+def dismiss_face_endpoint(
+    face_id: str,
+    db: Session = Depends(get_db),
+    _: str = Depends(require_face_validation_role),
+) -> FaceDismissalResponse:
+    try:
+        dismissal = dismiss_false_positive_face(
+            db.connection(),
+            face_id=face_id,
+        )
+    except FaceNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except FaceAlreadyAssignedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except FaceAlreadyDismissedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    db.commit()
+    return FaceDismissalResponse.model_validate(dismissal)
+
+
 @router.get(
     "/{face_id}/candidates",
     summary="Lookup nearest person candidates",
@@ -277,6 +325,15 @@ def lookup_face_candidates_endpoint(
 
     suggestion_policy = result["suggestion_policy"]
     candidates = result["candidates"]
+    prediction_metadata = resolve_prediction_metadata()
+    persisted_snapshot_count = persist_face_suggestions_from_live_candidates(
+        db.connection(),
+        face_id=face_id,
+        candidates=candidates if isinstance(candidates, list) else [],
+        model_version=prediction_metadata["model_version"],
+        limit=limit,
+    )
+    did_commit = persisted_snapshot_count >= 0
     if (
         suggestion_policy["decision"] == SUGGESTION_DECISION_REVIEW_NEEDED
         and isinstance(candidates, list)
@@ -295,6 +352,9 @@ def lookup_face_candidates_endpoint(
         )
         if review_needed_suggestion is not None:
             result["review_needed_suggestion"] = review_needed_suggestion
-            db.commit()
+            did_commit = True
+
+    if did_commit:
+        db.commit()
 
     return FaceCandidateLookupResponse.model_validate(result)

--- a/apps/api/app/routers/ingest_queue.py
+++ b/apps/api/app/routers/ingest_queue.py
@@ -7,6 +7,7 @@ from app.services.face_embedding_backfill import (
     FaceEmbeddingModelUnavailableError,
     reembed_missing_face_embeddings,
 )
+from app.services.face_suggestions import refresh_stale_unassigned_face_suggestions
 from app.services.ingest_queue_processor import process_pending_ingest_queue
 from app.services.storage_source_polling import trigger_storage_source_polling
 
@@ -138,6 +139,48 @@ class ReembedMissingFaceEmbeddingsResponse(BaseModel):
     refreshed_suggestion_scopes: int
 
 
+class RefreshStaleFaceSuggestionsRequest(BaseModel):
+    """Request payload for stale/uncomputed unassigned face-suggestion refresh."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "description": (
+                "Recompute suggestions for unassigned faces with missing snapshots or "
+                "snapshots older than the provided staleness threshold."
+            )
+        }
+    )
+
+    stale_after_minutes: int = Field(
+        default=24 * 60,
+        ge=0,
+        le=60 * 24 * 30,
+        description=(
+            "Face suggestions older than this threshold (minutes) are considered stale."
+        ),
+    )
+    face_limit: int = Field(
+        default=500,
+        ge=1,
+        le=10000,
+        description="Maximum number of unassigned faces to refresh in one call.",
+    )
+    suggestion_limit: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        description="Suggestion depth to persist per refreshed face.",
+    )
+
+
+class RefreshStaleFaceSuggestionsResponse(BaseModel):
+    stale_after_minutes: int
+    suggestion_limit: int
+    requested_face_limit: int
+    refreshed_face_count: int
+    stale_cutoff_ts: str
+
+
 @router.post(
     "/internal/ingest-queue/process",
     summary="Process ingest queue",
@@ -178,6 +221,39 @@ def process_face_suggestion_recompute_queue_endpoint(
         processed=result.processed,
         failed=result.failed,
         retryable_errors=result.retryable_errors,
+    )
+
+
+@router.post(
+    "/internal/face-suggestions/recompute/stale",
+    summary="Recompute stale unassigned face suggestions",
+    description=(
+        "Refresh suggestions for unassigned faces that have never been assessed or "
+        "whose persisted suggestions are older than a configurable age."
+    ),
+    response_model=RefreshStaleFaceSuggestionsResponse,
+    responses={403: {"description": "Worker role required"}},
+)
+def recompute_stale_unassigned_face_suggestions_endpoint(
+    body: RefreshStaleFaceSuggestionsRequest = Body(
+        default_factory=RefreshStaleFaceSuggestionsRequest
+    ),
+    _: None = Depends(require_worker_role),
+    db: Session = Depends(get_db),
+) -> RefreshStaleFaceSuggestionsResponse:
+    result = refresh_stale_unassigned_face_suggestions(
+        db.connection(),
+        stale_after_minutes=body.stale_after_minutes,
+        face_limit=body.face_limit,
+        suggestion_limit=body.suggestion_limit,
+    )
+    db.commit()
+    return RefreshStaleFaceSuggestionsResponse(
+        stale_after_minutes=result.stale_after_minutes,
+        suggestion_limit=result.suggestion_limit,
+        requested_face_limit=result.requested_face_limit,
+        refreshed_face_count=result.refreshed_face_count,
+        stale_cutoff_ts=result.stale_cutoff_ts.isoformat(),
     )
 
 

--- a/apps/api/app/routers/suggestions.py
+++ b/apps/api/app/routers/suggestions.py
@@ -35,6 +35,8 @@ class SuggestedUnassignedFaceResponse(BaseModel):
     bbox_y: int | None = None
     bbox_w: int | None = None
     bbox_h: int | None = None
+    bbox_space_width: int | None = None
+    bbox_space_height: int | None = None
     top_suggestion: TopFaceSuggestionResponse
 
 
@@ -92,12 +94,14 @@ class SuggestionConfirmFacesResponse(BaseModel):
 def list_suggestion_review_faces_endpoint(
     page: Annotated[int, Query(ge=1)] = 1,
     page_size: Annotated[int, Query(ge=1, le=100)] = 24,
+    min_confidence: Annotated[float, Query(ge=0, le=1)] = 0,
     db: Session = Depends(get_db),
 ) -> SuggestionReviewListResponse:
     result = list_unassigned_face_suggestion_photos(
         db.connection(),
         page=page,
         page_size=page_size,
+        min_confidence=min_confidence,
     )
     return SuggestionReviewListResponse.model_validate(result)
 

--- a/apps/api/app/services/face_assignment.py
+++ b/apps/api/app/services/face_assignment.py
@@ -14,7 +14,7 @@ from photoorg_db_schema import (
 
 from app.db.queue import IngestQueueStore
 from app.services.recognition_policy import resolve_prediction_metadata
-from app.storage import face_labels, faces, people
+from app.storage import face_labels, face_suggestions, faces, people
 
 
 class FaceNotFoundError(LookupError):
@@ -26,6 +26,10 @@ class PersonNotFoundError(LookupError):
 
 
 class FaceAlreadyAssignedError(RuntimeError):
+    pass
+
+
+class FaceAlreadyDismissedError(RuntimeError):
     pass
 
 
@@ -183,6 +187,54 @@ def confirm_face_assignment(
     }
 
 
+def dismiss_false_positive_face(
+    connection: Connection,
+    *,
+    face_id: str,
+) -> dict[str, str]:
+    row = _face_row(connection, face_id)
+    if row is None:
+        raise FaceNotFoundError("Face not found")
+    if row["person_id"] is not None:
+        raise FaceAlreadyAssignedError("Face already assigned")
+    if row["dismissed_ts"] is not None:
+        raise FaceAlreadyDismissedError("Face already dismissed")
+
+    dismissed_ts = datetime.now(UTC)
+    result = connection.execute(
+        update(faces)
+        .where(
+            faces.c.face_id == face_id,
+            faces.c.person_id.is_(None),
+            faces.c.dismissed_ts.is_(None),
+        )
+        .values(
+            dismissed_ts=dismissed_ts,
+            dismissal_provenance={
+                "workflow": "face-labeling",
+                "surface": "api",
+                "action": "dismiss_false_positive",
+            },
+        )
+    )
+    if result.rowcount != 1:
+        refreshed_row = _face_row(connection, face_id)
+        if refreshed_row is None:
+            raise FaceNotFoundError("Face not found")
+        if refreshed_row["person_id"] is not None:
+            raise FaceAlreadyAssignedError("Face already assigned")
+        if refreshed_row["dismissed_ts"] is not None:
+            raise FaceAlreadyDismissedError("Face already dismissed")
+        raise RuntimeError("Face dismissal changed; retry request")
+
+    connection.execute(delete(face_suggestions).where(face_suggestions.c.face_id == face_id))
+    return {
+        "face_id": str(row["face_id"]),
+        "photo_id": str(row["photo_id"]),
+        "dismissed_ts": dismissed_ts.isoformat().replace("+00:00", "Z"),
+    }
+
+
 def record_review_needed_face_suggestion(
     connection: Connection,
     *,
@@ -229,6 +281,7 @@ def _face_row(connection: Connection, face_id: str):
                 faces.c.face_id,
                 faces.c.photo_id,
                 faces.c.person_id,
+                faces.c.dismissed_ts,
             ).where(faces.c.face_id == face_id)
         )
         .mappings()

--- a/apps/api/app/services/face_suggestion_review.py
+++ b/apps/api/app/services/face_suggestion_review.py
@@ -11,7 +11,8 @@ from app.services.face_assignment import (
     PersonNotFoundError,
     assign_face_to_person,
 )
-from app.storage import face_suggestions, faces, people, photos
+from app.services.face_candidates import lookup_nearest_neighbor_candidates
+from app.storage import face_suggestions, faces, people, photo_exif_attributes, photos
 
 
 SUGGESTION_SKIP_FACE_NOT_FOUND = "face_not_found"
@@ -50,12 +51,119 @@ def _top_suggestion_subquery():
     )
 
 
+def _extract_bbox_space_dimensions(face_provenance: object) -> tuple[int | None, int | None]:
+    if not isinstance(face_provenance, dict):
+        return None, None
+    width = _coerce_positive_int(face_provenance.get("bbox_space_width"))
+    height = _coerce_positive_int(face_provenance.get("bbox_space_height"))
+    return width, height
+
+
+def _coerce_positive_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float):
+        coerced = int(value)
+        return coerced if coerced > 0 else None
+    if isinstance(value, str):
+        try:
+            coerced = int(value.strip())
+        except ValueError:
+            return None
+        return coerced if coerced > 0 else None
+    return None
+
+
+def _load_photo_dimension_map(
+    connection: Connection,
+    *,
+    photo_ids: list[str],
+) -> dict[str, tuple[int | None, int | None]]:
+    if not photo_ids:
+        return {}
+    dimension_attrs = {
+        "exif_ifd.exifimagewidth": "width",
+        "exif_ifd.exifimageheight": "height",
+        "exif_ifd.pixelxdimension": "width",
+        "exif_ifd.pixelydimension": "height",
+        "exif.imagewidth": "width",
+        "exif.imagelength": "height",
+    }
+    rows = (
+        connection.execute(
+            select(
+                photo_exif_attributes.c.photo_id,
+                photo_exif_attributes.c.exif_attribute_name,
+                photo_exif_attributes.c.exif_attribute_value,
+            ).where(photo_exif_attributes.c.photo_id.in_(photo_ids))
+        )
+        .mappings()
+        .all()
+    )
+    dimensions: dict[str, dict[str, int | None]] = {}
+    for row in rows:
+        photo_id = str(row["photo_id"])
+        key = str(row["exif_attribute_name"]).lower()
+        axis = dimension_attrs.get(key)
+        if axis is None:
+            continue
+        value = _coerce_positive_int(row["exif_attribute_value"])
+        if value is None:
+            continue
+        current = dimensions.setdefault(photo_id, {"width": None, "height": None})
+        # Keep the largest candidate for each axis; EXIF can repeat across namespaces.
+        existing = current[axis]
+        current[axis] = max(existing or 0, value)
+
+    return {
+        photo_id: (values.get("width"), values.get("height"))
+        for photo_id, values in dimensions.items()
+    }
+
+
+def _load_live_top_candidate_for_face(
+    connection: Connection,
+    *,
+    face_id: str,
+) -> dict[str, object] | None:
+    result = lookup_nearest_neighbor_candidates(
+        connection,
+        face_id=face_id,
+        limit=1,
+        enforce_min_confidence=False,
+    )
+    candidates = result.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        return None
+    top = candidates[0]
+    person_id = top.get("person_id")
+    display_name = top.get("display_name")
+    confidence = top.get("confidence")
+    if not isinstance(person_id, str) or not person_id:
+        return None
+    if not isinstance(display_name, str) or not display_name:
+        return None
+    try:
+        confidence_value = float(confidence)
+    except (TypeError, ValueError):
+        return None
+    return {
+        "person_id": person_id,
+        "display_name": display_name,
+        "confidence": min(1.0, max(0.0, confidence_value)),
+    }
+
+
 def list_unassigned_face_suggestion_photos(
     connection: Connection,
     *,
     page: int,
     page_size: int,
+    min_confidence: float = 0.0,
 ) -> dict[str, object]:
+    normalized_min_confidence = min(1.0, max(0.0, float(min_confidence)))
     top_suggestion = _top_suggestion_subquery()
     eligible_photo_ids = (
         select(faces.c.photo_id)
@@ -66,7 +174,9 @@ def list_unassigned_face_suggestion_photos(
         )
         .where(
             faces.c.person_id.is_(None),
+            faces.c.dismissed_ts.is_(None),
             photos.c.deleted_ts.is_(None),
+            top_suggestion.c.confidence >= normalized_min_confidence,
         )
         .distinct()
         .subquery()
@@ -88,7 +198,9 @@ def list_unassigned_face_suggestion_photos(
                 photos.c.thumbnail_height,
                 photos.c.shot_ts,
             )
-            .select_from(photos.join(eligible_photo_ids, eligible_photo_ids.c.photo_id == photos.c.photo_id))
+            .select_from(
+                photos.join(eligible_photo_ids, eligible_photo_ids.c.photo_id == photos.c.photo_id)
+            )
             .order_by(
                 case((photos.c.shot_ts.is_(None), 1), else_=0).asc(),
                 photos.c.shot_ts.desc(),
@@ -100,7 +212,6 @@ def list_unassigned_face_suggestion_photos(
         .mappings()
         .all()
     )
-
     photo_ids = [str(row["photo_id"]) for row in photo_rows]
     if not photo_ids:
         return {
@@ -122,6 +233,7 @@ def list_unassigned_face_suggestion_photos(
                 faces.c.bbox_y,
                 faces.c.bbox_w,
                 faces.c.bbox_h,
+                faces.c.provenance,
                 top_suggestion.c.person_id.label("suggested_person_id"),
                 top_suggestion.c.confidence.label("suggested_confidence"),
                 people.c.display_name.label("suggested_display_name"),
@@ -134,6 +246,8 @@ def list_unassigned_face_suggestion_photos(
             .where(
                 faces.c.photo_id.in_(photo_ids),
                 faces.c.person_id.is_(None),
+                faces.c.dismissed_ts.is_(None),
+                top_suggestion.c.confidence >= normalized_min_confidence,
             )
             .order_by(
                 faces.c.photo_id.asc(),
@@ -143,10 +257,27 @@ def list_unassigned_face_suggestion_photos(
         .mappings()
         .all()
     )
+    photo_dimension_map = _load_photo_dimension_map(connection, photo_ids=photo_ids)
 
     face_map: dict[str, list[dict[str, object]]] = {photo_id: [] for photo_id in photo_ids}
     for row in face_rows:
         photo_id = str(row["photo_id"])
+        bbox_space_width, bbox_space_height = _extract_bbox_space_dimensions(row["provenance"])
+        if bbox_space_width is None or bbox_space_height is None:
+            fallback_width, fallback_height = photo_dimension_map.get(photo_id, (None, None))
+            bbox_space_width = bbox_space_width or fallback_width
+            bbox_space_height = bbox_space_height or fallback_height
+        top_suggestion_payload = {
+            "person_id": str(row["suggested_person_id"]),
+            "display_name": str(row["suggested_display_name"]),
+            "confidence": float(row["suggested_confidence"]),
+        }
+        live_top_candidate = _load_live_top_candidate_for_face(
+            connection,
+            face_id=str(row["face_id"]),
+        )
+        if live_top_candidate is not None:
+            top_suggestion_payload = live_top_candidate
         face_map.setdefault(photo_id, []).append(
             {
                 "face_id": str(row["face_id"]),
@@ -154,21 +285,14 @@ def list_unassigned_face_suggestion_photos(
                 "bbox_y": row["bbox_y"],
                 "bbox_w": row["bbox_w"],
                 "bbox_h": row["bbox_h"],
-                "top_suggestion": {
-                    "person_id": str(row["suggested_person_id"]),
-                    "display_name": str(row["suggested_display_name"]),
-                    "confidence": float(row["suggested_confidence"]),
-                },
+                "bbox_space_width": bbox_space_width,
+                "bbox_space_height": bbox_space_height,
+                "top_suggestion": top_suggestion_payload,
             }
         )
 
     items: list[dict[str, object]] = []
     for row in photo_rows:
-        photo_id = str(row["photo_id"])
-        suggestions_for_photo = face_map.get(photo_id, [])
-        if not suggestions_for_photo:
-            continue
-
         thumbnail = None
         thumbnail_jpeg = row["thumbnail_jpeg"]
         thumbnail_mime_type = row["thumbnail_mime_type"]
@@ -184,6 +308,10 @@ def list_unassigned_face_suggestion_photos(
                 "data_base64": base64.b64encode(thumbnail_jpeg).decode("ascii"),
             }
 
+        photo_id = str(row["photo_id"])
+        suggestions_for_photo = face_map.get(photo_id, [])
+        if not suggestions_for_photo:
+            continue
         items.append(
             {
                 "photo_id": photo_id,

--- a/apps/api/app/services/face_suggestions.py
+++ b/apps/api/app/services/face_suggestions.py
@@ -10,10 +10,13 @@ from sqlalchemy.engine import Connection
 
 from photoorg_db_schema import FACE_LABEL_SOURCE_HUMAN_CONFIRMED
 
+from app.services.face_candidates import lookup_nearest_neighbor_candidates
+from app.services.recognition_policy import resolve_prediction_metadata
 from app.storage import face_labels, face_suggestions, faces, person_representations
 
 
 SCORING_VERSION = "hybrid-v1"
+LIVE_SCORING_VERSION = "nearest-neighbor-live-v1"
 
 
 @dataclass(frozen=True)
@@ -35,6 +38,76 @@ class StaleUnassignedRefreshResult:
     requested_face_limit: int
     refreshed_face_count: int
     stale_cutoff_ts: datetime
+
+
+def persist_face_suggestions_from_live_candidates(
+    connection: Connection,
+    *,
+    face_id: str,
+    candidates: list[dict[str, object]],
+    model_version: str,
+    limit: int = 5,
+) -> int:
+    source_row = (
+        connection.execute(
+            select(faces.c.face_id, faces.c.person_id).where(faces.c.face_id == face_id)
+        )
+        .mappings()
+        .first()
+    )
+    if source_row is None:
+        return 0
+    if source_row["person_id"] is not None:
+        _delete_face_suggestions(connection, face_id=face_id)
+        return 0
+
+    normalized_candidates: list[dict[str, object]] = []
+    for candidate in candidates[: max(0, limit)]:
+        person_id = candidate.get("person_id")
+        if not isinstance(person_id, str) or not person_id:
+            continue
+        confidence = candidate.get("confidence")
+        distance = candidate.get("distance")
+        try:
+            confidence_value = float(confidence)
+            distance_value = float(distance) if distance is not None else None
+        except (TypeError, ValueError):
+            continue
+        normalized_candidates.append(
+            {
+                "person_id": person_id,
+                "confidence": min(1.0, max(0.0, confidence_value)),
+                "distance": distance_value,
+                "matched_face_id": (
+                    str(candidate.get("matched_face_id"))
+                    if candidate.get("matched_face_id") is not None
+                    else None
+                ),
+            }
+        )
+
+    _delete_face_suggestions(connection, face_id=face_id)
+    for rank, candidate in enumerate(normalized_candidates, start=1):
+        connection.execute(
+            insert(face_suggestions).values(
+                face_suggestion_id=str(uuid4()),
+                face_id=face_id,
+                person_id=candidate["person_id"],
+                rank=rank,
+                confidence=candidate["confidence"],
+                centroid_distance=candidate["distance"],
+                knn_distance=candidate["distance"],
+                representation_version=1,
+                scoring_version=LIVE_SCORING_VERSION,
+                model_version=model_version,
+                provenance={
+                    "source": "live-candidate-lookup",
+                    "matched_face_id": candidate["matched_face_id"],
+                    "distance": candidate["distance"],
+                },
+            )
+        )
+    return len(normalized_candidates)
 
 
 def refresh_face_suggestions_for_person_scope(
@@ -225,73 +298,23 @@ def refresh_face_suggestions_for_face(
     if source_embedding is None:
         _delete_face_suggestions(connection, face_id=face_id)
         return
-
-    representations = _load_person_representations(connection)
-    if not representations:
-        _delete_face_suggestions(connection, face_id=face_id)
-        return
-    person_ids = [representation["person_id"] for representation in representations]
-    best_knn_distance = _load_best_knn_distance_by_person(
+    result = lookup_nearest_neighbor_candidates(
         connection,
-        source_embedding=source_embedding,
-        person_ids=person_ids,
+        face_id=face_id,
+        limit=limit,
+        enforce_min_confidence=False,
     )
-
-    ranked: list[_SuggestionCandidate] = []
-    for representation in representations:
-        centroid_distance = _cosine_distance(
-            source_embedding,
-            representation["centroid_embedding"],
-        )
-        if centroid_distance is None:
-            continue
-        person_id = representation["person_id"]
-        knn_distance = best_knn_distance.get(person_id)
-        if knn_distance is None:
-            continue
-        confidence = _combine_confidence(
-            centroid_distance=centroid_distance,
-            knn_distance=knn_distance,
-            confirmed_face_count=representation["confirmed_face_count"],
-            dispersion_score=representation["dispersion_score"],
-        )
-        ranked.append(
-            _SuggestionCandidate(
-                person_id=person_id,
-                confidence=confidence,
-                centroid_distance=centroid_distance,
-                knn_distance=knn_distance,
-                representation_version=representation["representation_version"],
-                model_version=representation["model_version"],
-                confirmed_face_count=representation["confirmed_face_count"],
-                dispersion_score=representation["dispersion_score"],
-            )
-        )
-
-    ranked.sort(key=lambda item: (-item.confidence, item.person_id))
-    top_ranked = ranked[:limit]
-
-    _delete_face_suggestions(connection, face_id=face_id)
-    for rank, candidate in enumerate(top_ranked, start=1):
-        connection.execute(
-            insert(face_suggestions).values(
-                face_suggestion_id=str(uuid4()),
-                face_id=face_id,
-                person_id=candidate.person_id,
-                rank=rank,
-                confidence=candidate.confidence,
-                centroid_distance=candidate.centroid_distance,
-                knn_distance=candidate.knn_distance,
-                representation_version=candidate.representation_version,
-                scoring_version=SCORING_VERSION,
-                model_version=candidate.model_version,
-                provenance={
-                    "scoring_version": SCORING_VERSION,
-                    "confirmed_face_count": candidate.confirmed_face_count,
-                    "dispersion_score": candidate.dispersion_score,
-                },
-            )
-        )
+    candidates = result.get("candidates")
+    if not isinstance(candidates, list):
+        candidates = []
+    model_version = resolve_prediction_metadata()["model_version"]
+    persist_face_suggestions_from_live_candidates(
+        connection,
+        face_id=face_id,
+        candidates=candidates,
+        model_version=model_version,
+        limit=limit,
+    )
 
 
 def _delete_face_suggestions(connection: Connection, *, face_id: str) -> None:

--- a/apps/api/app/services/face_suggestions.py
+++ b/apps/api/app/services/face_suggestions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from math import sqrt
 from uuid import uuid4
 
@@ -25,6 +26,15 @@ class _SuggestionCandidate:
     model_version: str
     confirmed_face_count: int
     dispersion_score: float | None
+
+
+@dataclass(frozen=True)
+class StaleUnassignedRefreshResult:
+    stale_after_minutes: int
+    suggestion_limit: int
+    requested_face_limit: int
+    refreshed_face_count: int
+    stale_cutoff_ts: datetime
 
 
 def refresh_face_suggestions_for_person_scope(
@@ -113,6 +123,81 @@ def refresh_face_suggestions_for_people_in_top_rank(
             limit=limit,
         )
     return len(target_face_rows)
+
+
+def refresh_stale_unassigned_face_suggestions(
+    connection: Connection,
+    *,
+    stale_after_minutes: int,
+    face_limit: int,
+    suggestion_limit: int = 5,
+) -> StaleUnassignedRefreshResult:
+    normalized_stale_after_minutes = max(0, stale_after_minutes)
+    normalized_face_limit = max(0, face_limit)
+    normalized_suggestion_limit = max(1, suggestion_limit)
+    stale_cutoff_ts = datetime.now(tz=UTC) - timedelta(
+        minutes=normalized_stale_after_minutes
+    )
+
+    if normalized_face_limit == 0:
+        return StaleUnassignedRefreshResult(
+            stale_after_minutes=normalized_stale_after_minutes,
+            suggestion_limit=normalized_suggestion_limit,
+            requested_face_limit=0,
+            refreshed_face_count=0,
+            stale_cutoff_ts=stale_cutoff_ts,
+        )
+
+    latest_suggestion_snapshot = (
+        select(
+            face_suggestions.c.face_id.label("face_id"),
+            func.max(face_suggestions.c.updated_ts).label("last_suggestion_ts"),
+        )
+        .group_by(face_suggestions.c.face_id)
+        .subquery()
+    )
+
+    target_face_ids = (
+        connection.execute(
+            select(faces.c.face_id)
+            .select_from(
+                faces.outerjoin(
+                    latest_suggestion_snapshot,
+                    latest_suggestion_snapshot.c.face_id == faces.c.face_id,
+                )
+            )
+            .where(
+                faces.c.person_id.is_(None),
+                faces.c.embedding.is_not(None),
+                (
+                    latest_suggestion_snapshot.c.face_id.is_(None)
+                    | (
+                        latest_suggestion_snapshot.c.last_suggestion_ts
+                        <= stale_cutoff_ts
+                    )
+                ),
+            )
+            .order_by(faces.c.face_id.asc())
+            .limit(normalized_face_limit)
+        )
+        .scalars()
+        .all()
+    )
+
+    for face_id in target_face_ids:
+        refresh_face_suggestions_for_face(
+            connection,
+            face_id=str(face_id),
+            limit=normalized_suggestion_limit,
+        )
+
+    return StaleUnassignedRefreshResult(
+        stale_after_minutes=normalized_stale_after_minutes,
+        suggestion_limit=normalized_suggestion_limit,
+        requested_face_limit=normalized_face_limit,
+        refreshed_face_count=len(target_face_ids),
+        stale_cutoff_ts=stale_cutoff_ts,
+    )
 
 
 def refresh_face_suggestions_for_face(

--- a/apps/api/tests/test_face_assignment_api.py
+++ b/apps/api/tests/test_face_assignment_api.py
@@ -12,7 +12,7 @@ from app.main import app
 from app.migrations import upgrade_database
 from app.routers import face_assignments as face_assignments_router
 from app.services import face_assignment as face_assignment_service
-from app.storage import face_labels, faces, ingest_queue, people, photos
+from app.storage import face_labels, face_suggestions, faces, ingest_queue, people, photos
 
 
 def _client(tmp_path, monkeypatch, filename: str) -> TestClient:
@@ -199,6 +199,125 @@ def test_face_assignment_api_rejects_missing_face_validation_role(tmp_path, monk
             select(faces.c.person_id).where(faces.c.face_id == "face-1")
         ).scalar_one_or_none()
     assert persisted_person_id is None
+
+
+def test_face_dismissal_api_marks_unassigned_face_as_dismissed_and_clears_suggestions(
+    tmp_path, monkeypatch
+):
+    database_url = _database_url(tmp_path, "face-dismiss.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+        connection.execute(
+            insert(face_suggestions).values(
+                face_suggestion_id="suggestion-1",
+                face_id="face-1",
+                person_id="person-1",
+                rank=1,
+                confidence=0.91,
+                centroid_distance=0.09,
+                knn_distance=0.09,
+                representation_version=1,
+                scoring_version="hybrid-v1",
+                model_version="recognition-v1",
+            )
+        )
+
+    client = _authorized_client()
+    response = client.post("/api/v1/faces/face-1/dismissals")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["face_id"] == "face-1"
+    assert payload["photo_id"] == "photo-1"
+    assert payload["dismissed_ts"].endswith("Z")
+
+    with engine.connect() as connection:
+        face_row = connection.execute(
+            select(
+                faces.c.dismissed_ts,
+                faces.c.dismissal_provenance,
+            ).where(faces.c.face_id == "face-1")
+        ).mappings().one()
+        persisted_suggestions = connection.execute(
+            select(face_suggestions.c.face_suggestion_id).where(face_suggestions.c.face_id == "face-1")
+        ).all()
+
+    assert face_row["dismissed_ts"] is not None
+    assert face_row["dismissal_provenance"] == {
+        "workflow": "face-labeling",
+        "surface": "api",
+        "action": "dismiss_false_positive",
+    }
+    assert persisted_suggestions == []
+
+
+def test_face_dismissal_api_rejects_already_assigned_face(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-dismiss-assigned.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+            )
+        )
+
+    client = _authorized_client()
+    response = client.post("/api/v1/faces/face-1/dismissals")
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Face already assigned"}
+
+
+def test_face_dismissal_api_rejects_already_dismissed_face(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-dismiss-dismissed.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 5, 6, 12, 0, tzinfo=UTC)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+                dismissed_ts=now,
+                dismissal_provenance={
+                    "workflow": "face-labeling",
+                    "surface": "api",
+                    "action": "dismiss_false_positive",
+                },
+            )
+        )
+
+    client = _authorized_client()
+    response = client.post("/api/v1/faces/face-1/dismissals")
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Face already dismissed"}
 
 
 def test_face_assignment_api_rejects_unrecognized_face_validation_role(tmp_path, monkeypatch):

--- a/apps/api/tests/test_face_candidates_api.py
+++ b/apps/api/tests/test_face_candidates_api.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine, insert, select
 from app.dependencies import _get_session_factory
 from app.main import app
 from app.migrations import upgrade_database
-from app.storage import face_labels, faces, people, photos
+from app.storage import face_labels, face_suggestions, faces, people, photos
 from photoorg_db_schema import EMBEDDING_DIMENSION
 
 
@@ -153,6 +153,16 @@ def test_face_candidates_api_returns_ranked_person_candidates_with_per_person_be
                 face_labels.c.provenance,
             ).where(face_labels.c.face_id == "source-face")
         ).mappings().one()
+        persisted_suggestions = connection.execute(
+            select(
+                face_suggestions.c.person_id,
+                face_suggestions.c.rank,
+                face_suggestions.c.confidence,
+                face_suggestions.c.scoring_version,
+            )
+            .where(face_suggestions.c.face_id == "source-face")
+            .order_by(face_suggestions.c.rank.asc())
+        ).mappings().all()
     assert persisted_person_id is None
     assert persisted_label["face_id"] == "source-face"
     assert persisted_label["person_id"] == "person-1"
@@ -171,6 +181,10 @@ def test_face_candidates_api_returns_ranked_person_candidates_with_per_person_be
         "candidate_distance": pytest.approx(0.000051, abs=1e-4),
         "candidate_confidence": pytest.approx(0.999949, abs=1e-4),
     }
+    assert persisted_suggestions[0]["person_id"] == "person-1"
+    assert persisted_suggestions[0]["rank"] == 1
+    assert persisted_suggestions[0]["confidence"] == pytest.approx(0.999949, abs=1e-4)
+    assert persisted_suggestions[0]["scoring_version"] == "nearest-neighbor-live-v1"
 
 
 def test_face_candidates_api_returns_review_needed_state_for_medium_confidence_matches(

--- a/apps/api/tests/test_face_suggestion_review_api.py
+++ b/apps/api/tests/test_face_suggestion_review_api.py
@@ -8,7 +8,7 @@ from sqlalchemy import create_engine, insert, select
 from app.dependencies import FACE_VALIDATION_ROLE_HEADER, _get_session_factory
 from app.main import app
 from app.migrations import upgrade_database
-from app.storage import face_suggestions, faces, people, photos
+from app.storage import face_suggestions, faces, people, photo_exif_attributes, photos
 
 
 def _client(tmp_path, monkeypatch, filename: str) -> TestClient:
@@ -94,6 +94,26 @@ def test_face_suggestion_review_list_returns_paginated_unassigned_faces_with_top
             ],
         )
         connection.execute(
+            faces.update()
+            .where(faces.c.face_id == "face-1")
+            .values(provenance={"bbox_space_width": 4000, "bbox_space_height": 3000})
+        )
+        connection.execute(
+            insert(photo_exif_attributes),
+            [
+                {
+                    "photo_id": "photo-1",
+                    "exif_attribute_name": "exif_ifd.ExifImageWidth",
+                    "exif_attribute_value": 5000,
+                },
+                {
+                    "photo_id": "photo-1",
+                    "exif_attribute_name": "exif_ifd.ExifImageHeight",
+                    "exif_attribute_value": 4000,
+                },
+            ],
+        )
+        connection.execute(
             insert(face_suggestions),
             [
                 {
@@ -167,12 +187,103 @@ def test_face_suggestion_review_list_returns_paginated_unassigned_faces_with_top
         "display_name": "Alex",
         "confidence": 0.97,
     }
+    assert payload["items"][0]["faces"][0]["bbox_space_width"] == 4000
+    assert payload["items"][0]["faces"][0]["bbox_space_height"] == 3000
+    assert payload["items"][0]["faces"][1]["bbox_space_width"] == 5000
+    assert payload["items"][0]["faces"][1]["bbox_space_height"] == 4000
 
     response_page_two = client.get("/api/v1/suggestions/faces", params={"page": 2, "page_size": 1})
     assert response_page_two.status_code == 200
     page_two_payload = response_page_two.json()
     assert page_two_payload["items"][0]["photo_id"] == "photo-2"
     assert [face["face_id"] for face in page_two_payload["items"][0]["faces"]] == ["face-3"]
+
+    response_filtered = client.get(
+        "/api/v1/suggestions/faces",
+        params={"page": 1, "page_size": 24, "min_confidence": 0.9},
+    )
+    assert response_filtered.status_code == 200
+    filtered_payload = response_filtered.json()
+    assert filtered_payload["page"] == {
+        "page": 1,
+        "page_size": 24,
+        "total_items": 1,
+        "total_pages": 1,
+    }
+    assert len(filtered_payload["items"]) == 1
+    assert filtered_payload["items"][0]["photo_id"] == "photo-1"
+    assert [face["face_id"] for face in filtered_payload["items"][0]["faces"]] == ["face-1"]
+
+
+def test_face_suggestion_review_list_omits_dismissed_faces(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "face-suggestion-review-dismissed.db")
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'face-suggestion-review-dismissed.db'}", future=True)
+    now = datetime(2026, 5, 6, 12, 0, tzinfo=UTC)
+    with engine.begin() as connection:
+        _insert_person(connection, person_id="person-1", display_name="Alex")
+        _insert_photo(
+            connection,
+            photo_id="photo-1",
+            path="/photos/1.jpg",
+            shot_ts=datetime(2026, 5, 5, 11, 0, tzinfo=UTC),
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-active",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-dismissed",
+                photo_id="photo-1",
+                person_id=None,
+                dismissed_ts=now,
+                dismissal_provenance={
+                    "workflow": "face-labeling",
+                    "surface": "api",
+                    "action": "dismiss_false_positive",
+                },
+            )
+        )
+        connection.execute(
+            insert(face_suggestions),
+            [
+                {
+                    "face_suggestion_id": "s1",
+                    "face_id": "face-active",
+                    "person_id": "person-1",
+                    "rank": 1,
+                    "confidence": 0.95,
+                    "centroid_distance": 0.05,
+                    "knn_distance": 0.05,
+                    "representation_version": 2,
+                    "scoring_version": "hybrid-v1",
+                    "model_version": "recognition-v1",
+                },
+                {
+                    "face_suggestion_id": "s2",
+                    "face_id": "face-dismissed",
+                    "person_id": "person-1",
+                    "rank": 1,
+                    "confidence": 0.96,
+                    "centroid_distance": 0.04,
+                    "knn_distance": 0.04,
+                    "representation_version": 2,
+                    "scoring_version": "hybrid-v1",
+                    "model_version": "recognition-v1",
+                },
+            ],
+        )
+
+    response = client.get("/api/v1/suggestions/faces", params={"page": 1, "page_size": 24})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["page"]["total_items"] == 1
+    assert [face["face_id"] for face in payload["items"][0]["faces"]] == ["face-active"]
 
 
 def test_face_suggestion_review_confirmation_assigns_selected_faces_to_top_suggestions(

--- a/apps/api/tests/test_face_suggestions_service.py
+++ b/apps/api/tests/test_face_suggestions_service.py
@@ -220,7 +220,7 @@ def test_refresh_face_suggestions_replaces_stale_snapshot_rows(tmp_path):
 
     assert len(rows) == 1
     assert rows[0]["face_suggestion_id"] != "stale-row"
-    assert rows[0]["scoring_version"] == "hybrid-v1"
+    assert rows[0]["scoring_version"] == "nearest-neighbor-live-v1"
 
 
 def test_refresh_face_suggestions_for_people_in_top_rank_reassesses_target_faces_only(tmp_path):
@@ -364,7 +364,7 @@ def test_refresh_face_suggestions_for_people_in_top_rank_reassesses_target_faces
 
     assert refreshed_count == 1
     assert len(source_a_rows) == 2
-    assert source_a_rows[0]["scoring_version"] == "hybrid-v1"
+    assert source_a_rows[0]["scoring_version"] == "nearest-neighbor-live-v1"
     assert source_a_rows[0]["person_id"] == "person-a"
     assert len(source_b_rows) == 1
     assert source_b_rows[0]["face_suggestion_id"] == "stale-b1"
@@ -524,7 +524,7 @@ def test_refresh_stale_unassigned_face_suggestions_selects_stale_or_missing_with
     assert result.refreshed_face_count == 2
     assert len(stale_rows) == 2
     assert stale_rows[0]["face_suggestion_id"] != "stale-row"
-    assert stale_rows[0]["scoring_version"] == "hybrid-v1"
+    assert stale_rows[0]["scoring_version"] == "nearest-neighbor-live-v1"
     assert len(missing_rows) == 2
     assert len(fresh_rows) == 1
     assert fresh_rows[0]["face_suggestion_id"] == "fresh-row"

--- a/apps/api/tests/test_face_suggestions_service.py
+++ b/apps/api/tests/test_face_suggestions_service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import create_engine, insert, select
 
@@ -8,6 +8,7 @@ from app.migrations import upgrade_database
 from app.services.face_suggestions import (
     refresh_face_suggestions_for_face,
     refresh_face_suggestions_for_people_in_top_rank,
+    refresh_stale_unassigned_face_suggestions,
 )
 from app.storage import (
     face_labels,
@@ -367,3 +368,163 @@ def test_refresh_face_suggestions_for_people_in_top_rank_reassesses_target_faces
     assert source_a_rows[0]["person_id"] == "person-a"
     assert len(source_b_rows) == 1
     assert source_b_rows[0]["face_suggestion_id"] == "stale-b1"
+
+
+def test_refresh_stale_unassigned_face_suggestions_selects_stale_or_missing_with_limit(tmp_path):
+    database_url = f"sqlite:///{tmp_path / 'face-suggestions-refresh-stale.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+
+    now = datetime.now(tz=UTC)
+    stale_ts = now - timedelta(hours=2)
+    fresh_ts = now - timedelta(minutes=5)
+
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-source-missing")
+        _insert_photo(connection, photo_id="photo-source-stale")
+        _insert_photo(connection, photo_id="photo-source-fresh")
+        _insert_photo(connection, photo_id="photo-labeled-a")
+        _insert_photo(connection, photo_id="photo-labeled-b")
+        _insert_person(connection, person_id="person-a", display_name="Alex")
+        _insert_person(connection, person_id="person-b", display_name="Blair")
+
+        connection.execute(
+            insert(faces),
+            [
+                {
+                    "face_id": "face-missing",
+                    "photo_id": "photo-source-missing",
+                    "person_id": None,
+                    "embedding": [1.0, 0.0],
+                },
+                {
+                    "face_id": "face-stale",
+                    "photo_id": "photo-source-stale",
+                    "person_id": None,
+                    "embedding": [1.0, 0.0],
+                },
+                {
+                    "face_id": "face-fresh",
+                    "photo_id": "photo-source-fresh",
+                    "person_id": None,
+                    "embedding": [1.0, 0.0],
+                },
+                {
+                    "face_id": "face-labeled-a",
+                    "photo_id": "photo-labeled-a",
+                    "person_id": "person-a",
+                    "embedding": [0.99, 0.01],
+                },
+                {
+                    "face_id": "face-labeled-b",
+                    "photo_id": "photo-labeled-b",
+                    "person_id": "person-b",
+                    "embedding": [0.9, 0.1],
+                },
+            ],
+        )
+        connection.execute(
+            insert(person_representations),
+            [
+                {
+                    "person_id": "person-a",
+                    "centroid_embedding": [0.98, 0.02],
+                    "confirmed_face_count": 4,
+                    "dispersion_score": 0.01,
+                    "representation_version": 7,
+                    "model_version": "nearest-neighbor-cosine-v1",
+                },
+                {
+                    "person_id": "person-b",
+                    "centroid_embedding": [0.9, 0.1],
+                    "confirmed_face_count": 4,
+                    "dispersion_score": 0.01,
+                    "representation_version": 7,
+                    "model_version": "nearest-neighbor-cosine-v1",
+                },
+            ],
+        )
+        connection.execute(
+            insert(face_labels),
+            [
+                {
+                    "face_label_id": "label-a",
+                    "face_id": "face-labeled-a",
+                    "person_id": "person-a",
+                    "label_source": "human_confirmed",
+                },
+                {
+                    "face_label_id": "label-b",
+                    "face_id": "face-labeled-b",
+                    "person_id": "person-b",
+                    "label_source": "human_confirmed",
+                },
+            ],
+        )
+        connection.execute(
+            insert(face_suggestions),
+            [
+                {
+                    "face_suggestion_id": "stale-row",
+                    "face_id": "face-stale",
+                    "person_id": "person-a",
+                    "rank": 1,
+                    "confidence": 0.1,
+                    "centroid_distance": 0.9,
+                    "knn_distance": 0.9,
+                    "representation_version": 1,
+                    "scoring_version": "hybrid-v0",
+                    "model_version": "legacy-v0",
+                    "created_ts": stale_ts,
+                    "updated_ts": stale_ts,
+                },
+                {
+                    "face_suggestion_id": "fresh-row",
+                    "face_id": "face-fresh",
+                    "person_id": "person-a",
+                    "rank": 1,
+                    "confidence": 0.1,
+                    "centroid_distance": 0.9,
+                    "knn_distance": 0.9,
+                    "representation_version": 1,
+                    "scoring_version": "hybrid-v0",
+                    "model_version": "legacy-v0",
+                    "created_ts": fresh_ts,
+                    "updated_ts": fresh_ts,
+                },
+            ],
+        )
+
+        result = refresh_stale_unassigned_face_suggestions(
+            connection,
+            stale_after_minutes=60,
+            face_limit=2,
+            suggestion_limit=2,
+        )
+
+        stale_rows = connection.execute(
+            select(face_suggestions)
+            .where(face_suggestions.c.face_id == "face-stale")
+            .order_by(face_suggestions.c.rank.asc())
+        ).mappings().all()
+        missing_rows = connection.execute(
+            select(face_suggestions)
+            .where(face_suggestions.c.face_id == "face-missing")
+            .order_by(face_suggestions.c.rank.asc())
+        ).mappings().all()
+        fresh_rows = connection.execute(
+            select(face_suggestions)
+            .where(face_suggestions.c.face_id == "face-fresh")
+            .order_by(face_suggestions.c.rank.asc())
+        ).mappings().all()
+
+    assert result.stale_after_minutes == 60
+    assert result.suggestion_limit == 2
+    assert result.requested_face_limit == 2
+    assert result.refreshed_face_count == 2
+    assert len(stale_rows) == 2
+    assert stale_rows[0]["face_suggestion_id"] != "stale-row"
+    assert stale_rows[0]["scoring_version"] == "hybrid-v1"
+    assert len(missing_rows) == 2
+    assert len(fresh_rows) == 1
+    assert fresh_rows[0]["face_suggestion_id"] == "fresh-row"

--- a/apps/api/tests/test_ingest_queue_api.py
+++ b/apps/api/tests/test_ingest_queue_api.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from datetime import UTC, datetime
 
 import pytest
 from fastapi.testclient import TestClient
@@ -90,6 +91,23 @@ def test_face_suggestion_recompute_queue_endpoint_rejects_missing_worker_role(cl
 def test_face_suggestion_recompute_queue_endpoint_rejects_wrong_worker_role(client: TestClient):
     response = client.post(
         "/api/v1/internal/face-suggestions/recompute/process",
+        headers={"X-Worker-Role": "wrong-role"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Worker role required"}
+
+
+def test_recompute_stale_face_suggestions_endpoint_rejects_missing_worker_role(client: TestClient):
+    response = client.post("/api/v1/internal/face-suggestions/recompute/stale")
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Worker role required"}
+
+
+def test_recompute_stale_face_suggestions_endpoint_rejects_wrong_worker_role(client: TestClient):
+    response = client.post(
+        "/api/v1/internal/face-suggestions/recompute/stale",
         headers={"X-Worker-Role": "wrong-role"},
     )
 
@@ -198,6 +216,56 @@ def test_face_suggestion_recompute_queue_endpoint_forwards_limit_with_payload_fi
         "processed": 0,
         "failed": 0,
         "retryable_errors": 0,
+    }
+
+
+def test_recompute_stale_face_suggestions_endpoint_forwards_args(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, int] = {}
+
+    class Result:
+        stale_after_minutes = 90
+        suggestion_limit = 4
+        requested_face_limit = 222
+        refreshed_face_count = 17
+        stale_cutoff_ts = datetime(2026, 5, 1, 10, 20, 30, tzinfo=UTC)
+
+    def fake_refresh(connection, *, stale_after_minutes: int, face_limit: int, suggestion_limit: int):
+        del connection
+        captured["stale_after_minutes"] = stale_after_minutes
+        captured["face_limit"] = face_limit
+        captured["suggestion_limit"] = suggestion_limit
+        return Result()
+
+    monkeypatch.setattr(
+        "app.routers.ingest_queue.refresh_stale_unassigned_face_suggestions",
+        fake_refresh,
+    )
+
+    response = client.post(
+        "/api/v1/internal/face-suggestions/recompute/stale",
+        headers={"X-Worker-Role": "ingest-processor"},
+        json={
+            "stale_after_minutes": 90,
+            "face_limit": 222,
+            "suggestion_limit": 4,
+        },
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "stale_after_minutes": 90,
+        "face_limit": 222,
+        "suggestion_limit": 4,
+    }
+    assert response.json() == {
+        "stale_after_minutes": 90,
+        "suggestion_limit": 4,
+        "requested_face_limit": 222,
+        "refreshed_face_count": 17,
+        "stale_cutoff_ts": "2026-05-01T10:20:30+00:00",
     }
 
 

--- a/apps/api/tests/test_photo_detail_api.py
+++ b/apps/api/tests/test_photo_detail_api.py
@@ -275,6 +275,67 @@ def test_photo_detail_api_exposes_ranked_face_suggestions(tmp_path, monkeypatch)
     ]
 
 
+def test_photo_detail_api_omits_dismissed_faces_and_recomputes_active_face_count(
+    tmp_path, monkeypatch
+):
+    database_url = f"sqlite:///{tmp_path / 'photo-detail-api-dismissed-faces.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 5, 6, 12, 0, tzinfo=UTC)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                sha256="sha-1",
+                created_ts=now,
+                updated_ts=now,
+                path="/photos/photo-1.jpg",
+                filesize=1024,
+                ext="jpg",
+                faces_count=2,
+            )
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-active",
+                photo_id="photo-1",
+                person_id=None,
+                bbox_x=10,
+                bbox_y=20,
+                bbox_w=30,
+                bbox_h=40,
+            )
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-dismissed",
+                photo_id="photo-1",
+                person_id=None,
+                bbox_x=50,
+                bbox_y=60,
+                bbox_w=70,
+                bbox_h=80,
+                dismissed_ts=now,
+                dismissal_provenance={
+                    "workflow": "face-labeling",
+                    "surface": "api",
+                    "action": "dismiss_false_positive",
+                },
+            )
+        )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/photos/photo-1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [face["face_id"] for face in payload["faces"]] == ["face-active"]
+    assert payload["metadata"]["faces_count"] == 1
+
+
 def test_photo_detail_api_allows_missing_shot_timestamp(tmp_path, monkeypatch):
     database_url = f"sqlite:///{tmp_path / 'photo-detail-api-null-shot-ts.db'}"
     upgrade_database(database_url)

--- a/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
@@ -840,6 +840,207 @@ describe("PhotoDetailRoutePage", () => {
     expect(screen.getByText("person-1")).toBeInTheDocument();
   });
 
+  it("shows a false-positive dismissal action only for unlabeled faces", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          buildPayload({
+            people: ["person-1"],
+            faces: [
+              {
+                face_id: "face-1",
+                person_id: "person-1",
+                bbox_x: 10,
+                bbox_y: 10,
+                bbox_w: 20,
+                bbox_h: 20,
+                label_source: "human_confirmed",
+                confidence: null,
+                model_version: null,
+                provenance: {
+                  workflow: "face-labeling",
+                  surface: "api",
+                  action: "assignment"
+                },
+                label_recorded_ts: "2026-03-28T19:33:00Z"
+              }
+            ]
+          })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            person_id: "person-1",
+            display_name: "Inez",
+            created_ts: "2026-03-28T19:30:00Z",
+            updated_ts: "2026-03-28T19:30:00Z"
+          }
+        ]
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          face_id: "face-1",
+          candidates: [],
+          suggestion_policy: {
+            decision: "no_suggestion",
+            review_threshold: 0.5,
+            auto_accept_threshold: 0.9,
+            top_candidate_confidence: null
+          },
+          review_needed_suggestion: null
+        })
+      } as Response);
+
+    renderDetail();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Open face assignment for face region 1" })
+    );
+
+    expect(await screen.findByRole("dialog", { name: "Face assignment" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Discard false positive" })).not.toBeInTheDocument();
+  });
+
+  it("dismisses an unlabeled false-positive face from the detail modal and removes it locally", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          buildPayload({
+            people: [],
+            faces: [
+              {
+                face_id: "face-1",
+                person_id: null,
+                bbox_x: 10,
+                bbox_y: 10,
+                bbox_w: 20,
+                bbox_h: 20,
+                label_source: null,
+                confidence: null,
+                model_version: null,
+                provenance: null,
+                label_recorded_ts: null
+              }
+            ],
+            metadata: {
+              ...buildPayload().metadata,
+              faces_count: 1
+            }
+          })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => []
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          face_id: "face-1",
+          candidates: [],
+          suggestion_policy: {
+            decision: "no_suggestion",
+            review_threshold: 0.5,
+            auto_accept_threshold: 0.9,
+            top_candidate_confidence: null
+          },
+          review_needed_suggestion: null
+        })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          face_id: "face-1",
+          photo_id: "photo-1",
+          dismissed_ts: "2026-05-06T12:00:00Z"
+        })
+      } as Response);
+
+    renderDetail();
+
+    expect(await screen.findByRole("heading", { name: "Photo detail", level: 1 })).toBeInTheDocument();
+    await user.click(
+      await screen.findByRole("button", { name: "Open face assignment for face region 1" })
+    );
+    expect(await screen.findByRole("button", { name: "Discard false positive" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Discard false positive" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Face assignment" })).not.toBeInTheDocument();
+    });
+    expect(screen.queryByRole("button", { name: "Open face assignment for face region 1" })).not.toBeInTheDocument();
+    expect(screen.getByText("No face regions detected for this photo.")).toBeInTheDocument();
+    expect(screen.getByText("0 detected")).toBeInTheDocument();
+  });
+
+  it("shows the dismissal permission error inline in the detail modal", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () =>
+          buildPayload({
+            people: [],
+            faces: [
+              {
+                face_id: "face-1",
+                person_id: null,
+                bbox_x: 10,
+                bbox_y: 10,
+                bbox_w: 20,
+                bbox_h: 20,
+                label_source: null,
+                confidence: null,
+                model_version: null,
+                provenance: null,
+                label_recorded_ts: null
+              }
+            ]
+          })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => []
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          face_id: "face-1",
+          candidates: [],
+          suggestion_policy: {
+            decision: "no_suggestion",
+            review_threshold: 0.5,
+            auto_accept_threshold: 0.9,
+            top_candidate_confidence: null
+          },
+          review_needed_suggestion: null
+        })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: async () => ({ detail: "Face validation role required" })
+      } as Response);
+
+    renderDetail();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Open face assignment for face region 1" })
+    );
+    await user.click(await screen.findByRole("button", { name: "Discard false positive" }));
+
+    expect(await screen.findByText("You do not have permission to discard faces.")).toBeInTheDocument();
+  });
+
   it("updates local face state after correction success when saving from the modal", async () => {
     const user = userEvent.setup();
 

--- a/apps/ui/src/pages/PhotoDetailRoutePage.tsx
+++ b/apps/ui/src/pages/PhotoDetailRoutePage.tsx
@@ -255,6 +255,27 @@ function applyFaceAssignment(
   };
 }
 
+function applyFaceDismissal(detail: PhotoDetailPayload, faceId: string): PhotoDetailPayload {
+  const nextFaces = detail.faces.filter((face) => face.face_id !== faceId);
+  const nextPeople = Array.from(
+    new Set(
+      nextFaces
+        .map((face) => face.person_id)
+        .filter((value): value is string => value !== null)
+    )
+  );
+
+  return {
+    ...detail,
+    faces: nextFaces,
+    people: nextPeople,
+    metadata: {
+      ...detail.metadata,
+      faces_count: nextFaces.length
+    }
+  };
+}
+
 export function PhotoDetailRoutePage() {
   const location = useLocation();
   const { photoId } = useParams<{ photoId: string }>();
@@ -478,6 +499,11 @@ export function PhotoDetailRoutePage() {
 
   function handleFaceAssigned(faceId: string, personId: string) {
     setDetail((current) => (current ? applyFaceAssignment(current, faceId, personId) : current));
+  }
+
+  function handleFaceDismissed(faceId: string) {
+    setDetail((current) => (current ? applyFaceDismissal(current, faceId) : current));
+    setActiveFaceModalId((current) => (current === faceId ? null : current));
   }
 
   function handlePersonCreated(person: {
@@ -880,6 +906,7 @@ export function PhotoDetailRoutePage() {
         }))}
         onClose={() => setActiveFaceModalId(null)}
         onFaceUpdated={handleFaceAssigned}
+        onFaceDismissed={handleFaceDismissed}
         onPersonCreated={handlePersonCreated}
       />
     </section>

--- a/apps/ui/src/pages/PhotoFaceAssignmentModal.tsx
+++ b/apps/ui/src/pages/PhotoFaceAssignmentModal.tsx
@@ -39,6 +39,7 @@ interface PhotoFaceAssignmentModalProps {
   people: FaceAssignmentModalPerson[];
   onClose: () => void;
   onFaceUpdated: (faceId: string, personId: string) => void;
+  onFaceDismissed: (faceId: string) => void;
   onPersonCreated: (person: FaceAssignmentModalPerson) => void;
 }
 
@@ -85,6 +86,19 @@ function mapCorrectionError(status: number, detail: string | null): string {
     return detail ?? "Face correction could not be applied.";
   }
   return `Correction request failed (${status}).`;
+}
+
+function mapDismissalError(status: number, detail: string | null): string {
+  if (status === 403) {
+    return "You do not have permission to discard faces.";
+  }
+  if (status === 404) {
+    return detail ?? "Face no longer exists.";
+  }
+  if (status === 409) {
+    return detail ?? "Face dismissal could not be applied.";
+  }
+  return `Dismissal request failed (${status}).`;
 }
 
 async function readErrorDetail(response: Response): Promise<string | null> {
@@ -149,6 +163,7 @@ export function PhotoFaceAssignmentModal({
   people,
   onClose,
   onFaceUpdated,
+  onFaceDismissed,
   onPersonCreated
 }: PhotoFaceAssignmentModalProps) {
   const [draft, setDraft] = useState("");
@@ -307,6 +322,37 @@ export function PhotoFaceAssignmentModal({
     }
   }
 
+  async function dismissFalsePositive() {
+    if (!face || face.person_id !== null || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/v1/faces/${face.face_id}/dismissals`, {
+        method: "POST",
+        headers: {
+          "X-Face-Validation-Role": "contributor"
+        }
+      });
+
+      if (!response.ok) {
+        const detail = await readErrorDetail(response);
+        setError(mapDismissalError(response.status, detail));
+        return;
+      }
+
+      onFaceDismissed(face.face_id);
+      onClose();
+    } catch {
+      setError("Could not discard face.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
   if (!isOpen || !face) {
     return null;
   }
@@ -369,6 +415,16 @@ export function PhotoFaceAssignmentModal({
                 {createCandidate ? `Create and assign "${createCandidate}"` : "Save and close"}
               </button>
             </div>
+            {face.person_id === null ? (
+              <button
+                type="button"
+                className="face-assignment-modal-dismiss"
+                onClick={() => void dismissFalsePositive()}
+                disabled={isBusy}
+              >
+                Discard false positive
+              </button>
+            ) : null}
 
             <section className="face-assignment-modal-suggestions" aria-label="Suggested names">
               <h4>Suggested names</h4>

--- a/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
+++ b/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { SuggestionsRoutePage } from "./SuggestionsRoutePage";
@@ -36,7 +36,7 @@ describe("SuggestionsRoutePage", () => {
         items: [
           {
             photo_id: "photo-1",
-            path: "/photos/photo-1.jpg",
+            path: "/storage-sources/source-1/family/trip/photo-1.jpg",
             thumbnail: {
               mime_type: "image/jpeg",
               width: 64,
@@ -77,12 +77,24 @@ describe("SuggestionsRoutePage", () => {
     renderPage();
 
     expect(await screen.findByRole("heading", { name: "Suggestions", level: 1 })).toBeInTheDocument();
-    expect(screen.getByText("/photos/photo-1.jpg")).toBeInTheDocument();
-    expect(screen.getByRole("img", { name: "Preview of /photos/photo-1.jpg" })).toBeInTheDocument();
+    expect(screen.getByText(".../family/trip/photo-1.jpg")).toBeInTheDocument();
+    expect(
+      screen.getByRole("img", { name: "Preview of /storage-sources/source-1/family/trip/photo-1.jpg" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "Open details for /storage-sources/source-1/family/trip/photo-1.jpg"
+      })
+    ).toHaveAttribute("href", "/library/photo-1");
     expect(screen.getByLabelText("Confirm suggestion for face face-1")).toBeChecked();
     expect(screen.getByLabelText("Confirm suggestion for face face-2")).toBeChecked();
-    expect(screen.getByText("Alex (97.0%)")).toBeInTheDocument();
-    expect(screen.getByText("Blair (82.0%)")).toBeInTheDocument();
+    expect(screen.getByText("Face 1: Alex (97.0%)")).toBeInTheDocument();
+    expect(screen.getByText("Face 2: Blair (82.0%)")).toBeInTheDocument();
+    const overlay = screen.getByRole("list", {
+      name: "Suggested face regions for /storage-sources/source-1/family/trip/photo-1.jpg"
+    });
+    expect(within(overlay).getByText("1")).toBeInTheDocument();
+    expect(within(overlay).getByText("2")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Previous page" })).toHaveAttribute(
       "aria-disabled",
       "true"
@@ -255,6 +267,110 @@ describe("SuggestionsRoutePage", () => {
     expect(fetchMock).toHaveBeenLastCalledWith("/api/v1/suggestions/faces?page=2&page_size=24");
   });
 
+  it("confirms only checked face assignments from the current page", async () => {
+    const user = userEvent.setup();
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          page: {
+            page: 1,
+            page_size: 24,
+            total_items: 2,
+            total_pages: 2
+          },
+          items: [
+            {
+              photo_id: "photo-1",
+              path: "/photos/photo-1.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-1",
+                  top_suggestion: {
+                    person_id: "person-1",
+                    display_name: "Alex",
+                    confidence: 0.97
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          page: {
+            page: 2,
+            page_size: 24,
+            total_items: 2,
+            total_pages: 2
+          },
+          items: [
+            {
+              photo_id: "photo-2",
+              path: "/photos/photo-2.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-2",
+                  top_suggestion: {
+                    person_id: "person-2",
+                    display_name: "Blair",
+                    confidence: 0.88
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          assigned: [
+            {
+              face_id: "face-2",
+              photo_id: "photo-2",
+              person_id: "person-2"
+            }
+          ],
+          skipped: []
+        })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          page: {
+            page: 2,
+            page_size: 24,
+            total_items: 0,
+            total_pages: 0
+          },
+          items: []
+        })
+      } as Response);
+
+    renderPage();
+    expect(await screen.findByText("/photos/photo-1.jpg")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Page 2" }));
+    expect(await screen.findByText("/photos/photo-2.jpg")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Confirm faces" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/v1/suggestions/confirmations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Face-Validation-Role": "contributor"
+        },
+        body: JSON.stringify({ face_ids: ["face-2"] })
+      });
+    });
+  });
+
   it("normalizes empty pagination to one disabled page control", async () => {
     fetchMock.mockResolvedValueOnce({
       ok: true,
@@ -279,5 +395,76 @@ describe("SuggestionsRoutePage", () => {
     );
     expect(screen.getByRole("button", { name: "Next page" })).toHaveAttribute("aria-disabled", "true");
     expect(screen.queryByText("Page 1 of 0")).not.toBeInTheDocument();
+  });
+
+  it("applies minimum certainty slider as a global suggestions filter", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          page: {
+            page: 1,
+            page_size: 24,
+            total_items: 2,
+            total_pages: 1
+          },
+          items: [
+            {
+              photo_id: "photo-1",
+              path: "/photos/photo-1.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-1",
+                  top_suggestion: {
+                    person_id: "person-1",
+                    display_name: "Alex",
+                    confidence: 0.97
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          page: {
+            page: 1,
+            page_size: 24,
+            total_items: 1,
+            total_pages: 1
+          },
+          items: [
+            {
+              photo_id: "photo-2",
+              path: "/photos/photo-2.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-2",
+                  top_suggestion: {
+                    person_id: "person-2",
+                    display_name: "Blair",
+                    confidence: 0.91
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      } as Response);
+
+    renderPage();
+    expect(await screen.findByText("/photos/photo-1.jpg")).toBeInTheDocument();
+
+    const thresholdSlider = screen.getByLabelText("Minimum suggestion certainty");
+    fireEvent.change(thresholdSlider, { target: { value: "90" } });
+
+    expect(await screen.findByText("/photos/photo-2.jpg")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/v1/suggestions/faces?page=1&page_size=24&min_confidence=0.9"
+    );
   });
 });

--- a/apps/ui/src/pages/SuggestionsRoutePage.tsx
+++ b/apps/ui/src/pages/SuggestionsRoutePage.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import ReactPaginate from "react-paginate";
+import { Link } from "react-router-dom";
+import { FaceBBoxOverlay, buildFaceOverlayRegions } from "./FaceBBoxOverlay";
 
 const PAGE_SIZE = 24;
 
@@ -22,6 +24,8 @@ type SuggestedFace = {
   bbox_y?: number | null;
   bbox_w?: number | null;
   bbox_h?: number | null;
+  bbox_space_width?: number | null;
+  bbox_space_height?: number | null;
   top_suggestion: TopSuggestion;
 };
 
@@ -61,12 +65,43 @@ function formatConfidence(confidence: number): string {
   return `${(confidence * 100).toFixed(1)}%`;
 }
 
+function formatDisplayPath(path: string): string {
+  const marker = "/storage-sources/";
+  const markerIndex = path.indexOf(marker);
+  if (markerIndex < 0) {
+    return path;
+  }
+
+  const pathAfterMarker = path.slice(markerIndex + marker.length);
+  const firstSlashAfterSourceId = pathAfterMarker.indexOf("/");
+  if (firstSlashAfterSourceId < 0) {
+    return path;
+  }
+
+  const sourceRelativePath = pathAfterMarker.slice(firstSlashAfterSourceId + 1).trim();
+  if (!sourceRelativePath) {
+    return path;
+  }
+
+  return `.../${sourceRelativePath}`;
+}
+
 function flattenFaceIds(items: SuggestionPhoto[]): string[] {
   return items.flatMap((photo) => photo.faces.map((face) => face.face_id));
 }
 
-async function fetchSuggestionsPage(page: number): Promise<SuggestionListPayload> {
-  const response = await fetch(`/api/v1/suggestions/faces?page=${page}&page_size=${PAGE_SIZE}`);
+async function fetchSuggestionsPage(
+  page: number,
+  minConfidenceThreshold: number
+): Promise<SuggestionListPayload> {
+  const params = new URLSearchParams({
+    page: String(page),
+    page_size: String(PAGE_SIZE)
+  });
+  if (minConfidenceThreshold > 0) {
+    params.set("min_confidence", String(minConfidenceThreshold));
+  }
+  const response = await fetch(`/api/v1/suggestions/faces?${params.toString()}`);
   if (!response.ok) {
     throw new Error(`Suggestions request failed (${response.status})`);
   }
@@ -90,6 +125,7 @@ async function confirmSuggestions(faceIds: string[]): Promise<SuggestionConfirmP
 
 export function SuggestionsRoutePage() {
   const [page, setPage] = useState(1);
+  const [minConfidencePercent, setMinConfidencePercent] = useState(0);
   const [payload, setPayload] = useState<SuggestionListPayload | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isConfirming, setIsConfirming] = useState(false);
@@ -97,11 +133,13 @@ export function SuggestionsRoutePage() {
   const [message, setMessage] = useState<string | null>(null);
   const [selectedFaceIds, setSelectedFaceIds] = useState<Set<string>>(new Set());
 
+  const minConfidenceThreshold = minConfidencePercent / 100;
+
   async function load(targetPage: number) {
     setIsLoading(true);
     setError(null);
     try {
-      const nextPayload = await fetchSuggestionsPage(targetPage);
+      const nextPayload = await fetchSuggestionsPage(targetPage, minConfidenceThreshold);
       setPayload(nextPayload);
       setSelectedFaceIds(new Set(flattenFaceIds(nextPayload.items)));
     } catch (caughtError: unknown) {
@@ -113,15 +151,19 @@ export function SuggestionsRoutePage() {
 
   useEffect(() => {
     void load(page);
-  }, [page]);
+  }, [page, minConfidenceThreshold]);
 
-  const selectedFaceIdsOrdered = useMemo(() => {
-    const selected = selectedFaceIds;
+  const currentPageFaceIdsOrdered = useMemo(() => {
     if (!payload) {
       return [] as string[];
     }
-    return flattenFaceIds(payload.items).filter((faceId) => selected.has(faceId));
-  }, [payload, selectedFaceIds]);
+    return flattenFaceIds(payload.items);
+  }, [payload]);
+
+  const selectedFaceIdsOrdered = useMemo(() => {
+    const selected = selectedFaceIds;
+    return currentPageFaceIdsOrdered.filter((faceId) => selected.has(faceId));
+  }, [currentPageFaceIdsOrdered, selectedFaceIds]);
 
   const totalPages = payload?.page.total_pages ?? 0;
   const totalItems = payload?.page.total_items ?? 0;
@@ -139,7 +181,10 @@ export function SuggestionsRoutePage() {
     setIsConfirming(true);
     setMessage(null);
     try {
-      const result = await confirmSuggestions(selectedFaceIdsOrdered);
+      const checkedFaceIdsOnCurrentPage = currentPageFaceIdsOrdered.filter((faceId) =>
+        selectedFaceIds.has(faceId)
+      );
+      const result = await confirmSuggestions(checkedFaceIdsOnCurrentPage);
       const assignedCount = result.assigned.length;
       const label = assignedCount === 1 ? "face suggestion" : "face suggestions";
       setMessage(`Confirmed ${assignedCount} ${label}.`);
@@ -162,6 +207,22 @@ export function SuggestionsRoutePage() {
           <p>{`Pending photos: ${totalItems}`}</p>
         </div>
         <div className="suggestions-header-actions">
+          <label className="suggestions-confidence-filter">
+            <span>{`Minimum certainty: ${minConfidencePercent}%`}</span>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={1}
+              value={minConfidencePercent}
+              aria-label="Minimum suggestion certainty"
+              onChange={(event) => {
+                setMinConfidencePercent(Number(event.currentTarget.value));
+                setPage(1);
+              }}
+              disabled={isLoading || isConfirming}
+            />
+          </label>
           <button
             type="button"
             onClick={() => {
@@ -196,59 +257,104 @@ export function SuggestionsRoutePage() {
 
       {!isLoading && !error && payload ? (
         <ol className="suggestions-grid" aria-label="Suggestion photo list">
-          {payload.items.map((photo) => (
-            <li key={photo.photo_id} className="suggestions-card">
-              <div className="suggestions-thumbnail-shell">
-                {photo.thumbnail ? (
-                  <img
-                    className="suggestions-thumbnail"
-                    src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
-                    width={photo.thumbnail.width}
-                    height={photo.thumbnail.height}
-                    alt={`Preview of ${photo.path}`}
-                  />
-                ) : (
-                  <div className="suggestions-thumbnail suggestions-thumbnail-placeholder" aria-hidden="true">
-                    No preview
-                  </div>
-                )}
-              </div>
-              <div className="suggestions-card-body">
-                <p className="suggestions-path" title={photo.path}>
-                  {photo.path}
-                </p>
-                <ul className="suggestions-face-list">
-                  {photo.faces.map((face) => {
-                    const isSelected = selectedFaceIds.has(face.face_id);
-                    return (
-                      <li key={face.face_id}>
-                        <label>
-                          <input
-                            type="checkbox"
-                            aria-label={`Confirm suggestion for face ${face.face_id}`}
-                            checked={isSelected}
-                            onChange={() => {
-                              setSelectedFaceIds((current) => {
-                                const next = new Set(current);
-                                if (next.has(face.face_id)) {
-                                  next.delete(face.face_id);
-                                } else {
-                                  next.add(face.face_id);
-                                }
-                                return next;
-                              });
-                            }}
-                            disabled={isLoading || isConfirming}
-                          />
-                          <span>{`${face.top_suggestion.display_name} (${formatConfidence(face.top_suggestion.confidence)})`}</span>
-                        </label>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-            </li>
-          ))}
+          {payload.items.map((photo) => {
+            const numberedFaces = photo.faces.map((face, index) => ({
+              ...face,
+              faceNumber: index + 1
+            }));
+            const faceNumberById = new Map(
+              numberedFaces.map((face) => [face.face_id, face.faceNumber] as const)
+            );
+            const overlayRegions =
+              photo.thumbnail
+                ? buildFaceOverlayRegions(
+                    numberedFaces.map((face) => ({
+                      face_id: face.face_id,
+                      person_id: null,
+                      bbox_x: face.bbox_x ?? null,
+                      bbox_y: face.bbox_y ?? null,
+                      bbox_w: face.bbox_w ?? null,
+                      bbox_h: face.bbox_h ?? null,
+                      bbox_space_width: face.bbox_space_width ?? null,
+                      bbox_space_height: face.bbox_space_height ?? null
+                    })),
+                    photo.thumbnail.width,
+                    photo.thumbnail.height
+                  )
+                : [];
+            const thumbnailShellStyle = photo.thumbnail
+              ? { aspectRatio: `${photo.thumbnail.width} / ${photo.thumbnail.height}` }
+              : undefined;
+            return (
+              <li key={photo.photo_id} className="suggestions-card">
+                <div className="suggestions-thumbnail-shell" style={thumbnailShellStyle}>
+                  <Link
+                    className="suggestions-thumbnail-link"
+                    to={`/library/${photo.photo_id}`}
+                    aria-label={`Open details for ${photo.path}`}
+                  >
+                    {photo.thumbnail ? (
+                      <img
+                        className="suggestions-thumbnail"
+                        src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
+                        width={photo.thumbnail.width}
+                        height={photo.thumbnail.height}
+                        alt={`Preview of ${photo.path}`}
+                      />
+                    ) : (
+                      <div className="suggestions-thumbnail suggestions-thumbnail-placeholder" aria-hidden="true">
+                        No preview
+                      </div>
+                    )}
+                    <FaceBBoxOverlay
+                      regions={overlayRegions}
+                      ariaLabel={`Suggested face regions for ${photo.path}`}
+                      renderRegionContent={(region) => (
+                        <span className="suggestions-face-overlay-badge" aria-hidden="true">
+                          {faceNumberById.get(region.faceId) ?? "?"}
+                        </span>
+                      )}
+                    />
+                  </Link>
+                </div>
+                <div className="suggestions-card-body">
+                  <p className="suggestions-path" title={photo.path}>
+                    {formatDisplayPath(photo.path)}
+                  </p>
+                  <ul className="suggestions-face-list">
+                    {photo.faces.map((face, index) => {
+                      const isSelected = selectedFaceIds.has(face.face_id);
+                      const faceNumber = index + 1;
+                      return (
+                        <li key={face.face_id}>
+                          <label>
+                            <input
+                              type="checkbox"
+                              aria-label={`Confirm suggestion for face ${face.face_id}`}
+                              checked={isSelected}
+                              onChange={() => {
+                                setSelectedFaceIds((current) => {
+                                  const next = new Set(current);
+                                  if (next.has(face.face_id)) {
+                                    next.delete(face.face_id);
+                                  } else {
+                                    next.add(face.face_id);
+                                  }
+                                  return next;
+                                });
+                              }}
+                              disabled={isLoading || isConfirming}
+                            />
+                            <span>{`Face ${faceNumber}: ${face.top_suggestion.display_name} (${formatConfidence(face.top_suggestion.confidence)})`}</span>
+                          </label>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              </li>
+            );
+          })}
         </ol>
       ) : null}
 

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -31,6 +31,18 @@
   font: inherit;
 }
 
+.suggestions-confidence-filter {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  color: #334155;
+  min-width: 12rem;
+}
+
+.suggestions-confidence-filter input {
+  width: 100%;
+}
+
 .suggestions-header-actions button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
@@ -53,8 +65,16 @@
 }
 
 .suggestions-thumbnail-shell {
+  position: relative;
   aspect-ratio: 4 / 3;
   background: #e2e8f0;
+}
+
+.suggestions-thumbnail-link {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .suggestions-thumbnail {
@@ -78,11 +98,13 @@
 
 .suggestions-path {
   margin: 0;
-  font-size: 0.82rem;
-  color: #1e293b;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  color: #475569;
+  font-size: 0.8rem;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: clip;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .suggestions-face-list {
@@ -94,11 +116,29 @@
 }
 
 .suggestions-face-list label {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 0.4rem;
-  font-size: 0.88rem;
+  font-size: 0.82rem;
   color: #0f172a;
+}
+
+.suggestions-face-overlay-badge {
+  position: absolute;
+  top: -0.55rem;
+  right: -0.55rem;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  border: 1px solid #f97316;
+  background: #fff7ed;
+  color: #9a3412;
+  font-size: 0.66rem;
+  font-weight: 700;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .suggestions-pagination {
@@ -1166,6 +1206,16 @@ body {
   border: 1px solid #bfdbfe;
   background: #eff6ff;
   color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.38rem 0.62rem;
+  font: inherit;
+}
+
+.face-assignment-modal-dismiss {
+  justify-self: start;
+  border: 1px solid #fecaca;
+  background: #fff1f2;
+  color: #b91c1c;
   border-radius: 0.45rem;
   padding: 0.38rem 0.62rem;
   font: inherit;

--- a/docs/superpowers/plans/2026-05-06-face-false-positive-dismissal.md
+++ b/docs/superpowers/plans/2026-05-06-face-false-positive-dismissal.md
@@ -1,0 +1,927 @@
+# Face False-Positive Dismissal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a permanent, role-gated false-positive dismissal flow for detected faces from photo detail, and keep dismissed faces out of photo detail and suggestions review reads.
+
+**Architecture:** Persist dismissal state directly on `faces` via `dismissed_ts` and `dismissal_provenance`, expose a new `POST /api/v1/faces/{face_id}/dismissals` endpoint on the existing face-labeling router, and treat only non-dismissed face rows as active in read models. The UI work stays confined to the photo-detail assignment modal and route-local state update path.
+
+**Tech Stack:** FastAPI, SQLAlchemy Core, Alembic initial-schema editing, Pydantic, React 18, TypeScript, Vitest, pytest
+
+---
+
+## File Structure
+
+**Schema and shared definitions**
+
+- Modify: `packages/db-schema/photoorg_db_schema/schema.py`
+  - Add `dismissed_ts` and `dismissal_provenance` to the shared `faces` table definition.
+- Modify: `apps/api/alembic/versions/20260321_000001_initial_schema.py`
+  - Mirror the same columns in the initial migration.
+
+**Backend write path**
+
+- Modify: `apps/api/app/services/face_assignment.py`
+  - Add dismissal-specific errors and the service function that marks a face dismissed and clears persisted suggestions.
+- Modify: `apps/api/app/routers/face_assignments.py`
+  - Add the `POST /faces/{face_id}/dismissals` endpoint and response model.
+- Modify: `apps/api/tests/test_face_assignment_api.py`
+  - Cover successful dismissal, auth failures, assigned-face conflict, dismissed-face conflict, and suggestion cleanup.
+
+**Backend read filtering**
+
+- Modify: `apps/api/app/repositories/photos_repo.py`
+  - Exclude dismissed faces from hydrated photo detail faces and derive `metadata.faces_count` from active faces for detail reads.
+- Modify: `apps/api/app/services/face_suggestion_review.py`
+  - Exclude dismissed faces from the suggestions review feed queries.
+- Modify: `apps/api/tests/test_photo_detail_api.py`
+  - Cover detail omission of dismissed faces and active-only face counts.
+- Modify: `apps/api/tests/test_face_suggestion_review_api.py`
+  - Cover dismissed faces being absent from `/api/v1/suggestions/faces`.
+
+**Frontend photo-detail UX**
+
+- Modify: `apps/ui/src/pages/PhotoFaceAssignmentModal.tsx`
+  - Add the discard action, dismissal request handling, and error mapping.
+- Modify: `apps/ui/src/pages/PhotoDetailRoutePage.tsx`
+  - Add local state mutation helper for removing a dismissed face and updating metadata.
+- Modify: `apps/ui/src/styles/app-shell.css`
+  - Style the destructive dismiss action in the modal.
+- Modify: `apps/ui/src/pages/PhotoDetailRoutePage.test.tsx`
+  - Cover the discard action, successful local removal, and permission/conflict error handling.
+
+## Task 1: Add Dismissal Schema and API Contract
+
+**Files:**
+- Modify: `packages/db-schema/photoorg_db_schema/schema.py:183-199`
+- Modify: `apps/api/alembic/versions/20260321_000001_initial_schema.py:275-290`
+- Modify: `apps/api/app/services/face_assignment.py:1-398`
+- Modify: `apps/api/app/routers/face_assignments.py:1-314`
+- Modify: `apps/api/tests/test_face_assignment_api.py`
+
+- [ ] **Step 1: Write the failing API tests**
+
+```python
+from app.storage import face_labels, face_suggestions, faces, ingest_queue, people, photos
+
+
+def test_face_dismissal_api_marks_unassigned_face_as_dismissed_and_clears_suggestions(
+    tmp_path, monkeypatch
+):
+    database_url = _database_url(tmp_path, "face-dismiss.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+        connection.execute(
+            insert(face_suggestions).values(
+                face_suggestion_id="suggestion-1",
+                face_id="face-1",
+                person_id="person-1",
+                rank=1,
+                confidence=0.91,
+                centroid_distance=0.09,
+                knn_distance=0.09,
+                representation_version=1,
+                scoring_version="hybrid-v1",
+                model_version="recognition-v1",
+            )
+        )
+
+    client = _authorized_client()
+    response = client.post("/api/v1/faces/face-1/dismissals")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["face_id"] == "face-1"
+    assert payload["photo_id"] == "photo-1"
+    assert payload["dismissed_ts"].endswith("Z")
+
+    with engine.connect() as connection:
+        face_row = connection.execute(
+            select(
+                faces.c.dismissed_ts,
+                faces.c.dismissal_provenance,
+            ).where(faces.c.face_id == "face-1")
+        ).mappings().one()
+        persisted_suggestions = connection.execute(
+            select(face_suggestions.c.face_suggestion_id).where(face_suggestions.c.face_id == "face-1")
+        ).all()
+
+    assert face_row["dismissed_ts"] is not None
+    assert face_row["dismissal_provenance"] == {
+        "workflow": "face-labeling",
+        "surface": "api",
+        "action": "dismiss_false_positive",
+    }
+    assert persisted_suggestions == []
+
+
+def test_face_dismissal_api_rejects_already_assigned_face(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-dismiss-assigned.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id="person-1",
+            )
+        )
+
+    client = _authorized_client()
+    response = client.post("/api/v1/faces/face-1/dismissals")
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Face already assigned"}
+
+
+def test_face_dismissal_api_rejects_already_dismissed_face(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-dismiss-dismissed.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 5, 6, 12, 0, tzinfo=UTC)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+                dismissed_ts=now,
+                dismissal_provenance={"workflow": "face-labeling", "surface": "api", "action": "dismiss_false_positive"},
+            )
+        )
+
+    client = _authorized_client()
+    response = client.post("/api/v1/faces/face-1/dismissals")
+
+    assert response.status_code == 409
+    assert response.json() == {"detail": "Face already dismissed"}
+```
+
+- [ ] **Step 2: Run the API dismissal tests to verify they fail**
+
+Run: `uv run pytest apps/api/tests/test_face_assignment_api.py -k dismissal -q`
+
+Expected: `FAIL` because `faces.dismissed_ts` / `faces.dismissal_provenance` do not exist yet and `POST /api/v1/faces/{face_id}/dismissals` is not implemented.
+
+- [ ] **Step 3: Add the shared schema columns**
+
+```python
+faces = Table(
+    "faces",
+    metadata,
+    Column("face_id", String(36), primary_key=True),
+    Column("photo_id", String(36), ForeignKey("photos.photo_id", ondelete="CASCADE"), nullable=False),
+    Column("person_id", String(36), ForeignKey("people.person_id", ondelete="RESTRICT")),
+    Column("bbox_x", Integer),
+    Column("bbox_y", Integer),
+    Column("bbox_w", Integer),
+    Column("bbox_h", Integer),
+    Column("bitmap", LargeBinary),
+    Column("embedding", JSON()),
+    Column("detector_name", String),
+    Column("detector_version", String),
+    Column("provenance", JSON()),
+    Column("dismissed_ts", TIMESTAMP(timezone=True)),
+    Column("dismissal_provenance", JSON()),
+    Column("created_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+)
+```
+
+```python
+op.create_table(
+    "faces",
+    sa.Column("face_id", sa.String(36), primary_key=True),
+    sa.Column("photo_id", sa.String(36), sa.ForeignKey("photos.photo_id", ondelete="CASCADE"), nullable=False),
+    sa.Column("person_id", sa.String(36), sa.ForeignKey("people.person_id", ondelete="RESTRICT"), nullable=True),
+    sa.Column("bbox_x", sa.Integer(), nullable=True),
+    sa.Column("bbox_y", sa.Integer(), nullable=True),
+    sa.Column("bbox_w", sa.Integer(), nullable=True),
+    sa.Column("bbox_h", sa.Integer(), nullable=True),
+    sa.Column("bitmap", sa.LargeBinary(), nullable=True),
+    sa.Column("embedding", embedding_type, nullable=True),
+    sa.Column("detector_name", sa.String(), nullable=True),
+    sa.Column("detector_version", sa.String(), nullable=True),
+    sa.Column("provenance", sa.JSON(), nullable=True),
+    sa.Column("dismissed_ts", sa.TIMESTAMP(timezone=True), nullable=True),
+    sa.Column("dismissal_provenance", sa.JSON(), nullable=True),
+    sa.Column("created_ts", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+)
+```
+
+- [ ] **Step 4: Implement the dismissal service and router contract**
+
+```python
+class FaceAlreadyDismissedError(RuntimeError):
+    pass
+
+
+def dismiss_false_positive_face(
+    connection: Connection,
+    *,
+    face_id: str,
+) -> dict[str, str]:
+    row = (
+        connection.execute(
+            select(
+                faces.c.face_id,
+                faces.c.photo_id,
+                faces.c.person_id,
+                faces.c.dismissed_ts,
+            ).where(faces.c.face_id == face_id)
+        )
+        .mappings()
+        .first()
+    )
+    if row is None:
+        raise FaceNotFoundError("Face not found")
+    if row["person_id"] is not None:
+        raise FaceAlreadyAssignedError("Face already assigned")
+    if row["dismissed_ts"] is not None:
+        raise FaceAlreadyDismissedError("Face already dismissed")
+
+    dismissed_ts = datetime.now(UTC)
+    connection.execute(
+        update(faces)
+        .where(faces.c.face_id == face_id, faces.c.person_id.is_(None), faces.c.dismissed_ts.is_(None))
+        .values(
+            dismissed_ts=dismissed_ts,
+            dismissal_provenance={
+                "workflow": "face-labeling",
+                "surface": "api",
+                "action": "dismiss_false_positive",
+            },
+        )
+    )
+    connection.execute(delete(face_suggestions).where(face_suggestions.c.face_id == face_id))
+    return {
+        "face_id": str(row["face_id"]),
+        "photo_id": str(row["photo_id"]),
+        "dismissed_ts": dismissed_ts.isoformat().replace("+00:00", "Z"),
+    }
+```
+
+```python
+class FaceDismissalResponse(BaseModel):
+    face_id: str
+    photo_id: str
+    dismissed_ts: str
+
+
+@router.post(
+    "/{face_id}/dismissals",
+    summary="Dismiss false-positive face detection",
+    description="Persistently dismiss an unassigned detected face that does not correspond to a real face.",
+    response_model=FaceDismissalResponse,
+    responses={
+        status.HTTP_403_FORBIDDEN: {"description": "Face validation role required"},
+        status.HTTP_404_NOT_FOUND: {"description": "Face not found"},
+        status.HTTP_409_CONFLICT: {"description": "Face already assigned or already dismissed"},
+    },
+)
+def dismiss_face_endpoint(
+    face_id: str,
+    db: Session = Depends(get_db),
+    _: str = Depends(require_face_validation_role),
+) -> FaceDismissalResponse:
+    try:
+        result = dismiss_false_positive_face(db.connection(), face_id=face_id)
+    except FaceNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except FaceAlreadyAssignedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except FaceAlreadyDismissedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    db.commit()
+    return FaceDismissalResponse.model_validate(result)
+```
+
+- [ ] **Step 5: Run the dismissal API tests to verify they pass**
+
+Run: `uv run pytest apps/api/tests/test_face_assignment_api.py -k dismissal -q`
+
+Expected: `PASS`
+
+- [ ] **Step 6: Commit the backend dismissal contract**
+
+```bash
+git add packages/db-schema/photoorg_db_schema/schema.py \
+  apps/api/alembic/versions/20260321_000001_initial_schema.py \
+  apps/api/app/services/face_assignment.py \
+  apps/api/app/routers/face_assignments.py \
+  apps/api/tests/test_face_assignment_api.py
+git commit -m "feat: add false-positive face dismissal api"
+```
+
+## Task 2: Filter Dismissed Faces from Photo Detail
+
+**Files:**
+- Modify: `apps/api/app/repositories/photos_repo.py:781-977`
+- Modify: `apps/api/tests/test_photo_detail_api.py`
+
+- [ ] **Step 1: Write the failing photo-detail tests**
+
+```python
+def test_photo_detail_api_omits_dismissed_faces_and_recomputes_active_face_count(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'photo-detail-api-dismissed-faces.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 5, 6, 12, 0, tzinfo=UTC)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                sha256="sha-1",
+                created_ts=now,
+                updated_ts=now,
+                path="/photos/photo-1.jpg",
+                filesize=1024,
+                ext="jpg",
+                faces_count=2,
+            )
+        )
+        connection.execute(
+            insert(faces),
+            [
+                {
+                    "face_id": "face-active",
+                    "photo_id": "photo-1",
+                    "person_id": None,
+                    "bbox_x": 10,
+                    "bbox_y": 20,
+                    "bbox_w": 30,
+                    "bbox_h": 40,
+                },
+                {
+                    "face_id": "face-dismissed",
+                    "photo_id": "photo-1",
+                    "person_id": None,
+                    "bbox_x": 50,
+                    "bbox_y": 60,
+                    "bbox_w": 70,
+                    "bbox_h": 80,
+                    "dismissed_ts": now,
+                    "dismissal_provenance": {
+                        "workflow": "face-labeling",
+                        "surface": "api",
+                        "action": "dismiss_false_positive",
+                    },
+                },
+            ],
+        )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/photos/photo-1")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [face["face_id"] for face in payload["faces"]] == ["face-active"]
+    assert payload["metadata"]["faces_count"] == 1
+```
+
+- [ ] **Step 2: Run the photo-detail dismissal test to verify it fails**
+
+Run: `uv run pytest apps/api/tests/test_photo_detail_api.py -k dismissed_faces -q`
+
+Expected: `FAIL` because dismissed face rows are still hydrated and `metadata.faces_count` still mirrors the stored `photos.faces_count`.
+
+- [ ] **Step 3: Filter dismissed faces and derive active face count in the repository**
+
+```python
+face_rows = self.db.execute(
+    select(*face_columns)
+    .where(
+        self.faces.c.photo_id.in_(pids),
+        self.faces.c.dismissed_ts.is_(None),
+    )
+    .order_by(self.faces.c.photo_id, self.faces.c.face_id)
+).all()
+```
+
+```python
+item = self._hydrate_items(rows, include_face_regions=True)[0]
+row = rows[0]
+item["metadata"] = {
+    "sha256": row.sha256,
+    "phash": row.phash,
+    "shot_ts_source": self._normalize_shot_ts_source_label(
+        row.shot_ts_source,
+        exif_attributes=exif_attributes,
+    ),
+    "camera_model": row.camera_model,
+    "software": row.software,
+    "gps_latitude": row.gps_latitude,
+    "gps_longitude": row.gps_longitude,
+    "gps_altitude": row.gps_altitude,
+    "exif_attributes": exif_attributes,
+    "exif_unmapped_attributes": exif_unmapped_attributes,
+    "created_ts": row.created_ts,
+    "updated_ts": row.updated_ts,
+    "modified_ts": row.modified_ts,
+    "deleted_ts": row.deleted_ts,
+    "faces_count": len(item["faces"]),
+    "faces_detected_ts": row.faces_detected_ts,
+}
+```
+
+- [ ] **Step 4: Run the photo-detail tests to verify they pass**
+
+Run: `uv run pytest apps/api/tests/test_photo_detail_api.py -k "dismissed_faces or projected_metadata" -q`
+
+Expected: `PASS`
+
+- [ ] **Step 5: Commit the photo-detail read filtering**
+
+```bash
+git add apps/api/app/repositories/photos_repo.py apps/api/tests/test_photo_detail_api.py
+git commit -m "feat: hide dismissed faces from photo detail"
+```
+
+## Task 3: Filter Dismissed Faces from Suggestions Review
+
+**Files:**
+- Modify: `apps/api/app/services/face_suggestion_review.py:159-330`
+- Modify: `apps/api/tests/test_face_suggestion_review_api.py`
+
+- [ ] **Step 1: Write the failing suggestions-review test**
+
+```python
+def test_face_suggestion_review_list_omits_dismissed_faces(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch, "face-suggestion-review-dismissed.db")
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'face-suggestion-review-dismissed.db'}", future=True)
+    now = datetime(2026, 5, 6, 12, 0, tzinfo=UTC)
+    with engine.begin() as connection:
+        _insert_person(connection, person_id="person-1", display_name="Alex")
+        _insert_photo(
+            connection,
+            photo_id="photo-1",
+            path="/photos/1.jpg",
+            shot_ts=datetime(2026, 5, 5, 11, 0, tzinfo=UTC),
+        )
+        connection.execute(
+            insert(faces),
+            [
+                {"face_id": "face-active", "photo_id": "photo-1", "person_id": None},
+                {
+                    "face_id": "face-dismissed",
+                    "photo_id": "photo-1",
+                    "person_id": None,
+                    "dismissed_ts": now,
+                    "dismissal_provenance": {
+                        "workflow": "face-labeling",
+                        "surface": "api",
+                        "action": "dismiss_false_positive",
+                    },
+                },
+            ],
+        )
+        connection.execute(
+            insert(face_suggestions),
+            [
+                {
+                    "face_suggestion_id": "s1",
+                    "face_id": "face-active",
+                    "person_id": "person-1",
+                    "rank": 1,
+                    "confidence": 0.95,
+                    "centroid_distance": 0.05,
+                    "knn_distance": 0.05,
+                    "representation_version": 2,
+                    "scoring_version": "hybrid-v1",
+                    "model_version": "recognition-v1",
+                },
+                {
+                    "face_suggestion_id": "s2",
+                    "face_id": "face-dismissed",
+                    "person_id": "person-1",
+                    "rank": 1,
+                    "confidence": 0.96,
+                    "centroid_distance": 0.04,
+                    "knn_distance": 0.04,
+                    "representation_version": 2,
+                    "scoring_version": "hybrid-v1",
+                    "model_version": "recognition-v1",
+                },
+            ],
+        )
+
+    response = client.get("/api/v1/suggestions/faces", params={"page": 1, "page_size": 24})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["page"]["total_items"] == 1
+    assert [face["face_id"] for face in payload["items"][0]["faces"]] == ["face-active"]
+```
+
+- [ ] **Step 2: Run the suggestions-review test to verify it fails**
+
+Run: `uv run pytest apps/api/tests/test_face_suggestion_review_api.py -k omitted_dismissed -q`
+
+Expected: `FAIL` because the current eligible-photo and face-row queries do not filter on `faces.dismissed_ts`.
+
+- [ ] **Step 3: Add `dismissed_ts IS NULL` to the review-feed queries**
+
+```python
+eligible_photo_ids = (
+    select(faces.c.photo_id)
+    .select_from(
+        faces.join(top_suggestion, top_suggestion.c.face_id == faces.c.face_id).join(
+            photos, photos.c.photo_id == faces.c.photo_id
+        )
+    )
+    .where(
+        faces.c.person_id.is_(None),
+        faces.c.dismissed_ts.is_(None),
+        photos.c.deleted_ts.is_(None),
+        top_suggestion.c.confidence >= normalized_min_confidence,
+    )
+    .distinct()
+    .subquery()
+)
+```
+
+```python
+face_rows = (
+    connection.execute(
+        select(
+            faces.c.photo_id,
+            faces.c.face_id,
+            faces.c.bbox_x,
+            faces.c.bbox_y,
+            faces.c.bbox_w,
+            faces.c.bbox_h,
+            faces.c.provenance,
+            top_suggestion.c.person_id.label("suggested_person_id"),
+            top_suggestion.c.confidence.label("suggested_confidence"),
+            people.c.display_name.label("suggested_display_name"),
+        )
+        .select_from(
+            faces.join(top_suggestion, top_suggestion.c.face_id == faces.c.face_id).join(
+                people, people.c.person_id == top_suggestion.c.person_id
+            )
+        )
+        .where(
+            faces.c.photo_id.in_(photo_ids),
+            faces.c.person_id.is_(None),
+            faces.c.dismissed_ts.is_(None),
+            top_suggestion.c.confidence >= normalized_min_confidence,
+        )
+        .order_by(faces.c.photo_id.asc(), faces.c.face_id.asc())
+    )
+    .mappings()
+    .all()
+)
+```
+
+- [ ] **Step 4: Run the suggestions-review tests to verify they pass**
+
+Run: `uv run pytest apps/api/tests/test_face_suggestion_review_api.py -q`
+
+Expected: `PASS`
+
+- [ ] **Step 5: Commit the suggestions-review filtering**
+
+```bash
+git add apps/api/app/services/face_suggestion_review.py apps/api/tests/test_face_suggestion_review_api.py
+git commit -m "feat: exclude dismissed faces from suggestions review"
+```
+
+## Task 4: Add the Photo-Detail Modal Dismiss Action and Local State Update
+
+**Files:**
+- Modify: `apps/ui/src/pages/PhotoFaceAssignmentModal.tsx`
+- Modify: `apps/ui/src/pages/PhotoDetailRoutePage.tsx`
+- Modify: `apps/ui/src/styles/app-shell.css`
+- Modify: `apps/ui/src/pages/PhotoDetailRoutePage.test.tsx`
+
+- [ ] **Step 1: Write the failing photo-detail UI tests**
+
+```tsx
+it("dismisses an unlabeled false-positive face from the detail modal and removes it locally", async () => {
+  const user = userEvent.setup();
+
+  fetchMock
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () =>
+        buildPayload({
+          faces: [
+            {
+              face_id: "face-1",
+              person_id: null,
+              bbox_x: 10,
+              bbox_y: 10,
+              bbox_w: 20,
+              bbox_h: 20,
+              label_source: null,
+              confidence: null,
+              model_version: null,
+              provenance: null,
+              label_recorded_ts: null
+            }
+          ]
+        })
+    } as Response)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => []
+    } as Response)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        face_id: "face-1",
+        candidates: [],
+        suggestion_policy: {
+          decision: "no_suggestion",
+          review_threshold: 0.5,
+          auto_accept_threshold: 0.9,
+          top_candidate_confidence: null
+        },
+        review_needed_suggestion: null
+      })
+    } as Response)
+    .mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        face_id: "face-1",
+        photo_id: "photo-1",
+        dismissed_ts: "2026-05-06T12:00:00Z"
+      })
+    } as Response);
+
+  renderDetail();
+
+  await user.click(await screen.findByRole("button", { name: "Open face assignment for face region 1" }));
+  await user.click(await screen.findByRole("button", { name: "Discard false positive" }));
+
+  await waitFor(() => {
+    expect(screen.queryByRole("dialog", { name: "Face assignment" })).not.toBeInTheDocument();
+  });
+  expect(screen.queryByRole("button", { name: "Open face assignment for face region 1" })).not.toBeInTheDocument();
+  expect(screen.getByText("No face regions detected for this photo.")).toBeInTheDocument();
+});
+
+
+it("shows the dismissal permission error inline in the detail modal", async () => {
+  const user = userEvent.setup();
+
+  fetchMock
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () =>
+        buildPayload({
+          faces: [
+            {
+              face_id: "face-1",
+              person_id: null,
+              bbox_x: 10,
+              bbox_y: 10,
+              bbox_w: 20,
+              bbox_h: 20,
+              label_source: null,
+              confidence: null,
+              model_version: null,
+              provenance: null,
+              label_recorded_ts: null
+            }
+          ]
+        })
+    } as Response)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => []
+    } as Response)
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        face_id: "face-1",
+        candidates: [],
+        suggestion_policy: {
+          decision: "no_suggestion",
+          review_threshold: 0.5,
+          auto_accept_threshold: 0.9,
+          top_candidate_confidence: null
+        },
+        review_needed_suggestion: null
+      })
+    } as Response)
+    .mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: "Face validation role required" })
+    } as Response);
+
+  renderDetail();
+
+  await user.click(await screen.findByRole("button", { name: "Open face assignment for face region 1" }));
+  await user.click(await screen.findByRole("button", { name: "Discard false positive" }));
+
+  expect(await screen.findByText("You do not have permission to discard faces.")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the photo-detail UI tests to verify they fail**
+
+Run: `npm --prefix apps/ui test -- src/pages/PhotoDetailRoutePage.test.tsx`
+
+Expected: `FAIL` because the modal does not render a dismiss action and the detail route has no local “remove dismissed face” state transition.
+
+- [ ] **Step 3: Implement the modal dismissal request and route-local removal helper**
+
+```tsx
+function mapDismissalError(status: number, detail: string | null): string {
+  if (status === 403) {
+    return "You do not have permission to discard faces.";
+  }
+  if (status === 404) {
+    return detail ?? "Face no longer exists.";
+  }
+  if (status === 409) {
+    return detail ?? "Face dismissal could not be applied.";
+  }
+  return `Dismissal request failed (${status}).`;
+}
+```
+
+```tsx
+interface PhotoFaceAssignmentModalProps {
+  isOpen: boolean;
+  face: (FaceAssignmentModalFace & { sequence: number }) | null;
+  region: FaceOverlayRegion | null;
+  thumbnail: FaceThumbnail | null;
+  people: FaceAssignmentModalPerson[];
+  onClose: () => void;
+  onFaceUpdated: (faceId: string, personId: string) => void;
+  onFaceDismissed: (faceId: string) => void;
+  onPersonCreated: (person: FaceAssignmentModalPerson) => void;
+}
+```
+
+```tsx
+async function dismissFalsePositive() {
+  if (!face || face.person_id !== null || isSubmitting) {
+    return;
+  }
+
+  setIsSubmitting(true);
+  setError(null);
+  try {
+    const response = await fetch(`/api/v1/faces/${face.face_id}/dismissals`, {
+      method: "POST",
+      headers: {
+        "X-Face-Validation-Role": "contributor"
+      }
+    });
+    if (!response.ok) {
+      const detail = await readErrorDetail(response);
+      setError(mapDismissalError(response.status, detail));
+      return;
+    }
+    onFaceDismissed(face.face_id);
+    onClose();
+  } catch {
+    setError("Could not discard face.");
+  } finally {
+    setIsSubmitting(false);
+  }
+}
+```
+
+```tsx
+{face.person_id === null ? (
+  <button
+    type="button"
+    className="face-assignment-modal-dismiss"
+    onClick={() => void dismissFalsePositive()}
+    disabled={isBusy}
+  >
+    Discard false positive
+  </button>
+) : null}
+```
+
+```tsx
+function applyFaceDismissal(detail: PhotoDetailPayload, faceId: string): PhotoDetailPayload {
+  const nextFaces = detail.faces.filter((face) => face.face_id !== faceId);
+  const nextPeople = Array.from(
+    new Set(
+      nextFaces
+        .map((face) => face.person_id)
+        .filter((value): value is string => value !== null)
+    )
+  );
+
+  return {
+    ...detail,
+    faces: nextFaces,
+    people: nextPeople,
+    metadata: {
+      ...detail.metadata,
+      faces_count: nextFaces.length
+    }
+  };
+}
+```
+
+```tsx
+function handleFaceDismissed(faceId: string) {
+  setDetail((current) => (current ? applyFaceDismissal(current, faceId) : current));
+  setActiveFaceModalId((current) => (current === faceId ? null : current));
+}
+```
+
+```tsx
+<PhotoFaceAssignmentModal
+  isOpen={selectedFaceForModal !== null}
+  face={selectedFaceForModal}
+  region={selectedRegionForModal}
+  thumbnail={detail?.thumbnail ?? null}
+  people={peopleDirectory.map((person) => ({
+    person_id: person.person_id,
+    display_name: person.display_name,
+    created_ts: person.created_ts,
+    updated_ts: person.updated_ts
+  }))}
+  onClose={() => setActiveFaceModalId(null)}
+  onFaceUpdated={handleFaceAssigned}
+  onFaceDismissed={handleFaceDismissed}
+  onPersonCreated={handlePersonCreated}
+/>
+```
+
+```css
+.face-assignment-modal-dismiss {
+  border: 1px solid #fecaca;
+  background: #fff1f2;
+  color: #b91c1c;
+}
+```
+
+- [ ] **Step 4: Run the photo-detail UI tests to verify they pass**
+
+Run: `npm --prefix apps/ui test -- src/pages/PhotoDetailRoutePage.test.tsx`
+
+Expected: `PASS`
+
+- [ ] **Step 5: Commit the photo-detail dismissal UX**
+
+```bash
+git add apps/ui/src/pages/PhotoFaceAssignmentModal.tsx \
+  apps/ui/src/pages/PhotoDetailRoutePage.tsx \
+  apps/ui/src/styles/app-shell.css \
+  apps/ui/src/pages/PhotoDetailRoutePage.test.tsx
+git commit -m "feat: add false-positive dismissal to photo detail"
+```
+
+## Task 5: Final Verification
+
+**Files:**
+- No code changes expected
+
+- [ ] **Step 1: Run the targeted backend verification suite**
+
+Run: `uv run pytest apps/api/tests/test_face_assignment_api.py apps/api/tests/test_photo_detail_api.py apps/api/tests/test_face_suggestion_review_api.py -q`
+
+Expected: `PASS`
+
+- [ ] **Step 2: Run the targeted frontend verification suite**
+
+Run: `npm --prefix apps/ui test -- src/pages/PhotoDetailRoutePage.test.tsx`
+
+Expected: `PASS`
+
+- [ ] **Step 3: Commit only if verification required follow-up edits**
+
+```bash
+git status --short
+```
+
+Expected: no unexpected modified files beyond this feature scope.

--- a/docs/superpowers/specs/2026-05-06-face-false-positive-dismissal-design.md
+++ b/docs/superpowers/specs/2026-05-06-face-false-positive-dismissal-design.md
@@ -1,0 +1,256 @@
+# Face False-Positive Dismissal Design
+
+Date: 2026-05-06
+Topic: Permanent dismissal of false-positive face detections from photo detail
+
+## Summary
+
+Allow an authorized human reviewer to permanently dismiss a detected face bounding box when it does not correspond to a real face.
+
+The dismissal is:
+
+- persistent
+- available only from photo detail
+- gated by the existing face-validation role
+- not reversible in the product
+
+Implementation should preserve the original detection record for auditability while removing the dismissed face from all active review and display surfaces.
+
+## Goals
+
+- Let a human discard a false-positive face detection from photo detail.
+- Keep dismissed detections from reappearing in photo detail reads.
+- Keep dismissed detections from reappearing in suggestion-review reads.
+- Preserve audit context for why a detection stopped being active.
+- Reuse existing role-gated face-review patterns and error handling.
+
+## Non-Goals
+
+- Adding a restore or undo workflow.
+- Adding discard actions to the batch suggestions page.
+- Deleting historical detection records outright.
+- Solving detector drift across materially different future bounding boxes.
+
+## Product Decisions (Validated)
+
+- Dismissal is permanent from the product point of view.
+- There is no restore action in this slice.
+- Only users with the accepted `X-Face-Validation-Role` may dismiss a face.
+- The action is exposed only on photo detail, not on `/suggestions`.
+- Already-assigned faces cannot be dismissed as false positives.
+
+## Current State Constraints
+
+- `faces` is the durable record for detected face regions.
+- Photo detail reads surface `faces` rows directly.
+- Suggestion review reads also source active work from `faces`.
+- There is no existing false-positive or dismissed state on `faces`.
+- `face_labels` is used as a person-label provenance ledger, not as the source of detection lifecycle state.
+
+## Recommended Approach
+
+Store dismissal state directly on `faces` and treat only non-dismissed rows as active.
+
+Why this approach:
+
+- It preserves the original detection record instead of destroying it.
+- It avoids overloading `face_labels` with non-label lifecycle state.
+- It is smaller and clearer than introducing a separate review-status table.
+- It naturally supports filtering dismissed faces out of all active read surfaces.
+
+Rejected alternatives:
+
+- Hard-delete the `faces` row.
+  - Too destructive.
+  - Loses auditability.
+  - Makes later reasoning about detector behavior harder.
+- Add a separate face review/status table.
+  - More flexible, but unnecessarily heavy for a single permanent dismissal state.
+
+## Data Model Design
+
+Add dismissal fields directly to `faces`:
+
+- `dismissed_ts TIMESTAMPTZ NULL`
+- `dismissal_provenance JSON NULL`
+
+Semantics:
+
+- `dismissed_ts IS NULL` means the detection is active.
+- `dismissed_ts IS NOT NULL` means the detection has been permanently dismissed as a false positive.
+- `dismissal_provenance` records the action context for audit/debugging.
+
+Proposed dismissal provenance payload:
+
+```json
+{
+  "workflow": "face-labeling",
+  "surface": "api",
+  "action": "dismiss_false_positive"
+}
+```
+
+Schema update policy:
+
+- Update the initial Alembic revision directly.
+- Keep the shared schema source aligned with the same fields and constraints.
+
+Rationale:
+
+- This repository is still evolving its initial schema directly in early-stage slices.
+- No backward-compatibility migration flow is needed for this feature at the current stage.
+
+## Write API Design
+
+Add a role-gated endpoint on the existing face-labeling surface:
+
+- `POST /api/v1/faces/{face_id}/dismissals`
+
+Response shape:
+
+- return the `face_id`
+- return the owning `photo_id`
+- return `dismissed_ts`
+
+Success preconditions:
+
+- face exists
+- face is not already dismissed
+- face is not assigned to a person
+
+Successful behavior:
+
+1. set `faces.dismissed_ts` to the current timestamp
+2. set `faces.dismissal_provenance` to the dismissal provenance payload
+3. delete any persisted `face_suggestions` rows for that `face_id`
+4. commit the transaction
+
+Error behavior:
+
+- `403 Forbidden`
+  - missing or unaccepted face-validation role
+- `404 Not Found`
+  - face does not exist
+- `409 Conflict`
+  - face is already assigned
+  - face is already dismissed
+
+Design note:
+
+- Return conflicts for invalid state transitions instead of silently succeeding so the UI can surface state drift consistently with the existing assignment/correction endpoints.
+
+## Read Behavior Design
+
+Dismissed faces must be excluded from active read surfaces.
+
+### Photo Detail
+
+- `GET /api/v1/photos/{photo_id}` must omit dismissed faces from the `faces` list.
+- Face-related metadata shown to the user should reflect active faces only.
+
+Specifically:
+
+- `metadata.faces_count` should count only non-dismissed faces
+- overlay regions should only be built from non-dismissed faces
+- people summaries should be derived from the filtered active face list as they are today
+
+### Suggestions Review
+
+- `GET /api/v1/suggestions/faces` must exclude dismissed faces.
+- Any helper query that resolves “unassigned active suggestion work” must require `faces.dismissed_ts IS NULL`.
+
+Rationale:
+
+- Permanent dismissal should remove the false positive from all active human-review surfaces, not only from the page where it was dismissed.
+
+## UI Design
+
+Scope is limited to photo detail.
+
+### Placement
+
+Add a `Discard false positive` action for unlabeled faces in photo detail.
+
+Recommended placement:
+
+- alongside the existing unlabeled-face assignment controls
+- not in the batch suggestions workflow
+- not for already-labeled faces
+
+### Interaction Behavior
+
+On success, the client should update local detail state immediately so the dismissed face disappears without a full reload:
+
+- remove the face from `detail.faces`
+- update visible overlay boxes
+- update unlabeled face assignment controls
+- update visible people/face summary derived from current detail state
+
+### Permissions and Errors
+
+Use the same contributor header and overall error-handling style as other face-review actions.
+
+Suggested message mapping:
+
+- `403`: user lacks permission to discard faces
+- `404`: face no longer exists
+- `409`: face is already assigned or already dismissed
+- network failure: generic discard failure message
+
+## State and Data Flow
+
+1. User opens photo detail.
+2. UI loads active faces from `GET /api/v1/photos/{photo_id}`.
+3. User triggers `Discard false positive` for an unlabeled face.
+4. UI calls `POST /api/v1/faces/{face_id}/dismissals` with the face-validation role header.
+5. API validates state and persists dismissal on `faces`.
+6. API deletes any stale `face_suggestions` rows for that face.
+7. UI removes the face from local state after success.
+8. Subsequent photo-detail and suggestions-review reads no longer include that face.
+
+## Edge Conditions
+
+- Dismissing an already-assigned face is rejected.
+- Dismissing an already-dismissed face is rejected.
+- If a later ingest rerun touches the same face record, the face remains dismissed because the row still exists.
+- If detector changes yield a materially different bounding box and therefore a different `face_id`, that new detection may appear again as new review work.
+
+This last case is acceptable in this slice because detector-identity reconciliation is a separate concern from permanent dismissal of an existing detection record.
+
+## Testing Strategy
+
+### Backend
+
+Add tests for:
+
+- successful dismissal of an unassigned face
+- rejection when role header is missing
+- rejection when role header is unaccepted
+- `404` for unknown face
+- `409` for already-assigned face
+- `409` for already-dismissed face
+- persisted suggestion rows are removed for dismissed faces
+- photo detail omits dismissed faces
+- photo detail `metadata.faces_count` reflects active faces only
+- suggestions review omits dismissed faces
+
+### Frontend
+
+Add tests for:
+
+- discard action is shown for an unlabeled face in photo detail
+- discard action is not shown for labeled faces
+- successful dismiss removes the face from the overlay immediately
+- successful dismiss removes the face from assignment controls immediately
+- permission/conflict failures surface the correct error message
+
+## Implementation Notes
+
+- Keep dismissal state on `faces`; do not extend `face_labels` for this feature.
+- Reuse existing face-review router/service structure instead of creating a separate subsystem.
+- Apply the active-face filter consistently in repository and suggestion-review queries to avoid split-brain behavior between surfaces.
+
+## Open Follow-Ups
+
+- If future product work needs reviewer history or restore behavior, revisit whether `faces` state is still sufficient or whether a dedicated review-event model is warranted.
+- If detector drift becomes noisy in practice, consider a later feature for suppressing semantically similar future detections rather than only the exact historical `face_id`.

--- a/packages/db-schema/photoorg_db_schema/schema.py
+++ b/packages/db-schema/photoorg_db_schema/schema.py
@@ -195,6 +195,8 @@ faces = Table(
     Column("detector_name", String),
     Column("detector_version", String),
     Column("provenance", JSON()),
+    Column("dismissed_ts", TIMESTAMP(timezone=True)),
+    Column("dismissal_provenance", JSON()),
     Column("created_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
 )
 


### PR DESCRIPTION
## Summary
- add an internal worker endpoint to recompute stale face suggestions for unassigned faces
- add service logic to target unassigned faces with missing snapshots or snapshots older than a configurable TTL
- support bounded processing with face_limit and configurable suggestion_limit
- return refresh counts and computed cutoff timestamp

## Endpoint
- POST /api/v1/internal/face-suggestions/recompute/stale
- worker-role protected via X-Worker-Role: ingest-processor

## Tests
- add endpoint auth/argument-forwarding coverage in test_ingest_queue_api.py
- add service selection/limit behavior coverage in test_face_suggestions_service.py

## Validation
- uv run --group test python -m pytest apps/api/tests/test_ingest_queue_api.py apps/api/tests/test_face_suggestions_service.py
- uv run ruff check apps/api/app/routers/ingest_queue.py apps/api/app/services/face_suggestions.py apps/api/tests/test_ingest_queue_api.py apps/api/tests/test_face_suggestions_service.py