### PR TITLE
feat: add persisted suggestions exclude filters

### DIFF
--- a/apps/api/alembic/versions/20260321_000001_initial_schema.py
+++ b/apps/api/alembic/versions/20260321_000001_initial_schema.py
@@ -285,8 +285,6 @@ def upgrade() -> None:
         sa.Column("detector_name", sa.String(), nullable=True),
         sa.Column("detector_version", sa.String(), nullable=True),
         sa.Column("provenance", sa.JSON(), nullable=True),
-        sa.Column("dismissed_ts", sa.TIMESTAMP(timezone=True), nullable=True),
-        sa.Column("dismissal_provenance", sa.JSON(), nullable=True),
         sa.Column("created_ts", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
     )
     op.create_index("idx_faces_photo_id", "faces", ["photo_id"], unique=False)

--- a/apps/api/alembic/versions/20260506_000001_add_face_dismissal_columns.py
+++ b/apps/api/alembic/versions/20260506_000001_add_face_dismissal_columns.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260506_000001"
+down_revision = "20260321_000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("faces") as batch_op:
+        batch_op.add_column(sa.Column("dismissed_ts", sa.TIMESTAMP(timezone=True), nullable=True))
+        batch_op.add_column(sa.Column("dismissal_provenance", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("faces") as batch_op:
+        batch_op.drop_column("dismissal_provenance")
+        batch_op.drop_column("dismissed_ts")

--- a/apps/api/tests/test_migrations.py
+++ b/apps/api/tests/test_migrations.py
@@ -188,6 +188,44 @@ def test_upgrade_database_enforces_faces_person_fk_constraint(tmp_path):
             )
 
 
+def test_upgrade_database_adds_face_dismissal_columns_to_existing_schema(tmp_path):
+    from app.migrations import upgrade_database
+
+    database_url = f"sqlite:///{tmp_path / 'face-dismissal-upgrade.db'}"
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.exec_driver_sql(
+            """
+            CREATE TABLE faces (
+                face_id VARCHAR(36) PRIMARY KEY,
+                photo_id VARCHAR(36) NOT NULL,
+                person_id VARCHAR(36),
+                bbox_x INTEGER,
+                bbox_y INTEGER,
+                bbox_w INTEGER,
+                bbox_h INTEGER,
+                bitmap BLOB,
+                embedding JSON,
+                detector_name VARCHAR,
+                detector_version VARCHAR,
+                provenance JSON,
+                created_ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        connection.exec_driver_sql("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
+        connection.exec_driver_sql(
+            "INSERT INTO alembic_version (version_num) VALUES ('20260321_000001')"
+        )
+
+    upgrade_database(database_url)
+
+    with engine.connect() as connection:
+        columns = {column["name"] for column in inspect(connection).get_columns("faces")}
+
+    assert {"dismissed_ts", "dismissal_provenance"} <= columns
+
+
 def test_upgrade_database_creates_ingest_queue_table(tmp_path):
     from app.migrations import upgrade_database
 

--- a/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
+++ b/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
@@ -3,6 +3,11 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { SuggestionsRoutePage } from "./SuggestionsRoutePage";
 
+type MockReply = {
+  body: unknown;
+  status?: number;
+};
+
 function renderPage() {
   return render(
     <MemoryRouter initialEntries={["/suggestions"]}>
@@ -11,68 +16,164 @@ function renderPage() {
   );
 }
 
+function reply(body: unknown, status = 200): MockReply {
+  return { body, status };
+}
+
+function buildPeoplePayload() {
+  return [
+    {
+      person_id: "person-1",
+      display_name: "Alex",
+      created_ts: "2026-03-28T19:30:00Z",
+      updated_ts: "2026-03-28T19:30:00Z"
+    },
+    {
+      person_id: "person-2",
+      display_name: "Blair",
+      created_ts: "2026-03-28T19:31:00Z",
+      updated_ts: "2026-03-28T19:31:00Z"
+    },
+    {
+      person_id: "person-3",
+      display_name: "Casey",
+      created_ts: "2026-03-28T19:32:00Z",
+      updated_ts: "2026-03-28T19:32:00Z"
+    }
+  ];
+}
+
+function buildSuggestionsPayload({
+  page = 1,
+  totalItems,
+  totalPages = 1,
+  items
+}: {
+  page?: number;
+  totalItems?: number;
+  totalPages?: number;
+  items: Array<{
+    photo_id: string;
+    path: string;
+    thumbnail: {
+      mime_type: string;
+      width: number;
+      height: number;
+      data_base64: string;
+    } | null;
+    faces: Array<{
+      face_id: string;
+      bbox_x?: number;
+      bbox_y?: number;
+      bbox_w?: number;
+      bbox_h?: number;
+      top_suggestion: {
+        person_id: string;
+        display_name: string;
+        confidence: number;
+      };
+    }>;
+  }>;
+}) {
+  return {
+    page: {
+      page,
+      page_size: 24,
+      total_items: totalItems ?? items.length,
+      total_pages: totalPages
+    },
+    items
+  };
+}
+
+function installFetchRoutes(
+  fetchMock: ReturnType<typeof vi.fn>,
+  routes: Record<string, MockReply | MockReply[]>
+) {
+  const normalizedRoutes = new Map<string, MockReply[]>(
+    Object.entries(routes).map(([key, value]) => [key, Array.isArray(value) ? [...value] : [value]])
+  );
+
+  fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const method = (init?.method ?? "GET").toUpperCase();
+    const url = typeof input === "string" ? input : input.toString();
+    const routeKey = `${method} ${url}`;
+    const replies = normalizedRoutes.get(routeKey);
+    if (!replies || replies.length === 0) {
+      throw new Error(`Unexpected fetch request: ${routeKey}`);
+    }
+    const currentReply = replies.length > 1 ? replies.shift() : replies[0];
+    const status = currentReply?.status ?? 200;
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => currentReply?.body
+    } as Response;
+  });
+}
+
 describe("SuggestionsRoutePage", () => {
   const fetchMock = vi.fn();
 
   beforeEach(() => {
     fetchMock.mockReset();
     vi.stubGlobal("fetch", fetchMock);
+    window.localStorage.clear();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    window.localStorage.clear();
   });
 
   it("renders a paginated list of photos with unassigned face top suggestions", async () => {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        page: {
-          page: 1,
-          page_size: 24,
-          total_items: 2,
-          total_pages: 2
-        },
-        items: [
-          {
-            photo_id: "photo-1",
-            path: "/storage-sources/source-1/family/trip/photo-1.jpg",
-            thumbnail: {
-              mime_type: "image/jpeg",
-              width: 64,
-              height: 48,
-              data_base64: "ZmFrZS10aHVtYi1ieXRlcw=="
-            },
-            faces: [
-              {
-                face_id: "face-1",
-                bbox_x: 10,
-                bbox_y: 20,
-                bbox_w: 30,
-                bbox_h: 40,
-                top_suggestion: {
-                  person_id: "person-1",
-                  display_name: "Alex",
-                  confidence: 0.97
-                }
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": reply(
+        buildSuggestionsPayload({
+          totalItems: 2,
+          totalPages: 2,
+          items: [
+            {
+              photo_id: "photo-1",
+              path: "/storage-sources/source-1/family/trip/photo-1.jpg",
+              thumbnail: {
+                mime_type: "image/jpeg",
+                width: 64,
+                height: 48,
+                data_base64: "ZmFrZS10aHVtYi1ieXRlcw=="
               },
-              {
-                face_id: "face-2",
-                bbox_x: 12,
-                bbox_y: 22,
-                bbox_w: 32,
-                bbox_h: 42,
-                top_suggestion: {
-                  person_id: "person-2",
-                  display_name: "Blair",
-                  confidence: 0.82
+              faces: [
+                {
+                  face_id: "face-1",
+                  bbox_x: 10,
+                  bbox_y: 20,
+                  bbox_w: 30,
+                  bbox_h: 40,
+                  top_suggestion: {
+                    person_id: "person-1",
+                    display_name: "Alex",
+                    confidence: 0.97
+                  }
+                },
+                {
+                  face_id: "face-2",
+                  bbox_x: 12,
+                  bbox_y: 22,
+                  bbox_w: 32,
+                  bbox_h: 42,
+                  top_suggestion: {
+                    person_id: "person-2",
+                    display_name: "Blair",
+                    confidence: 0.82
+                  }
                 }
-              }
-            ]
-          }
-        ]
-      })
-    } as Response);
+              ]
+            }
+          ]
+        })
+      )
+    });
 
     renderPage();
 
@@ -107,68 +208,57 @@ describe("SuggestionsRoutePage", () => {
   it("allows unmarking faces and only confirms checked face IDs", async () => {
     const user = userEvent.setup();
 
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          page: {
-            page: 1,
-            page_size: 24,
-            total_items: 1,
-            total_pages: 1
-          },
-          items: [
-            {
-              photo_id: "photo-1",
-              path: "/photos/photo-1.jpg",
-              thumbnail: null,
-              faces: [
-                {
-                  face_id: "face-1",
-                  top_suggestion: {
-                    person_id: "person-1",
-                    display_name: "Alex",
-                    confidence: 0.97
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": [
+        reply(
+          buildSuggestionsPayload({
+            items: [
+              {
+                photo_id: "photo-1",
+                path: "/photos/photo-1.jpg",
+                thumbnail: null,
+                faces: [
+                  {
+                    face_id: "face-1",
+                    top_suggestion: {
+                      person_id: "person-1",
+                      display_name: "Alex",
+                      confidence: 0.97
+                    }
+                  },
+                  {
+                    face_id: "face-2",
+                    top_suggestion: {
+                      person_id: "person-2",
+                      display_name: "Blair",
+                      confidence: 0.82
+                    }
                   }
-                },
-                {
-                  face_id: "face-2",
-                  top_suggestion: {
-                    person_id: "person-2",
-                    display_name: "Blair",
-                    confidence: 0.82
-                  }
-                }
-              ]
-            }
-          ]
-        })
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          assigned: [
-            {
-              face_id: "face-1",
-              photo_id: "photo-1",
-              person_id: "person-1"
-            }
-          ],
-          skipped: []
-        })
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          page: {
-            page: 1,
-            page_size: 24,
-            total_items: 0,
-            total_pages: 0
-          },
-          items: []
-        })
-      } as Response);
+                ]
+              }
+            ]
+          })
+        ),
+        reply(
+          buildSuggestionsPayload({
+            totalItems: 0,
+            totalPages: 0,
+            items: []
+          })
+        )
+      ],
+      "POST /api/v1/suggestions/confirmations": reply({
+        assigned: [
+          {
+            face_id: "face-1",
+            photo_id: "photo-1",
+            person_id: "person-1"
+          }
+        ],
+        skipped: []
+      })
+    });
 
     renderPage();
 
@@ -200,16 +290,12 @@ describe("SuggestionsRoutePage", () => {
   it("navigates between pages", async () => {
     const user = userEvent.setup();
 
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          page: {
-            page: 1,
-            page_size: 24,
-            total_items: 2,
-            total_pages: 2
-          },
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": reply(
+        buildSuggestionsPayload({
+          totalItems: 2,
+          totalPages: 2,
           items: [
             {
               photo_id: "photo-1",
@@ -228,16 +314,12 @@ describe("SuggestionsRoutePage", () => {
             }
           ]
         })
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          page: {
-            page: 2,
-            page_size: 24,
-            total_items: 2,
-            total_pages: 2
-          },
+      ),
+      "GET /api/v1/suggestions/faces?page=2&page_size=24": reply(
+        buildSuggestionsPayload({
+          page: 2,
+          totalItems: 2,
+          totalPages: 2,
           items: [
             {
               photo_id: "photo-2",
@@ -256,7 +338,8 @@ describe("SuggestionsRoutePage", () => {
             }
           ]
         })
-      } as Response);
+      )
+    });
 
     renderPage();
 
@@ -264,22 +347,18 @@ describe("SuggestionsRoutePage", () => {
     await user.click(screen.getByRole("button", { name: "Page 2" }));
 
     expect(await screen.findByText("/photos/photo-2.jpg")).toBeInTheDocument();
-    expect(fetchMock).toHaveBeenLastCalledWith("/api/v1/suggestions/faces?page=2&page_size=24");
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/suggestions/faces?page=2&page_size=24");
   });
 
   it("confirms only checked face assignments from the current page", async () => {
     const user = userEvent.setup();
 
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          page: {
-            page: 1,
-            page_size: 24,
-            total_items: 2,
-            total_pages: 2
-          },
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": reply(
+        buildSuggestionsPayload({
+          totalItems: 2,
+          totalPages: 2,
           items: [
             {
               photo_id: "photo-1",
@@ -298,60 +377,52 @@ describe("SuggestionsRoutePage", () => {
             }
           ]
         })
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          page: {
+      ),
+      "GET /api/v1/suggestions/faces?page=2&page_size=24": [
+        reply(
+          buildSuggestionsPayload({
             page: 2,
-            page_size: 24,
-            total_items: 2,
-            total_pages: 2
-          },
-          items: [
-            {
-              photo_id: "photo-2",
-              path: "/photos/photo-2.jpg",
-              thumbnail: null,
-              faces: [
-                {
-                  face_id: "face-2",
-                  top_suggestion: {
-                    person_id: "person-2",
-                    display_name: "Blair",
-                    confidence: 0.88
+            totalItems: 2,
+            totalPages: 2,
+            items: [
+              {
+                photo_id: "photo-2",
+                path: "/photos/photo-2.jpg",
+                thumbnail: null,
+                faces: [
+                  {
+                    face_id: "face-2",
+                    top_suggestion: {
+                      person_id: "person-2",
+                      display_name: "Blair",
+                      confidence: 0.88
+                    }
                   }
-                }
-              ]
-            }
-          ]
-        })
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          assigned: [
-            {
-              face_id: "face-2",
-              photo_id: "photo-2",
-              person_id: "person-2"
-            }
-          ],
-          skipped: []
-        })
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          page: {
+                ]
+              }
+            ]
+          })
+        ),
+        reply(
+          buildSuggestionsPayload({
             page: 2,
-            page_size: 24,
-            total_items: 0,
-            total_pages: 0
-          },
-          items: []
-        })
-      } as Response);
+            totalItems: 0,
+            totalPages: 0,
+            items: []
+          })
+        )
+      ],
+      "POST /api/v1/suggestions/confirmations": reply({
+        assigned: [
+          {
+            face_id: "face-2",
+            photo_id: "photo-2",
+            person_id: "person-2"
+          }
+        ],
+        skipped: []
+      })
+    });
 
     renderPage();
     expect(await screen.findByText("/photos/photo-1.jpg")).toBeInTheDocument();
@@ -372,18 +443,16 @@ describe("SuggestionsRoutePage", () => {
   });
 
   it("normalizes empty pagination to one disabled page control", async () => {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        page: {
-          page: 1,
-          page_size: 24,
-          total_items: 0,
-          total_pages: 0
-        },
-        items: []
-      })
-    } as Response);
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": reply(
+        buildSuggestionsPayload({
+          totalItems: 0,
+          totalPages: 0,
+          items: []
+        })
+      )
+    });
 
     renderPage();
 
@@ -398,16 +467,11 @@ describe("SuggestionsRoutePage", () => {
   });
 
   it("applies minimum certainty slider as a global suggestions filter", async () => {
-    fetchMock
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          page: {
-            page: 1,
-            page_size: 24,
-            total_items: 2,
-            total_pages: 1
-          },
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": reply(
+        buildSuggestionsPayload({
+          totalItems: 2,
           items: [
             {
               photo_id: "photo-1",
@@ -426,16 +490,10 @@ describe("SuggestionsRoutePage", () => {
             }
           ]
         })
-      } as Response)
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          page: {
-            page: 1,
-            page_size: 24,
-            total_items: 1,
-            total_pages: 1
-          },
+      ),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24&min_confidence=0.9": reply(
+        buildSuggestionsPayload({
+          totalItems: 1,
           items: [
             {
               photo_id: "photo-2",
@@ -454,7 +512,8 @@ describe("SuggestionsRoutePage", () => {
             }
           ]
         })
-      } as Response);
+      )
+    });
 
     renderPage();
     expect(await screen.findByText("/photos/photo-1.jpg")).toBeInTheDocument();
@@ -463,8 +522,259 @@ describe("SuggestionsRoutePage", () => {
     fireEvent.change(thresholdSlider, { target: { value: "90" } });
 
     expect(await screen.findByText("/photos/photo-2.jpg")).toBeInTheDocument();
-    expect(fetchMock).toHaveBeenLastCalledWith(
+    expect(fetchMock).toHaveBeenCalledWith(
       "/api/v1/suggestions/faces?page=1&page_size=24&min_confidence=0.9"
     );
+  });
+
+  it("restores persisted minimum certainty and excluded people from local storage", async () => {
+    window.localStorage.setItem(
+      "photo-org:suggestions:filters",
+      JSON.stringify({
+        minConfidencePercent: 90,
+        excludedPersonIds: ["person-2"]
+      })
+    );
+
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24&min_confidence=0.9": reply(
+        buildSuggestionsPayload({
+          items: [
+            {
+              photo_id: "photo-1",
+              path: "/photos/photo-1.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-1",
+                  top_suggestion: {
+                    person_id: "person-1",
+                    display_name: "Alex",
+                    confidence: 0.97
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      )
+    });
+
+    renderPage();
+
+    expect(await screen.findByDisplayValue("90")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Exclude Blair" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+
+  it("falls back to defaults when persisted filter state is invalid", async () => {
+    window.localStorage.setItem("photo-org:suggestions:filters", "{bad json");
+
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": reply(
+        buildSuggestionsPayload({
+          items: [
+            {
+              photo_id: "photo-1",
+              path: "/photos/photo-1.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-1",
+                  top_suggestion: {
+                    person_id: "person-1",
+                    display_name: "Alex",
+                    confidence: 0.97
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      )
+    });
+
+    renderPage();
+
+    expect(await screen.findByDisplayValue("0")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Exclude Alex" })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+  });
+
+  it("hides excluded faces, persists filter changes, and omits photos with no visible faces", async () => {
+    const user = userEvent.setup();
+
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": reply(
+        buildSuggestionsPayload({
+          totalItems: 2,
+          items: [
+            {
+              photo_id: "photo-1",
+              path: "/photos/photo-1.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-1",
+                  top_suggestion: {
+                    person_id: "person-1",
+                    display_name: "Alex",
+                    confidence: 0.97
+                  }
+                },
+                {
+                  face_id: "face-2",
+                  top_suggestion: {
+                    person_id: "person-2",
+                    display_name: "Blair",
+                    confidence: 0.82
+                  }
+                }
+              ]
+            },
+            {
+              photo_id: "photo-2",
+              path: "/photos/photo-2.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-3",
+                  top_suggestion: {
+                    person_id: "person-2",
+                    display_name: "Blair",
+                    confidence: 0.87
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      )
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("Face 2: Blair (82.0%)")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Exclude Blair" }));
+
+    expect(screen.queryByText("Face 2: Blair (82.0%)")).not.toBeInTheDocument();
+    expect(screen.queryByText("/photos/photo-2.jpg")).not.toBeInTheDocument();
+    expect(screen.getByText("Pending photos: 1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Exclude Blair" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    expect(window.localStorage.getItem("photo-org:suggestions:filters")).toContain("person-2");
+  });
+
+  it("confirms only currently visible face ids after exclusions are applied", async () => {
+    const user = userEvent.setup();
+
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": [
+        reply(
+          buildSuggestionsPayload({
+            totalItems: 2,
+            items: [
+              {
+                photo_id: "photo-1",
+                path: "/photos/photo-1.jpg",
+                thumbnail: null,
+                faces: [
+                  {
+                    face_id: "face-1",
+                    top_suggestion: {
+                      person_id: "person-1",
+                      display_name: "Alex",
+                      confidence: 0.97
+                    }
+                  },
+                  {
+                    face_id: "face-2",
+                    top_suggestion: {
+                      person_id: "person-2",
+                      display_name: "Blair",
+                      confidence: 0.82
+                    }
+                  }
+                ]
+              },
+              {
+                photo_id: "photo-2",
+                path: "/photos/photo-2.jpg",
+                thumbnail: null,
+                faces: [
+                  {
+                    face_id: "face-3",
+                    top_suggestion: {
+                      person_id: "person-2",
+                      display_name: "Blair",
+                      confidence: 0.87
+                    }
+                  }
+                ]
+              }
+            ]
+          })
+        ),
+        reply(
+          buildSuggestionsPayload({
+            totalItems: 1,
+            items: [
+              {
+                photo_id: "photo-1",
+                path: "/photos/photo-1.jpg",
+                thumbnail: null,
+                faces: [
+                  {
+                    face_id: "face-1",
+                    top_suggestion: {
+                      person_id: "person-1",
+                      display_name: "Alex",
+                      confidence: 0.97
+                    }
+                  }
+                ]
+              }
+            ]
+          })
+        )
+      ],
+      "POST /api/v1/suggestions/confirmations": reply({
+        assigned: [
+          {
+            face_id: "face-1",
+            photo_id: "photo-1",
+            person_id: "person-1"
+          }
+        ],
+        skipped: []
+      })
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("Face 2: Blair (82.0%)")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Exclude Blair" }));
+    await user.click(screen.getByRole("button", { name: "Confirm faces" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/v1/suggestions/confirmations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Face-Validation-Role": "contributor"
+        },
+        body: JSON.stringify({ face_ids: ["face-1"] })
+      });
+    });
   });
 });

--- a/apps/ui/src/pages/SuggestionsRoutePage.tsx
+++ b/apps/ui/src/pages/SuggestionsRoutePage.tsx
@@ -1,7 +1,11 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import ReactPaginate from "react-paginate";
 import { Link } from "react-router-dom";
 import { FaceBBoxOverlay, buildFaceOverlayRegions } from "./FaceBBoxOverlay";
+import {
+  loadSuggestionsFilterState,
+  saveSuggestionsFilterState
+} from "./suggestions/suggestionsRouteMemory";
 
 const PAGE_SIZE = 24;
 
@@ -58,6 +62,11 @@ type SuggestionConfirmPayload = {
   }>;
 };
 
+type PersonRecord = {
+  person_id: string;
+  display_name: string;
+};
+
 function formatConfidence(confidence: number): string {
   if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
     return "0.0%";
@@ -108,6 +117,14 @@ async function fetchSuggestionsPage(
   return (await response.json()) as SuggestionListPayload;
 }
 
+async function fetchPeopleDirectory(): Promise<PersonRecord[]> {
+  const response = await fetch("/api/v1/people");
+  if (!response.ok) {
+    throw new Error(`People request failed (${response.status})`);
+  }
+  return (await response.json()) as PersonRecord[];
+}
+
 async function confirmSuggestions(faceIds: string[]): Promise<SuggestionConfirmPayload> {
   const response = await fetch("/api/v1/suggestions/confirmations", {
     method: "POST",
@@ -124,8 +141,15 @@ async function confirmSuggestions(faceIds: string[]): Promise<SuggestionConfirmP
 }
 
 export function SuggestionsRoutePage() {
+  const initialStoredFiltersRef = useRef(loadSuggestionsFilterState());
   const [page, setPage] = useState(1);
-  const [minConfidencePercent, setMinConfidencePercent] = useState(0);
+  const [minConfidencePercent, setMinConfidencePercent] = useState(
+    initialStoredFiltersRef.current?.minConfidencePercent ?? 0
+  );
+  const [excludedPersonIds, setExcludedPersonIds] = useState<string[]>(
+    initialStoredFiltersRef.current?.excludedPersonIds ?? []
+  );
+  const [peopleDirectory, setPeopleDirectory] = useState<PersonRecord[]>([]);
   const [payload, setPayload] = useState<SuggestionListPayload | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isConfirming, setIsConfirming] = useState(false);
@@ -134,6 +158,7 @@ export function SuggestionsRoutePage() {
   const [selectedFaceIds, setSelectedFaceIds] = useState<Set<string>>(new Set());
 
   const minConfidenceThreshold = minConfidencePercent / 100;
+  const excludedPersonIdSet = useMemo(() => new Set(excludedPersonIds), [excludedPersonIds]);
 
   async function load(targetPage: number) {
     setIsLoading(true);
@@ -153,20 +178,64 @@ export function SuggestionsRoutePage() {
     void load(page);
   }, [page, minConfidenceThreshold]);
 
-  const currentPageFaceIdsOrdered = useMemo(() => {
-    if (!payload) {
-      return [] as string[];
+  useEffect(() => {
+    let isCanceled = false;
+
+    async function loadPeople() {
+      try {
+        const people = await fetchPeopleDirectory();
+        if (!isCanceled) {
+          setPeopleDirectory(people);
+        }
+      } catch {
+        if (!isCanceled) {
+          setPeopleDirectory([]);
+        }
+      }
     }
-    return flattenFaceIds(payload.items);
-  }, [payload]);
+
+    void loadPeople();
+
+    return () => {
+      isCanceled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    saveSuggestionsFilterState({
+      minConfidencePercent,
+      excludedPersonIds
+    });
+  }, [excludedPersonIds, minConfidencePercent]);
+
+  const visibleItems = useMemo(() => {
+    if (!payload) {
+      return [] as SuggestionPhoto[];
+    }
+    return payload.items
+      .map((photo) => ({
+        ...photo,
+        faces: photo.faces.filter((face) => !excludedPersonIdSet.has(face.top_suggestion.person_id))
+      }))
+      .filter((photo) => photo.faces.length > 0);
+  }, [excludedPersonIdSet, payload]);
+
+  const currentPageFaceIdsOrdered = useMemo(() => {
+    return flattenFaceIds(visibleItems);
+  }, [visibleItems]);
 
   const selectedFaceIdsOrdered = useMemo(() => {
     const selected = selectedFaceIds;
     return currentPageFaceIdsOrdered.filter((faceId) => selected.has(faceId));
   }, [currentPageFaceIdsOrdered, selectedFaceIds]);
 
+  const excludedPeople = useMemo(
+    () => peopleDirectory.filter((person) => excludedPersonIdSet.has(person.person_id)),
+    [excludedPersonIdSet, peopleDirectory]
+  );
+
   const totalPages = payload?.page.total_pages ?? 0;
-  const totalItems = payload?.page.total_items ?? 0;
+  const totalItems = visibleItems.length;
   const normalizedTotalPages = Number.isInteger(totalPages) && totalPages > 0 ? totalPages : 1;
   const normalizedRequestedPage = Number.isInteger(page) && page > 0 ? page : 1;
   const clampedRequestedPage = Math.min(normalizedRequestedPage, normalizedTotalPages);
@@ -198,6 +267,16 @@ export function SuggestionsRoutePage() {
     }
   }
 
+  function toggleExcludedPerson(personId: string) {
+    setExcludedPersonIds((current) => {
+      if (current.includes(personId)) {
+        return current.filter((entry) => entry !== personId);
+      }
+      return [...current, personId];
+    });
+    setPage(1);
+  }
+
   return (
     <section className="page suggestions-page" aria-labelledby="suggestions-title">
       <div className="suggestions-header">
@@ -207,24 +286,69 @@ export function SuggestionsRoutePage() {
           <p>{`Pending photos: ${totalItems}`}</p>
         </div>
         <div className="suggestions-header-actions">
-          <label className="suggestions-confidence-filter">
-            <span>{`Minimum certainty: ${minConfidencePercent}%`}</span>
-            <input
-              type="range"
-              min={0}
-              max={100}
-              step={1}
-              value={minConfidencePercent}
-              aria-label="Minimum suggestion certainty"
-              onChange={(event) => {
-                setMinConfidencePercent(Number(event.currentTarget.value));
-                setPage(1);
-              }}
-              disabled={isLoading || isConfirming}
-            />
-          </label>
+          <div className="suggestions-filter-group">
+            <label className="suggestions-confidence-filter">
+              <span>{`Minimum certainty: ${minConfidencePercent}%`}</span>
+              <input
+                type="range"
+                min={0}
+                max={100}
+                step={1}
+                value={minConfidencePercent}
+                aria-label="Minimum suggestion certainty"
+                onChange={(event) => {
+                  setMinConfidencePercent(Number(event.currentTarget.value));
+                  setPage(1);
+                }}
+                disabled={isLoading || isConfirming}
+              />
+            </label>
+            {peopleDirectory.length > 0 ? (
+              <div className="suggestions-people-filter">
+                <p className="suggestions-filter-label">Exclude people</p>
+                <ul className="search-chip-list suggestions-active-filters" aria-label="Excluded people filters">
+                  {peopleDirectory.map((person) => {
+                    const excluded = excludedPersonIdSet.has(person.person_id);
+                    return (
+                      <li key={person.person_id}>
+                        <button
+                          type="button"
+                          className={excluded ? "search-chip search-chip-active" : "search-chip"}
+                          aria-pressed={excluded}
+                          aria-label={`Exclude ${person.display_name}`}
+                          onClick={() => toggleExcludedPerson(person.person_id)}
+                          disabled={isLoading || isConfirming}
+                        >
+                          {person.display_name}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+                {excludedPeople.length > 0 ? (
+                  <ul className="search-chip-list suggestions-active-filters" aria-label="Active excluded people">
+                    {excludedPeople.map((person) => (
+                      <li key={person.person_id}>
+                        <button
+                          type="button"
+                          className="search-chip search-chip-active"
+                          aria-label={`Remove excluded person ${person.display_name}`}
+                          onClick={() => toggleExcludedPerson(person.person_id)}
+                          disabled={isLoading || isConfirming}
+                        >
+                          {`excluded: ${person.display_name}`}
+                          <span aria-hidden="true"> ×</span>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
           <button
             type="button"
+            className="suggestions-confirm-button"
             onClick={() => {
               void handleConfirmFaces();
             }}
@@ -251,13 +375,13 @@ export function SuggestionsRoutePage() {
       ) : null}
       {message ? <p>{message}</p> : null}
 
-      {!isLoading && !error && payload && payload.items.length === 0 ? (
+      {!isLoading && !error && payload && visibleItems.length === 0 ? (
         <p className="suggestions-empty">No pending suggestions.</p>
       ) : null}
 
       {!isLoading && !error && payload ? (
         <ol className="suggestions-grid" aria-label="Suggestion photo list">
-          {payload.items.map((photo) => {
+          {visibleItems.map((photo) => {
             const numberedFaces = photo.faces.map((face, index) => ({
               ...face,
               faceNumber: index + 1

--- a/apps/ui/src/pages/suggestions/suggestionsRouteMemory.ts
+++ b/apps/ui/src/pages/suggestions/suggestionsRouteMemory.ts
@@ -1,0 +1,82 @@
+const SUGGESTIONS_FILTERS_KEY = "photo-org:suggestions:filters";
+
+export interface StoredSuggestionsFilterState {
+  minConfidencePercent: number;
+  excludedPersonIds: string[];
+}
+
+function resolveLocalStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isValidMinConfidencePercent(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 100;
+}
+
+function sanitizeExcludedPersonIds(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const normalized = value
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  return normalized.length === value.length ? normalized : null;
+}
+
+export function loadSuggestionsFilterState(): StoredSuggestionsFilterState | null {
+  const storage = resolveLocalStorage();
+  if (!storage) {
+    return null;
+  }
+
+  const rawValue = storage.getItem(SUGGESTIONS_FILTERS_KEY);
+  if (!rawValue) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue) as {
+      minConfidencePercent?: unknown;
+      excludedPersonIds?: unknown;
+    };
+
+    if (!isValidMinConfidencePercent(parsed.minConfidencePercent)) {
+      return null;
+    }
+
+    const excludedPersonIds = sanitizeExcludedPersonIds(parsed.excludedPersonIds);
+    if (!excludedPersonIds) {
+      return null;
+    }
+
+    return {
+      minConfidencePercent: parsed.minConfidencePercent,
+      excludedPersonIds
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function saveSuggestionsFilterState(state: StoredSuggestionsFilterState): void {
+  const storage = resolveLocalStorage();
+  if (!storage) {
+    return;
+  }
+
+  storage.setItem(
+    SUGGESTIONS_FILTERS_KEY,
+    JSON.stringify({
+      minConfidencePercent: state.minConfidencePercent,
+      excludedPersonIds: state.excludedPersonIds
+    })
+  );
+}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -22,7 +22,14 @@
   color: #334155;
 }
 
-.suggestions-header-actions button {
+.suggestions-header-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.suggestions-confirm-button {
   border: 1px solid #bfdbfe;
   background: #eff6ff;
   color: #1d4ed8;
@@ -43,7 +50,28 @@
   width: 100%;
 }
 
-.suggestions-header-actions button:disabled {
+.suggestions-filter-group {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.suggestions-people-filter {
+  display: grid;
+  gap: 0.45rem;
+  max-width: 28rem;
+}
+
+.suggestions-filter-label {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #334155;
+}
+
+.suggestions-active-filters {
+  align-items: flex-start;
+}
+
+.suggestions-confirm-button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }

--- a/docs/superpowers/plans/2026-05-06-suggestions-exclude-filter.md
+++ b/docs/superpowers/plans/2026-05-06-suggestions-exclude-filter.md
@@ -1,0 +1,273 @@
+# Suggestions Exclude Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add persisted Suggestions page filters for minimum certainty and excluded people, and suppress visible suggestions whose top match is excluded.
+
+**Architecture:** Keep the API contract unchanged and implement filtering entirely in the UI route. Add a small Suggestions-specific `localStorage` helper, load the people directory once for badge toggles, derive the visible payload from the fetched suggestions payload plus local filter state, and keep confirmation scoped to the visible checked face ids.
+
+**Tech Stack:** React, TypeScript, React Testing Library, Vitest, existing app-shell CSS
+
+---
+
+### Task 1: Persisted Suggestions Filter State
+
+**Files:**
+- Create: `apps/ui/src/pages/suggestions/suggestionsRouteMemory.ts`
+- Test: `apps/ui/src/pages/SuggestionsRoutePage.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests in `apps/ui/src/pages/SuggestionsRoutePage.test.tsx` that preload `window.localStorage` and assert:
+
+```ts
+window.localStorage.setItem(
+  "photo-org:suggestions:filters",
+  JSON.stringify({ minConfidencePercent: 90, excludedPersonIds: ["person-2"] })
+);
+```
+
+The rendered page should:
+
+```ts
+expect(await screen.findByDisplayValue("90")).toBeInTheDocument();
+expect(screen.getByRole("button", { name: "Exclude Blair" })).toHaveAttribute(
+  "aria-pressed",
+  "true"
+);
+```
+
+Also add an invalid-storage test:
+
+```ts
+window.localStorage.setItem("photo-org:suggestions:filters", "{bad json");
+expect(await screen.findByDisplayValue("0")).toBeInTheDocument();
+expect(screen.getByRole("button", { name: "Exclude Alex" })).toHaveAttribute(
+  "aria-pressed",
+  "false"
+);
+```
+
+- [ ] **Step 2: Run the targeted tests to verify failure**
+
+Run:
+
+```bash
+npm --prefix apps/ui test -- SuggestionsRoutePage
+```
+
+Expected: FAIL because the page does not read persisted filter state or render exclude controls.
+
+- [ ] **Step 3: Write the storage helper**
+
+Create `apps/ui/src/pages/suggestions/suggestionsRouteMemory.ts` with a guarded `localStorage` helper:
+
+```ts
+const SUGGESTIONS_FILTERS_KEY = "photo-org:suggestions:filters";
+
+export interface StoredSuggestionsFilterState {
+  minConfidencePercent: number;
+  excludedPersonIds: string[];
+}
+
+function resolveLocalStorage(): Storage | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+```
+
+Include:
+
+```ts
+export function loadSuggestionsFilterState(): StoredSuggestionsFilterState | null
+export function saveSuggestionsFilterState(state: StoredSuggestionsFilterState): void
+```
+
+Validation rules:
+- `minConfidencePercent` must be an integer between `0` and `100`
+- `excludedPersonIds` must be an array of non-empty strings
+- invalid payloads return `null`
+
+- [ ] **Step 4: Run the targeted tests to verify progress**
+
+Run:
+
+```bash
+npm --prefix apps/ui test -- SuggestionsRoutePage
+```
+
+Expected: still FAIL because the route page is not using the new helper yet.
+
+### Task 2: Exclude People UI And Derived Visible Payload
+
+**Files:**
+- Modify: `apps/ui/src/pages/SuggestionsRoutePage.tsx`
+- Modify: `apps/ui/src/styles/app-shell.css`
+- Test: `apps/ui/src/pages/SuggestionsRoutePage.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend `apps/ui/src/pages/SuggestionsRoutePage.test.tsx` with:
+
+```ts
+expect(await screen.findByRole("button", { name: "Exclude Alex" })).toBeInTheDocument();
+await user.click(screen.getByRole("button", { name: "Exclude Blair" }));
+expect(screen.queryByText("Face 2: Blair (82.0%)")).not.toBeInTheDocument();
+expect(window.localStorage.getItem("photo-org:suggestions:filters")).toContain("person-2");
+```
+
+Add a whole-photo suppression case:
+
+```ts
+expect(screen.queryByText("/photos/photo-2.jpg")).not.toBeInTheDocument();
+expect(screen.getByText("Pending photos: 1")).toBeInTheDocument();
+```
+
+Add slider persistence coverage:
+
+```ts
+fireEvent.change(screen.getByLabelText("Minimum suggestion certainty"), {
+  target: { value: "90" }
+});
+expect(window.localStorage.getItem("photo-org:suggestions:filters")).toContain(
+  "\"minConfidencePercent\":90"
+);
+```
+
+- [ ] **Step 2: Run the targeted tests to verify failure**
+
+Run:
+
+```bash
+npm --prefix apps/ui test -- SuggestionsRoutePage
+```
+
+Expected: FAIL because the route has no people-directory fetch, no exclude badges, and no derived visible filtering.
+
+- [ ] **Step 3: Write the minimal route implementation**
+
+In `apps/ui/src/pages/SuggestionsRoutePage.tsx`:
+
+- add a `PersonRecord` type with `person_id` and `display_name`
+- add `fetchPeopleDirectory()` calling `/api/v1/people`
+- initialize `minConfidencePercent` and `excludedPersonIds` from `loadSuggestionsFilterState()`
+- keep the fetched suggestions payload as raw state, then derive visible photos with:
+
+```ts
+const visibleItems = useMemo(() => {
+  if (!payload) {
+    return [] as SuggestionPhoto[];
+  }
+  return payload.items
+    .map((photo) => ({
+      ...photo,
+      faces: photo.faces.filter(
+        (face) => !excludedPersonIds.has(face.top_suggestion.person_id)
+      )
+    }))
+    .filter((photo) => photo.faces.length > 0);
+}, [payload, excludedPersonIds]);
+```
+
+- derive `currentPageFaceIdsOrdered` from `visibleItems`
+- save filter state whenever `minConfidencePercent` or `excludedPersonIds` changes
+- fetch the people directory once in `useEffect`
+- toggle exclusions by `person_id`, reset page to `1` when exclusions change
+- render toggle badges:
+
+```tsx
+<button
+  type="button"
+  className={excluded ? "search-chip search-chip-active" : "search-chip"}
+  aria-pressed={excluded}
+  aria-label={`Exclude ${person.display_name}`}
+>
+  {person.display_name}
+</button>
+```
+
+- render active removable chips using excluded people whose directory entries are known
+- show `Pending photos` from `visibleItems.length`
+
+- [ ] **Step 4: Add minimal supporting styles**
+
+In `apps/ui/src/styles/app-shell.css`, add compact layout styles for:
+- `.suggestions-header-actions`
+- `.suggestions-filter-group`
+- `.suggestions-people-filter`
+- `.suggestions-active-filters`
+
+Reuse the existing `.search-chip` styling rather than inventing a new badge component.
+
+- [ ] **Step 5: Run the targeted tests to verify they pass**
+
+Run:
+
+```bash
+npm --prefix apps/ui test -- SuggestionsRoutePage
+```
+
+Expected: PASS for the Suggestions route test file.
+
+### Task 3: Confirmation Scope And Final Verification
+
+**Files:**
+- Modify: `apps/ui/src/pages/SuggestionsRoutePage.test.tsx`
+- Modify: `apps/ui/src/pages/SuggestionsRoutePage.tsx` (only if needed)
+
+- [ ] **Step 1: Write the failing confirmation-scope test**
+
+Add a test that excludes one person, confirms the remaining faces, and asserts:
+
+```ts
+await waitFor(() => {
+  expect(fetchMock).toHaveBeenCalledWith("/api/v1/suggestions/confirmations", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Face-Validation-Role": "contributor"
+    },
+    body: JSON.stringify({ face_ids: ["face-1"] })
+  });
+});
+```
+
+Where the raw payload also included a hidden excluded face such as `face-2`.
+
+- [ ] **Step 2: Run the targeted tests to verify failure if behavior is still wrong**
+
+Run:
+
+```bash
+npm --prefix apps/ui test -- SuggestionsRoutePage
+```
+
+Expected: either PASS immediately because visible-face scoping is already correct, or FAIL with excluded hidden face ids still being submitted.
+
+- [ ] **Step 3: Adjust the confirmation path only if the test fails**
+
+Ensure confirmation uses the derived visible face ordering:
+
+```ts
+const checkedFaceIdsOnCurrentPage = currentPageFaceIdsOrdered.filter((faceId) =>
+  selectedFaceIds.has(faceId)
+);
+```
+
+No raw payload face ids should be used for confirmation after filtering.
+
+- [ ] **Step 4: Run final verification**
+
+Run:
+
+```bash
+npm --prefix apps/ui test -- SuggestionsRoutePage
+```
+
+Expected: PASS with `0` failures for the targeted Suggestions route tests.

--- a/docs/superpowers/specs/2026-05-06-suggestions-exclude-filter-design.md
+++ b/docs/superpowers/specs/2026-05-06-suggestions-exclude-filter-design.md
@@ -1,0 +1,104 @@
+# Suggestions Exclude Filter Design
+
+Date: 2026-05-06
+Scope: Suggestions page exclude-people filter and persisted client-side filter state
+
+## Summary
+
+Add an exclude-people filter to the Suggestions page so reviewers can suppress faces whose current top suggestion matches selected people. Persist both the exclude-people selection and the existing `Minimum certainty` slider in `localStorage` so these preferences survive route changes, reloads, and leaving and returning to the site.
+
+## Goals
+
+- let users exclude one or more people from the suggestions review flow
+- hide faces when their highest-confidence suggestion belongs to an excluded person
+- hide photo cards that have no remaining visible faces after exclusion
+- persist the exclude-people filter in `localStorage`
+- persist the `Minimum certainty` slider value in `localStorage`
+- keep confirmation behavior aligned with the visible filtered set only
+
+## Non-Goals
+
+- changing the suggestions API contract
+- adding server-side support for exclude filters
+- changing suggestion ranking or confidence calculation
+- persisting per-face checkbox selections across reloads
+
+## Decision Snapshot
+
+- people source: existing `/api/v1/people` directory
+- exclude state identity: `person_id`
+- exclude state presentation: badge-style toggle controls plus active removable chips
+- filter execution: client-side after suggestions payload load
+- confidence persistence: `localStorage`
+- malformed stored data handling: ignore and fall back to defaults
+
+## UX Behavior
+
+The Suggestions header keeps the `Minimum certainty` slider and adds an `Exclude people` control populated from the people directory. Each person renders as a toggleable badge. Selecting a badge excludes that person; selecting it again removes the exclusion.
+
+Active exclusions also render as removable chips so the current filter state remains obvious even when the people directory is long. The page continues to default visible faces to checked for confirmation.
+
+## Filtering Rules
+
+- fetch suggestions from the existing endpoint using the current minimum-confidence threshold
+- after payload load, remove any face whose `top_suggestion.person_id` is in the excluded set
+- if a photo has zero faces left after exclusion, omit that photo from the rendered grid
+- `Pending photos` should reflect the visible filtered payload, not the raw API total, so the page summary matches what the user can act on
+- confirmation requests must include only currently visible and currently checked face ids
+
+## Persistence Model
+
+Store both values in `window.localStorage` under Suggestions-specific keys:
+
+- excluded people: array of `person_id` strings
+- minimum certainty: integer percent from `0` to `100`
+
+On initial render:
+
+- load both values from `localStorage`
+- validate shape and bounds
+- fall back to an empty excluded set and `0` percent if data is missing or invalid
+
+On user changes:
+
+- update React state immediately
+- write the normalized value back to `localStorage`
+
+## Implementation Notes
+
+- keep a small Suggestions-specific storage helper near the route page, similar in style to the existing library route memory helper
+- fetch the people directory once on page load and tolerate failure by rendering no people badges rather than blocking the suggestions workflow
+- maintain filtering in derived UI state rather than mutating raw API payloads in place
+- preserve the existing page reset behavior when the minimum-confidence slider changes
+- also reset to page `1` when the exclude-people filter changes so pagination stays predictable
+
+## Testing Strategy
+
+Add or extend route tests to cover:
+
+- restoring the persisted minimum-confidence slider value from `localStorage`
+- restoring persisted excluded people from `localStorage`
+- excluding a person hides matching faces from the rendered list
+- excluding a person hides photo cards with no remaining visible faces
+- toggling an exclusion updates persisted state
+- confirmation submits only visible checked face ids after filtering
+- invalid stored values fall back safely to defaults
+
+## Verification Commands
+
+Run from `apps/ui`:
+
+1. `npm run test -- SuggestionsRoutePage`
+
+## Risks And Mitigations
+
+- risk: visible item counts diverge from API totals
+  - mitigation: compute displayed counts from filtered payload and keep the copy scoped to what the user can act on
+- risk: stale excluded `person_id`s remain in storage after people directory changes
+  - mitigation: keep stored ids harmless; they simply stop matching if no suggestion references them
+- risk: localStorage access throws in restricted environments
+  - mitigation: guard storage access and fall back to in-memory defaults
+
+## Open Questions
+
+- none for this slice


### PR DESCRIPTION
## Summary
- add a persisted Suggestions page filter state helper backed by localStorage
- add exclude-people badges and hide faces or photo cards when the top suggestion is excluded
- expand Suggestions route tests to cover persisted filters, exclude behavior, and confirmation scoping

## Test Plan
- [x] npm --prefix apps/ui test -- SuggestionsRoutePage
- [x] npm --prefix apps/ui run build