### PR TITLE
Improve face suggestion review workflow and server-side exclusion filtering

### DIFF
--- a/apps/api/app/routers/face_assignments.py
+++ b/apps/api/app/routers/face_assignments.py
@@ -15,6 +15,7 @@ from app.services.face_assignment import (
     FaceNotAssignedError,
     FaceNotFoundError,
     PersonNotFoundError,
+    assign_face_to_unknown_person,
     confirm_face_assignment,
     dismiss_false_positive_face,
     record_review_needed_face_suggestion,
@@ -100,6 +101,18 @@ class FaceDismissalResponse(BaseModel):
     face_id: str
     photo_id: str
     dismissed_ts: str
+
+
+class FaceUnknownIdentityResponse(BaseModel):
+    """Assignment result for an acknowledged human face with unknown identity."""
+
+    model_config = ConfigDict(
+        json_schema_extra={"description": "Resolved assignment to the system unknown-person identity."}
+    )
+
+    face_id: str
+    photo_id: str
+    person_id: str
 
 
 class FaceCandidateResponse(BaseModel):
@@ -293,6 +306,38 @@ def dismiss_face_endpoint(
 
     db.commit()
     return FaceDismissalResponse.model_validate(dismissal)
+
+
+@router.post(
+    "/{face_id}/unknown-identities",
+    summary="Mark face as human with unknown name",
+    description="Assign an unlabeled detected face to the system unknown-person identity.",
+    response_model=FaceUnknownIdentityResponse,
+    responses={
+        status.HTTP_403_FORBIDDEN: {"description": "Face validation role required"},
+        status.HTTP_404_NOT_FOUND: {"description": "Face not found"},
+        status.HTTP_409_CONFLICT: {"description": "Face already assigned or already dismissed"},
+    },
+)
+def assign_face_to_unknown_identity_endpoint(
+    face_id: str,
+    db: Session = Depends(get_db),
+    _: str = Depends(require_face_validation_role),
+) -> FaceUnknownIdentityResponse:
+    try:
+        assignment = assign_face_to_unknown_person(
+            db.connection(),
+            face_id=face_id,
+        )
+    except FaceNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    except FaceAlreadyAssignedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except FaceAlreadyDismissedError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+    db.commit()
+    return FaceUnknownIdentityResponse.model_validate(assignment)
 
 
 @router.get(

--- a/apps/api/app/routers/suggestions.py
+++ b/apps/api/app/routers/suggestions.py
@@ -27,6 +27,7 @@ class TopFaceSuggestionResponse(BaseModel):
     person_id: str
     display_name: str
     confidence: float
+    rank: int | None = None
 
 
 class SuggestedUnassignedFaceResponse(BaseModel):
@@ -38,6 +39,7 @@ class SuggestedUnassignedFaceResponse(BaseModel):
     bbox_space_width: int | None = None
     bbox_space_height: int | None = None
     top_suggestion: TopFaceSuggestionResponse
+    suggestions: list[TopFaceSuggestionResponse] = Field(default_factory=list)
 
 
 class SuggestionReviewPhotoResponse(BaseModel):
@@ -59,6 +61,11 @@ class SuggestionReviewListResponse(BaseModel):
     items: list[SuggestionReviewPhotoResponse]
 
 
+class SuggestionSelectedAssignmentRequest(BaseModel):
+    face_id: str
+    person_id: str
+
+
 class SuggestionConfirmFacesRequest(BaseModel):
     model_config = ConfigDict(
         json_schema_extra={
@@ -67,6 +74,7 @@ class SuggestionConfirmFacesRequest(BaseModel):
     )
 
     face_ids: list[str] = Field(default_factory=list, max_length=500)
+    assignments: list[SuggestionSelectedAssignmentRequest] = Field(default_factory=list, max_length=500)
 
 
 class SuggestedFaceAssignmentResponse(BaseModel):
@@ -95,6 +103,7 @@ def list_suggestion_review_faces_endpoint(
     page: Annotated[int, Query(ge=1)] = 1,
     page_size: Annotated[int, Query(ge=1, le=100)] = 24,
     min_confidence: Annotated[float, Query(ge=0, le=1)] = 0,
+    excluded_person_ids: Annotated[list[str] | None, Query()] = None,
     db: Session = Depends(get_db),
 ) -> SuggestionReviewListResponse:
     result = list_unassigned_face_suggestion_photos(
@@ -102,6 +111,7 @@ def list_suggestion_review_faces_endpoint(
         page=page,
         page_size=page_size,
         min_confidence=min_confidence,
+        excluded_person_ids=excluded_person_ids,
     )
     return SuggestionReviewListResponse.model_validate(result)
 
@@ -124,6 +134,10 @@ def confirm_suggestion_faces_endpoint(
     result = confirm_top_face_suggestions(
         db.connection(),
         face_ids=body.face_ids,
+        selected_assignments=[
+            {"face_id": assignment.face_id, "person_id": assignment.person_id}
+            for assignment in body.assignments
+        ],
     )
     db.commit()
     return SuggestionConfirmFacesResponse.model_validate(result)

--- a/apps/api/app/services/face_assignment.py
+++ b/apps/api/app/services/face_assignment.py
@@ -13,6 +13,7 @@ from photoorg_db_schema import (
 )
 
 from app.db.queue import IngestQueueStore
+from app.services.people import get_or_create_unknown_person
 from app.services.recognition_policy import resolve_prediction_metadata
 from app.storage import face_labels, face_suggestions, faces, people
 
@@ -43,6 +44,30 @@ class FaceAlreadyAssignedToPersonError(RuntimeError):
 
 class FaceAssignedToDifferentPersonError(RuntimeError):
     pass
+
+
+def assign_face_to_unknown_person(
+    connection: Connection,
+    *,
+    face_id: str,
+) -> dict[str, str]:
+    row = _face_row(connection, face_id)
+    if row is None:
+        raise FaceNotFoundError("Face not found")
+    if row["person_id"] is not None:
+        raise FaceAlreadyAssignedError("Face already assigned")
+    if row["dismissed_ts"] is not None:
+        raise FaceAlreadyDismissedError("Face already dismissed")
+
+    unknown_person = get_or_create_unknown_person(
+        connection,
+        now=datetime.now(UTC),
+    )
+    return assign_face_to_person(
+        connection,
+        face_id=face_id,
+        person_id=str(unknown_person["person_id"]),
+    )
 
 
 def assign_face_to_person(

--- a/apps/api/app/services/face_candidates.py
+++ b/apps/api/app/services/face_candidates.py
@@ -11,6 +11,7 @@ from app.services.recognition_policy import (
     distance_to_confidence,
     resolve_suggestion_thresholds,
 )
+from app.services.people import UNKNOWN_PERSON_DISPLAY_NAME
 from app.storage import faces, people
 
 
@@ -125,6 +126,7 @@ def _lookup_candidates_postgresql(
             faces.c.face_id != face_id,
             faces.c.person_id.is_not(None),
             faces.c.embedding.is_not(None),
+            people.c.display_name != UNKNOWN_PERSON_DISPLAY_NAME,
         )
         .subquery()
     )
@@ -174,6 +176,7 @@ def _lookup_candidates_python(
                 faces.c.face_id != face_id,
                 faces.c.person_id.is_not(None),
                 faces.c.embedding.is_not(None),
+                people.c.display_name != UNKNOWN_PERSON_DISPLAY_NAME,
             )
         )
         .mappings()

--- a/apps/api/app/services/face_suggestion_review.py
+++ b/apps/api/app/services/face_suggestion_review.py
@@ -11,7 +11,7 @@ from app.services.face_assignment import (
     PersonNotFoundError,
     assign_face_to_person,
 )
-from app.services.face_candidates import lookup_nearest_neighbor_candidates
+from app.services.people import UNKNOWN_PERSON_DISPLAY_NAME
 from app.storage import face_suggestions, faces, people, photo_exif_attributes, photos
 
 
@@ -19,31 +19,39 @@ SUGGESTION_SKIP_FACE_NOT_FOUND = "face_not_found"
 SUGGESTION_SKIP_ALREADY_ASSIGNED = "already_assigned"
 SUGGESTION_SKIP_NO_TOP_SUGGESTION = "no_top_suggestion"
 SUGGESTION_SKIP_SUGGESTED_PERSON_NOT_FOUND = "suggested_person_not_found"
+SUGGESTION_SKIP_SELECTED_PERSON_NOT_SUGGESTED = "selected_person_not_suggested"
 
 
-def _top_suggestion_subquery():
-    ranked = (
-        select(
-            face_suggestions.c.face_id.label("face_id"),
-            face_suggestions.c.person_id.label("person_id"),
-            face_suggestions.c.confidence.label("confidence"),
-            func.row_number()
-            .over(
-                partition_by=face_suggestions.c.face_id,
-                order_by=(
-                    face_suggestions.c.rank.asc(),
-                    face_suggestions.c.confidence.desc(),
-                    face_suggestions.c.person_id.asc(),
-                ),
-            )
-            .label("suggestion_rank"),
+def _top_suggestion_subquery(*, excluded_person_ids: set[str]):
+    ranked = select(
+        face_suggestions.c.face_id.label("face_id"),
+        face_suggestions.c.person_id.label("person_id"),
+        people.c.display_name.label("display_name"),
+        face_suggestions.c.confidence.label("confidence"),
+        func.row_number()
+        .over(
+            partition_by=face_suggestions.c.face_id,
+            order_by=(
+                face_suggestions.c.rank.asc(),
+                face_suggestions.c.confidence.desc(),
+                face_suggestions.c.person_id.asc(),
+            ),
         )
-        .subquery()
-    )
+        .label("suggestion_rank"),
+    ).select_from(
+        face_suggestions.join(
+            people,
+            face_suggestions.c.person_id == people.c.person_id,
+        )
+    ).where(people.c.display_name != UNKNOWN_PERSON_DISPLAY_NAME)
+    if excluded_person_ids:
+        ranked = ranked.where(~face_suggestions.c.person_id.in_(sorted(excluded_person_ids)))
+    ranked = ranked.subquery()
     return (
         select(
             ranked.c.face_id,
             ranked.c.person_id,
+            ranked.c.display_name,
             ranked.c.confidence,
         )
         .where(ranked.c.suggestion_rank == 1)
@@ -123,48 +131,23 @@ def _load_photo_dimension_map(
     }
 
 
-def _load_live_top_candidate_for_face(
-    connection: Connection,
-    *,
-    face_id: str,
-) -> dict[str, object] | None:
-    result = lookup_nearest_neighbor_candidates(
-        connection,
-        face_id=face_id,
-        limit=1,
-        enforce_min_confidence=False,
-    )
-    candidates = result.get("candidates")
-    if not isinstance(candidates, list) or not candidates:
-        return None
-    top = candidates[0]
-    person_id = top.get("person_id")
-    display_name = top.get("display_name")
-    confidence = top.get("confidence")
-    if not isinstance(person_id, str) or not person_id:
-        return None
-    if not isinstance(display_name, str) or not display_name:
-        return None
-    try:
-        confidence_value = float(confidence)
-    except (TypeError, ValueError):
-        return None
-    return {
-        "person_id": person_id,
-        "display_name": display_name,
-        "confidence": min(1.0, max(0.0, confidence_value)),
-    }
-
-
 def list_unassigned_face_suggestion_photos(
     connection: Connection,
     *,
     page: int,
     page_size: int,
     min_confidence: float = 0.0,
+    excluded_person_ids: list[str] | None = None,
 ) -> dict[str, object]:
     normalized_min_confidence = min(1.0, max(0.0, float(min_confidence)))
-    top_suggestion = _top_suggestion_subquery()
+    normalized_excluded_person_ids = {
+        person_id.strip()
+        for person_id in (excluded_person_ids or [])
+        if isinstance(person_id, str) and person_id.strip()
+    }
+    top_suggestion = _top_suggestion_subquery(
+        excluded_person_ids=normalized_excluded_person_ids,
+    )
     eligible_photo_ids = (
         select(faces.c.photo_id)
         .select_from(
@@ -236,12 +219,10 @@ def list_unassigned_face_suggestion_photos(
                 faces.c.provenance,
                 top_suggestion.c.person_id.label("suggested_person_id"),
                 top_suggestion.c.confidence.label("suggested_confidence"),
-                people.c.display_name.label("suggested_display_name"),
+                top_suggestion.c.display_name.label("suggested_display_name"),
             )
             .select_from(
-                faces.join(top_suggestion, top_suggestion.c.face_id == faces.c.face_id).join(
-                    people, people.c.person_id == top_suggestion.c.person_id
-                )
+                faces.join(top_suggestion, top_suggestion.c.face_id == faces.c.face_id)
             )
             .where(
                 faces.c.photo_id.in_(photo_ids),
@@ -258,6 +239,50 @@ def list_unassigned_face_suggestion_photos(
         .all()
     )
     photo_dimension_map = _load_photo_dimension_map(connection, photo_ids=photo_ids)
+    face_ids = [str(row["face_id"]) for row in face_rows]
+    suggestion_rows = (
+        connection.execute(
+            select(
+                face_suggestions.c.face_id,
+                face_suggestions.c.person_id,
+                people.c.display_name,
+                face_suggestions.c.rank,
+                face_suggestions.c.confidence,
+            )
+            .select_from(
+                face_suggestions.join(
+                    people,
+                    face_suggestions.c.person_id == people.c.person_id,
+                )
+            )
+            .where(
+                face_suggestions.c.face_id.in_(face_ids),
+                people.c.display_name != UNKNOWN_PERSON_DISPLAY_NAME,
+            )
+            .order_by(
+                face_suggestions.c.face_id.asc(),
+                face_suggestions.c.rank.asc(),
+                face_suggestions.c.confidence.desc(),
+                face_suggestions.c.person_id.asc(),
+            )
+        )
+        .mappings()
+        .all()
+    )
+    suggestions_by_face_id: dict[str, list[dict[str, object]]] = {}
+    for row in suggestion_rows:
+        person_id = str(row["person_id"])
+        if person_id in normalized_excluded_person_ids:
+            continue
+        face_id = str(row["face_id"])
+        suggestions_by_face_id.setdefault(face_id, []).append(
+            {
+                "person_id": person_id,
+                "display_name": str(row["display_name"]),
+                "confidence": float(row["confidence"]),
+                "rank": int(row["rank"]),
+            }
+        )
 
     face_map: dict[str, list[dict[str, object]]] = {photo_id: [] for photo_id in photo_ids}
     for row in face_rows:
@@ -267,20 +292,19 @@ def list_unassigned_face_suggestion_photos(
             fallback_width, fallback_height = photo_dimension_map.get(photo_id, (None, None))
             bbox_space_width = bbox_space_width or fallback_width
             bbox_space_height = bbox_space_height or fallback_height
-        top_suggestion_payload = {
-            "person_id": str(row["suggested_person_id"]),
-            "display_name": str(row["suggested_display_name"]),
-            "confidence": float(row["suggested_confidence"]),
-        }
-        live_top_candidate = _load_live_top_candidate_for_face(
-            connection,
-            face_id=str(row["face_id"]),
-        )
-        if live_top_candidate is not None:
-            top_suggestion_payload = live_top_candidate
+        face_id = str(row["face_id"])
+        suggestions = suggestions_by_face_id.get(face_id, [])
+        if not suggestions:
+            top_suggestion_payload = {
+                "person_id": str(row["suggested_person_id"]),
+                "display_name": str(row["suggested_display_name"]),
+                "confidence": float(row["suggested_confidence"]),
+            }
+            suggestions = [top_suggestion_payload]
+        top_suggestion_payload = suggestions[0]
         face_map.setdefault(photo_id, []).append(
             {
-                "face_id": str(row["face_id"]),
+                "face_id": face_id,
                 "bbox_x": row["bbox_x"],
                 "bbox_y": row["bbox_y"],
                 "bbox_w": row["bbox_w"],
@@ -288,6 +312,7 @@ def list_unassigned_face_suggestion_photos(
                 "bbox_space_width": bbox_space_width,
                 "bbox_space_height": bbox_space_height,
                 "top_suggestion": top_suggestion_payload,
+                "suggestions": suggestions,
             }
         )
 
@@ -336,12 +361,31 @@ def confirm_top_face_suggestions(
     connection: Connection,
     *,
     face_ids: list[str],
+    selected_assignments: list[dict[str, str]] | None = None,
 ) -> dict[str, object]:
     assigned: list[dict[str, str]] = []
     skipped: list[dict[str, str]] = []
 
+    explicit_assignments: dict[str, str] = {}
+    for assignment in selected_assignments or []:
+        raw_face_id = assignment.get("face_id")
+        raw_person_id = assignment.get("person_id")
+        if not isinstance(raw_face_id, str) or not raw_face_id.strip():
+            continue
+        if not isinstance(raw_person_id, str) or not raw_person_id.strip():
+            continue
+        explicit_assignments[raw_face_id.strip()] = raw_person_id.strip()
+
     seen: set[str] = set()
-    unique_face_ids = [face_id for face_id in face_ids if face_id and not (face_id in seen or seen.add(face_id))]
+    unique_face_ids: list[str] = []
+    for face_id in list(explicit_assignments.keys()) + face_ids:
+        if not isinstance(face_id, str):
+            continue
+        normalized_face_id = face_id.strip()
+        if not normalized_face_id or normalized_face_id in seen:
+            continue
+        seen.add(normalized_face_id)
+        unique_face_ids.append(normalized_face_id)
 
     for face_id in unique_face_ids:
         face_row = (
@@ -363,25 +407,45 @@ def confirm_top_face_suggestions(
             skipped.append({"face_id": face_id, "reason": SUGGESTION_SKIP_ALREADY_ASSIGNED})
             continue
 
-        top_suggestion_row = (
+        suggestion_rows = (
             connection.execute(
                 select(face_suggestions.c.person_id)
+                .select_from(
+                    face_suggestions.join(
+                        people,
+                        face_suggestions.c.person_id == people.c.person_id,
+                    )
+                )
                 .where(face_suggestions.c.face_id == face_id)
+                .where(people.c.display_name != UNKNOWN_PERSON_DISPLAY_NAME)
                 .order_by(
                     face_suggestions.c.rank.asc(),
                     face_suggestions.c.confidence.desc(),
                     face_suggestions.c.person_id.asc(),
                 )
-                .limit(1)
             )
             .mappings()
-            .first()
+            .all()
         )
-        if top_suggestion_row is None:
+        if not suggestion_rows:
             skipped.append({"face_id": face_id, "reason": SUGGESTION_SKIP_NO_TOP_SUGGESTION})
             continue
 
-        suggested_person_id = str(top_suggestion_row["person_id"])
+        suggested_person_ids = [str(row["person_id"]) for row in suggestion_rows]
+        selected_person_id = explicit_assignments.get(face_id)
+        if selected_person_id is None:
+            suggested_person_id = suggested_person_ids[0]
+        elif selected_person_id not in suggested_person_ids:
+            skipped.append(
+                {
+                    "face_id": face_id,
+                    "reason": SUGGESTION_SKIP_SELECTED_PERSON_NOT_SUGGESTED,
+                }
+            )
+            continue
+        else:
+            suggested_person_id = selected_person_id
+
         try:
             assignment = assign_face_to_person(
                 connection,

--- a/apps/api/app/services/people.py
+++ b/apps/api/app/services/people.py
@@ -10,6 +10,8 @@ from sqlalchemy.exc import IntegrityError
 
 from app.storage import face_labels, faces, people
 
+UNKNOWN_PERSON_DISPLAY_NAME = "Unknown person"
+
 
 class PersonNotFoundError(LookupError):
     pass
@@ -105,6 +107,27 @@ def delete_person(connection: Connection, person_id: str) -> None:
     if person is None:
         raise PersonNotFoundError("Person not found")
     raise PersonInUseError("Person is referenced by face or label data")
+
+
+def get_or_create_unknown_person(
+    connection: Connection,
+    *,
+    now: datetime,
+) -> dict[str, object]:
+    existing = (
+        connection.execute(
+            select(people).where(people.c.display_name == UNKNOWN_PERSON_DISPLAY_NAME)
+        )
+        .mappings()
+        .first()
+    )
+    if existing is not None:
+        return _person_from_row(existing)
+    return create_person(
+        connection,
+        display_name=UNKNOWN_PERSON_DISPLAY_NAME,
+        now=now,
+    )
 
 
 def _normalize_utc_datetime(value: datetime) -> datetime:

--- a/apps/api/tests/test_face_assignment_api.py
+++ b/apps/api/tests/test_face_assignment_api.py
@@ -320,6 +320,43 @@ def test_face_dismissal_api_rejects_already_dismissed_face(tmp_path, monkeypatch
     assert response.json() == {"detail": "Face already dismissed"}
 
 
+def test_face_unknown_identity_api_assigns_face_to_system_unknown_person(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-unknown-identity.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+
+    client = _authorized_client()
+    response = client.post("/api/v1/faces/face-1/unknown-identities")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["face_id"] == "face-1"
+    assert payload["photo_id"] == "photo-1"
+    assert isinstance(payload["person_id"], str) and payload["person_id"]
+
+    with engine.connect() as connection:
+        assigned_person_id = connection.execute(
+            select(faces.c.person_id).where(faces.c.face_id == "face-1")
+        ).scalar_one_or_none()
+        unknown_person_name = connection.execute(
+            select(people.c.display_name).where(people.c.person_id == payload["person_id"])
+        ).scalar_one_or_none()
+    assert assigned_person_id == payload["person_id"]
+    assert unknown_person_name == "Unknown person"
+
+
 def test_face_assignment_api_rejects_unrecognized_face_validation_role(tmp_path, monkeypatch):
     database_url = _database_url(tmp_path, "face-assign-wrong-role.db")
     upgrade_database(database_url)

--- a/apps/api/tests/test_face_suggestion_review_api.py
+++ b/apps/api/tests/test_face_suggestion_review_api.py
@@ -186,6 +186,13 @@ def test_face_suggestion_review_list_returns_paginated_unassigned_faces_with_top
         "person_id": "person-1",
         "display_name": "Alex",
         "confidence": 0.97,
+        "rank": 1,
+    }
+    assert payload["items"][0]["faces"][0]["suggestions"][0] == {
+        "person_id": "person-1",
+        "display_name": "Alex",
+        "confidence": 0.97,
+        "rank": 1,
     }
     assert payload["items"][0]["faces"][0]["bbox_space_width"] == 4000
     assert payload["items"][0]["faces"][0]["bbox_space_height"] == 3000
@@ -213,6 +220,27 @@ def test_face_suggestion_review_list_returns_paginated_unassigned_faces_with_top
     assert len(filtered_payload["items"]) == 1
     assert filtered_payload["items"][0]["photo_id"] == "photo-1"
     assert [face["face_id"] for face in filtered_payload["items"][0]["faces"]] == ["face-1"]
+
+    response_excluded = client.get(
+        "/api/v1/suggestions/faces",
+        params={
+            "page": 1,
+            "page_size": 24,
+            "excluded_person_ids": ["person-2"],
+        },
+    )
+    assert response_excluded.status_code == 200
+    excluded_payload = response_excluded.json()
+    assert excluded_payload["page"] == {
+        "page": 1,
+        "page_size": 24,
+        "total_items": 2,
+        "total_pages": 1,
+    }
+    assert excluded_payload["items"][0]["photo_id"] == "photo-1"
+    assert [face["face_id"] for face in excluded_payload["items"][0]["faces"]] == ["face-1"]
+    assert excluded_payload["items"][1]["photo_id"] == "photo-2"
+    assert [face["face_id"] for face in excluded_payload["items"][1]["faces"]] == ["face-3"]
 
 
 def test_face_suggestion_review_list_omits_dismissed_faces(tmp_path, monkeypatch):
@@ -364,6 +392,81 @@ def test_face_suggestion_review_confirmation_assigns_selected_faces_to_top_sugge
 
     assert person_face_1 == "person-1"
     assert person_face_2 is None
+
+
+def test_face_suggestion_review_confirmation_assigns_selected_dropdown_person(
+    tmp_path,
+    monkeypatch,
+):
+    client = _authorized_client(tmp_path, monkeypatch, "face-suggestion-review-confirm-selected.db")
+
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'face-suggestion-review-confirm-selected.db'}", future=True
+    )
+    with engine.begin() as connection:
+        _insert_person(connection, person_id="person-1", display_name="Alex")
+        _insert_person(connection, person_id="person-2", display_name="Blair")
+        _insert_photo(
+            connection,
+            photo_id="photo-1",
+            path="/photos/1.jpg",
+            shot_ts=datetime(2026, 5, 5, 11, 0, tzinfo=UTC),
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+        connection.execute(
+            insert(face_suggestions),
+            [
+                {
+                    "face_suggestion_id": "s1",
+                    "face_id": "face-1",
+                    "person_id": "person-1",
+                    "rank": 1,
+                    "confidence": 0.93,
+                    "centroid_distance": 0.07,
+                    "knn_distance": 0.07,
+                    "representation_version": 2,
+                    "scoring_version": "hybrid-v1",
+                    "model_version": "recognition-v1",
+                },
+                {
+                    "face_suggestion_id": "s2",
+                    "face_id": "face-1",
+                    "person_id": "person-2",
+                    "rank": 2,
+                    "confidence": 0.89,
+                    "centroid_distance": 0.11,
+                    "knn_distance": 0.11,
+                    "representation_version": 2,
+                    "scoring_version": "hybrid-v1",
+                    "model_version": "recognition-v1",
+                },
+            ],
+        )
+
+    response = client.post(
+        "/api/v1/suggestions/confirmations",
+        json={
+            "face_ids": ["face-1"],
+            "assignments": [{"face_id": "face-1", "person_id": "person-2"}],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["assigned"] == [
+        {
+            "face_id": "face-1",
+            "photo_id": "photo-1",
+            "person_id": "person-2",
+        }
+    ]
+    assert payload["skipped"] == []
 
 
 def test_face_suggestion_review_confirmation_requires_face_validation_role(tmp_path, monkeypatch):

--- a/apps/ui/src/pages/FaceAssignmentControls.test.tsx
+++ b/apps/ui/src/pages/FaceAssignmentControls.test.tsx
@@ -60,6 +60,38 @@ describe("FaceAssignmentControls", () => {
     expect(screen.getByLabelText("Assign face 2")).toBeInTheDocument();
   });
 
+  it("supports assigning an unlabeled face as unknown human identity", async () => {
+    const user = userEvent.setup();
+    const onAssigned = vi.fn();
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ face_id: "face-1", photo_id: "photo-1", person_id: "unknown-person" })
+    } as Response);
+
+    render(
+      <FaceAssignmentControls
+        faces={[{ face_id: "face-1", person_id: null }]}
+        people={[{ person_id: "person-1", display_name: "Inez" }]}
+        onAssigned={onAssigned}
+        onCorrected={onCorrected}
+      />
+    );
+
+    await user.selectOptions(screen.getByLabelText("Assign face 1"), "__unknown_person__");
+
+    await waitFor(() => {
+      expect(onAssigned).toHaveBeenCalledWith("face-1", "unknown-person");
+    });
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/faces/face-1/unknown-identities", {
+      method: "POST",
+      headers: {
+        "X-Face-Validation-Role": "contributor"
+      }
+    });
+  });
+
   it("shows deterministic inline 403 error", async () => {
     const user = userEvent.setup();
 

--- a/apps/ui/src/pages/FaceAssignmentControls.tsx
+++ b/apps/ui/src/pages/FaceAssignmentControls.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 type FaceLabelSource = "human_confirmed" | "machine_suggested" | null;
 
 const NOT_AVAILABLE = "Not available";
+const UNKNOWN_PERSON_OPTION_VALUE = "__unknown_person__";
 
 export interface FaceAssignmentFace {
   face_id: string;
@@ -70,6 +71,22 @@ function mapCorrectionError(status: number, detail: string | null): string {
   }
 
   return `Correction request failed (${status}).`;
+}
+
+function mapUnknownIdentityError(status: number, detail: string | null): string {
+  if (status === 403) {
+    return "You do not have permission to assign faces.";
+  }
+
+  if (status === 404) {
+    return detail ?? "Face no longer exists.";
+  }
+
+  if (status === 409) {
+    return detail ?? "Face assignment could not be applied.";
+  }
+
+  return `Unknown-identity request failed (${status}).`;
 }
 
 function resolvePersonLabel(people: FaceAssignmentPerson[], personId: string): string {
@@ -205,6 +222,41 @@ export function FaceAssignmentControls({
     }
   }
 
+  async function assignUnknown(faceId: string) {
+    setIsSubmitting(true);
+    setAssignmentError(null);
+    setCorrectionProvenance(null);
+
+    try {
+      const response = await fetch(`/api/v1/faces/${faceId}/unknown-identities`, {
+        method: "POST",
+        headers: {
+          "X-Face-Validation-Role": "contributor"
+        }
+      });
+
+      if (!response.ok) {
+        const detail = await readErrorDetail(response);
+        setAssignmentError(mapUnknownIdentityError(response.status, detail));
+        return;
+      }
+
+      const payload = (await response.json()) as { person_id?: unknown };
+      const personId = typeof payload.person_id === "string" ? payload.person_id : "";
+      if (!personId) {
+        setAssignmentError("Unknown-identity response was missing person information.");
+        return;
+      }
+
+      onAssigned(faceId, personId);
+      setActiveIndex((current) => current + 1);
+    } catch {
+      setAssignmentError("Could not assign face.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
   async function correct(faceId: string, previousPersonId: string, personId: string) {
     setCorrectionFaceIdInFlight(faceId);
     setCorrectionError(null);
@@ -264,12 +316,17 @@ export function FaceAssignmentControls({
                 if (!personId) {
                   return;
                 }
+                if (personId === UNKNOWN_PERSON_OPTION_VALUE) {
+                  void assignUnknown(activeFace.face_id);
+                  return;
+                }
                 void assign(activeFace.face_id, personId);
               }}
             >
               <option value="" disabled>
                 Select person
               </option>
+              <option value={UNKNOWN_PERSON_OPTION_VALUE}>Human face (name unknown)</option>
               {people.map((person) => (
                 <option key={person.person_id} value={person.person_id}>
                   {person.display_name}

--- a/apps/ui/src/pages/FaceBBoxOverlay.tsx
+++ b/apps/ui/src/pages/FaceBBoxOverlay.tsx
@@ -30,6 +30,7 @@ interface FaceBBoxOverlayProps {
   getRegionAriaLabel?: (region: FaceOverlayRegion, index: number) => string;
   renderRegionContent?: (region: FaceOverlayRegion, index: number) => ReactNode;
   onRegionClick?: (region: FaceOverlayRegion, index: number) => void;
+  allowRegionHover?: boolean;
 }
 
 function clamp(value: number, min: number, max: number): number {
@@ -147,7 +148,8 @@ export function FaceBBoxOverlay({
   ariaLabel,
   getRegionAriaLabel = defaultRegionAriaLabel,
   renderRegionContent,
-  onRegionClick
+  onRegionClick,
+  allowRegionHover = false
 }: FaceBBoxOverlayProps) {
   if (regions.length === 0) {
     return null;
@@ -158,7 +160,7 @@ export function FaceBBoxOverlay({
       {regions.map((region, index) => (
         <li
           key={region.faceId}
-          className={`detail-face-overlay${onRegionClick ? " is-interactive" : ""}`}
+          className={`detail-face-overlay${onRegionClick ? " is-interactive" : ""}${allowRegionHover ? " is-hoverable" : ""}`}
           aria-label={getRegionAriaLabel(region, index)}
           role={onRegionClick ? "button" : undefined}
           tabIndex={onRegionClick ? 0 : undefined}

--- a/apps/ui/src/pages/PhotoFaceAssignmentModal.tsx
+++ b/apps/ui/src/pages/PhotoFaceAssignmentModal.tsx
@@ -101,6 +101,19 @@ function mapDismissalError(status: number, detail: string | null): string {
   return `Dismissal request failed (${status}).`;
 }
 
+function mapUnknownIdentityError(status: number, detail: string | null): string {
+  if (status === 403) {
+    return "You do not have permission to assign faces.";
+  }
+  if (status === 404) {
+    return detail ?? "Face no longer exists.";
+  }
+  if (status === 409) {
+    return detail ?? "Face assignment could not be applied.";
+  }
+  return `Unknown-identity request failed (${status}).`;
+}
+
 async function readErrorDetail(response: Response): Promise<string | null> {
   try {
     const payload = (await response.json()) as { detail?: unknown };
@@ -353,6 +366,44 @@ export function PhotoFaceAssignmentModal({
     }
   }
 
+  async function markUnknownHumanIdentity() {
+    if (!face || face.person_id !== null || isSubmitting) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/v1/faces/${face.face_id}/unknown-identities`, {
+        method: "POST",
+        headers: {
+          "X-Face-Validation-Role": "contributor"
+        }
+      });
+
+      if (!response.ok) {
+        const detail = await readErrorDetail(response);
+        setError(mapUnknownIdentityError(response.status, detail));
+        return;
+      }
+
+      const payload = (await response.json()) as { person_id?: unknown };
+      const personId = typeof payload.person_id === "string" ? payload.person_id : "";
+      if (!personId) {
+        setError("Unknown-identity response was missing person information.");
+        return;
+      }
+
+      onFaceUpdated(face.face_id, personId);
+      onClose();
+    } catch {
+      setError("Could not mark face as unknown person.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
   if (!isOpen || !face) {
     return null;
   }
@@ -416,14 +467,24 @@ export function PhotoFaceAssignmentModal({
               </button>
             </div>
             {face.person_id === null ? (
-              <button
-                type="button"
-                className="face-assignment-modal-dismiss"
-                onClick={() => void dismissFalsePositive()}
-                disabled={isBusy}
-              >
-                Discard false positive
-              </button>
+              <div className="face-assignment-modal-unlabeled-actions">
+                <button
+                  type="button"
+                  className="face-assignment-modal-unknown"
+                  onClick={() => void markUnknownHumanIdentity()}
+                  disabled={isBusy}
+                >
+                  Mark human face, name unknown
+                </button>
+                <button
+                  type="button"
+                  className="face-assignment-modal-dismiss"
+                  onClick={() => void dismissFalsePositive()}
+                  disabled={isBusy}
+                >
+                  Discard false positive
+                </button>
+              </div>
             ) : null}
 
             <section className="face-assignment-modal-suggestions" aria-label="Suggested names">

--- a/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
+++ b/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
@@ -72,9 +72,36 @@ function buildSuggestionsPayload({
         display_name: string;
         confidence: number;
       };
+      suggestions?: Array<{
+        person_id: string;
+        display_name: string;
+        confidence: number;
+        rank?: number;
+      }>;
     }>;
   }>;
 }) {
+  const normalizedItems = items.map((photo) => ({
+    ...photo,
+    faces: photo.faces.map((face) => ({
+      ...face,
+      suggestions:
+        "suggestions" in face && Array.isArray((face as { suggestions?: unknown }).suggestions)
+          ? (face as { suggestions: Array<{ person_id: string; display_name: string; confidence: number; rank?: number }> }).suggestions.map(
+              (suggestion, index) => ({
+                ...suggestion,
+                rank: suggestion.rank ?? index + 1
+              })
+            )
+          : [
+              {
+                ...face.top_suggestion,
+                rank: 1
+              }
+            ]
+    }))
+  }));
+
   return {
     page: {
       page,
@@ -82,7 +109,7 @@ function buildSuggestionsPayload({
       total_items: totalItems ?? items.length,
       total_pages: totalPages
     },
-    items
+    items: normalizedItems
   };
 }
 
@@ -189,8 +216,8 @@ describe("SuggestionsRoutePage", () => {
     ).toHaveAttribute("href", "/library/photo-1");
     expect(screen.getByLabelText("Confirm suggestion for face face-1")).toBeChecked();
     expect(screen.getByLabelText("Confirm suggestion for face face-2")).toBeChecked();
-    expect(screen.getByText("Face 1: Alex (97.0%)")).toBeInTheDocument();
-    expect(screen.getByText("Face 2: Blair (82.0%)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Choose suggestion for face face-1")).toHaveDisplayValue("Alex");
+    expect(screen.getByLabelText("Choose suggestion for face face-2")).toHaveDisplayValue("Blair");
     const overlay = screen.getByRole("list", {
       name: "Suggested face regions for /storage-sources/source-1/family/trip/photo-1.jpg"
     });
@@ -280,11 +307,342 @@ describe("SuggestionsRoutePage", () => {
           "Content-Type": "application/json",
           "X-Face-Validation-Role": "contributor"
         },
-        body: JSON.stringify({ face_ids: ["face-1"] })
+        body: JSON.stringify({
+          face_ids: ["face-1"],
+          assignments: [{ face_id: "face-1", person_id: "person-1" }]
+        })
       });
     });
 
     expect(await screen.findByText("Confirmed 1 face suggestion.")).toBeInTheDocument();
+  });
+
+  it("submits the selected dropdown suggestion for a checked face", async () => {
+    const user = userEvent.setup();
+
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": [
+        reply(
+          buildSuggestionsPayload({
+            items: [
+              {
+                photo_id: "photo-1",
+                path: "/photos/photo-1.jpg",
+                thumbnail: null,
+                faces: [
+                  {
+                    face_id: "face-1",
+                    top_suggestion: {
+                      person_id: "person-1",
+                      display_name: "Alex",
+                      confidence: 0.97
+                    },
+                    suggestions: [
+                      { person_id: "person-1", display_name: "Alex", confidence: 0.97, rank: 1 },
+                      { person_id: "person-3", display_name: "Casey", confidence: 0.89, rank: 2 }
+                    ]
+                  }
+                ]
+              }
+            ]
+          })
+        ),
+        reply(
+          buildSuggestionsPayload({
+            totalItems: 0,
+            totalPages: 0,
+            items: []
+          })
+        )
+      ],
+      "POST /api/v1/suggestions/confirmations": reply({
+        assigned: [
+          {
+            face_id: "face-1",
+            photo_id: "photo-1",
+            person_id: "person-3"
+          }
+        ],
+        skipped: []
+      })
+    });
+
+    renderPage();
+
+    const selector = await screen.findByLabelText("Choose suggestion for face face-1");
+    await user.clear(selector);
+    await user.type(selector, "Casey");
+    await user.click(screen.getByRole("button", { name: "Confirm faces" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/v1/suggestions/confirmations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Face-Validation-Role": "contributor"
+        },
+        body: JSON.stringify({
+          face_ids: ["face-1"],
+          assignments: [{ face_id: "face-1", person_id: "person-3" }]
+        })
+      });
+    });
+  });
+
+  it("confirms one face only with a typed unsuggested name", async () => {
+    const user = userEvent.setup();
+
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": [
+        reply(
+          buildSuggestionsPayload({
+            items: [
+              {
+                photo_id: "photo-1",
+                path: "/photos/photo-1.jpg",
+                thumbnail: null,
+                faces: [
+                  {
+                    face_id: "face-1",
+                    top_suggestion: {
+                      person_id: "person-1",
+                      display_name: "Alex",
+                      confidence: 0.97
+                    }
+                  },
+                  {
+                    face_id: "face-2",
+                    top_suggestion: {
+                      person_id: "person-2",
+                      display_name: "Blair",
+                      confidence: 0.88
+                    }
+                  }
+                ]
+              }
+            ]
+          })
+        ),
+        reply(
+          buildSuggestionsPayload({
+            items: [
+              {
+                photo_id: "photo-1",
+                path: "/photos/photo-1.jpg",
+                thumbnail: null,
+                faces: [
+                  {
+                    face_id: "face-2",
+                    top_suggestion: {
+                      person_id: "person-2",
+                      display_name: "Blair",
+                      confidence: 0.88
+                    }
+                  }
+                ]
+              }
+            ]
+          })
+        )
+      ],
+      "POST /api/v1/people": reply({
+        person_id: "person-new",
+        display_name: "Dana New",
+        created_ts: "2026-05-06T12:00:00Z",
+        updated_ts: "2026-05-06T12:00:00Z"
+      }, 201),
+      "POST /api/v1/faces/face-1/assignments": reply({
+        face_id: "face-1",
+        photo_id: "photo-1",
+        person_id: "person-new"
+      }, 201)
+    });
+
+    renderPage();
+
+    const faceChoice = await screen.findByLabelText("Choose suggestion for face face-1");
+    await user.clear(faceChoice);
+    await user.type(faceChoice, "Dana New");
+    await user.click(screen.getAllByRole("button", { name: "Confirm face" })[0]);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/v1/people", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ display_name: "Dana New" })
+      });
+    });
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/v1/faces/face-1/assignments", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Face-Validation-Role": "contributor"
+        },
+        body: JSON.stringify({ person_id: "person-new" })
+      });
+    });
+  });
+
+  it("orders suggested names by likelihood in the face chooser", async () => {
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": reply(
+        buildSuggestionsPayload({
+          items: [
+            {
+              photo_id: "photo-1",
+              path: "/photos/photo-1.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-1",
+                  top_suggestion: {
+                    person_id: "person-1",
+                    display_name: "Alex",
+                    confidence: 0.97
+                  },
+                  suggestions: [
+                    { person_id: "person-2", display_name: "Blair", confidence: 0.76, rank: 2 },
+                    { person_id: "person-1", display_name: "Alex", confidence: 0.97, rank: 1 },
+                    { person_id: "person-3", display_name: "Casey", confidence: 0.81, rank: 3 }
+                  ]
+                }
+              ]
+            }
+          ]
+        })
+      )
+    });
+
+    renderPage();
+
+    const faceChoice = await screen.findByLabelText("Choose suggestion for face face-1");
+    const listId = faceChoice.getAttribute("list");
+    expect(listId).toBeTruthy();
+    const datalist = document.getElementById(listId ?? "");
+    expect(datalist).not.toBeNull();
+    const optionValues = Array.from(datalist?.querySelectorAll("option") ?? []).map(
+      (option) => option.getAttribute("value") ?? ""
+    );
+    expect(optionValues).toEqual(["Alex", "Casey", "Blair"]);
+  });
+
+  it("can mark a face as unknown from the face action button", async () => {
+    const user = userEvent.setup();
+
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": [
+        reply(
+          buildSuggestionsPayload({
+            items: [
+              {
+                photo_id: "photo-1",
+                path: "/photos/photo-1.jpg",
+                thumbnail: null,
+                faces: [
+                  {
+                    face_id: "face-1",
+                    top_suggestion: {
+                      person_id: "person-1",
+                      display_name: "Alex",
+                      confidence: 0.97
+                    }
+                  }
+                ]
+              }
+            ]
+          })
+        ),
+        reply(
+          buildSuggestionsPayload({
+            totalItems: 0,
+            totalPages: 0,
+            items: []
+          })
+        )
+      ],
+      "POST /api/v1/faces/face-1/unknown-identities": reply({
+        face_id: "face-1",
+        photo_id: "photo-1",
+        person_id: "unknown-person"
+      })
+    });
+
+    renderPage();
+
+    await screen.findByLabelText("Choose suggestion for face face-1");
+    await user.click(screen.getByRole("button", { name: "Mark face face-1 as unknown" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/v1/faces/face-1/unknown-identities", {
+        method: "POST",
+        headers: {
+          "X-Face-Validation-Role": "contributor"
+        }
+      });
+    });
+  });
+
+  it("can discard a face as false positive from the face action button", async () => {
+    const user = userEvent.setup();
+
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": [
+        reply(
+          buildSuggestionsPayload({
+            items: [
+              {
+                photo_id: "photo-1",
+                path: "/photos/photo-1.jpg",
+                thumbnail: null,
+                faces: [
+                  {
+                    face_id: "face-1",
+                    top_suggestion: {
+                      person_id: "person-1",
+                      display_name: "Alex",
+                      confidence: 0.97
+                    }
+                  }
+                ]
+              }
+            ]
+          })
+        ),
+        reply(
+          buildSuggestionsPayload({
+            totalItems: 0,
+            totalPages: 0,
+            items: []
+          })
+        )
+      ],
+      "POST /api/v1/faces/face-1/dismissals": reply({
+        face_id: "face-1",
+        photo_id: "photo-1"
+      })
+    });
+
+    renderPage();
+
+    await screen.findByLabelText("Choose suggestion for face face-1");
+    await user.click(screen.getByRole("button", { name: "Discard face face-1 as false positive" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/v1/faces/face-1/dismissals", {
+        method: "POST",
+        headers: {
+          "X-Face-Validation-Role": "contributor"
+        }
+      });
+    });
   });
 
   it("navigates between pages", async () => {
@@ -437,7 +795,10 @@ describe("SuggestionsRoutePage", () => {
           "Content-Type": "application/json",
           "X-Face-Validation-Role": "contributor"
         },
-        body: JSON.stringify({ face_ids: ["face-2"] })
+        body: JSON.stringify({
+          face_ids: ["face-2"],
+          assignments: [{ face_id: "face-2", person_id: "person-2" }]
+        })
       });
     });
   });
@@ -538,7 +899,7 @@ describe("SuggestionsRoutePage", () => {
 
     installFetchRoutes(fetchMock, {
       "GET /api/v1/people": reply(buildPeoplePayload()),
-      "GET /api/v1/suggestions/faces?page=1&page_size=24&min_confidence=0.9": reply(
+      "GET /api/v1/suggestions/faces?page=1&page_size=24&min_confidence=0.9&excluded_person_ids=person-2": reply(
         buildSuggestionsPayload({
           items: [
             {
@@ -564,10 +925,7 @@ describe("SuggestionsRoutePage", () => {
     renderPage();
 
     expect(await screen.findByDisplayValue("90")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Exclude Blair" })).toHaveAttribute(
-      "aria-pressed",
-      "true"
-    );
+    expect(screen.getByRole("button", { name: "Remove excluded person Blair" })).toBeInTheDocument();
   });
 
   it("falls back to defaults when persisted filter state is invalid", async () => {
@@ -601,10 +959,7 @@ describe("SuggestionsRoutePage", () => {
     renderPage();
 
     expect(await screen.findByDisplayValue("0")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Exclude Alex" })).toHaveAttribute(
-      "aria-pressed",
-      "false"
-    );
+    expect(screen.queryByRole("button", { name: /Remove excluded person/i })).not.toBeInTheDocument();
   });
 
   it("hides excluded faces, persists filter changes, and omits photos with no visible faces", async () => {
@@ -656,21 +1011,44 @@ describe("SuggestionsRoutePage", () => {
             }
           ]
         })
+      ),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24&excluded_person_ids=person-2": reply(
+        buildSuggestionsPayload({
+          totalItems: 1,
+          items: [
+            {
+              photo_id: "photo-1",
+              path: "/photos/photo-1.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-1",
+                  top_suggestion: {
+                    person_id: "person-1",
+                    display_name: "Alex",
+                    confidence: 0.97
+                  }
+                }
+              ]
+            }
+          ]
+        })
       )
     });
 
     renderPage();
 
-    expect(await screen.findByText("Face 2: Blair (82.0%)")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Exclude Blair" }));
+    expect(await screen.findByLabelText("Choose suggestion for face face-2")).toHaveDisplayValue("Blair");
+    await user.selectOptions(screen.getByLabelText("Add excluded person"), "person-2");
 
-    expect(screen.queryByText("Face 2: Blair (82.0%)")).not.toBeInTheDocument();
-    expect(screen.queryByText("/photos/photo-2.jpg")).not.toBeInTheDocument();
-    expect(screen.getByText("Pending photos: 1")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Exclude Blair" })).toHaveAttribute(
-      "aria-pressed",
-      "true"
-    );
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/v1/suggestions/faces?page=1&page_size=24&excluded_person_ids=person-2"
+      );
+    });
+    expect(screen.queryByLabelText("Choose suggestion for face face-2")).not.toBeInTheDocument();
+    expect(await screen.findByText("Pending photos: 1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove excluded person Blair" })).toBeInTheDocument();
     expect(window.localStorage.getItem("photo-org:suggestions:filters")).toContain("person-2");
   });
 
@@ -725,6 +1103,8 @@ describe("SuggestionsRoutePage", () => {
             ]
           })
         ),
+      ],
+      "GET /api/v1/suggestions/faces?page=1&page_size=24&excluded_person_ids=person-2": [
         reply(
           buildSuggestionsPayload({
             totalItems: 1,
@@ -746,6 +1126,13 @@ describe("SuggestionsRoutePage", () => {
               }
             ]
           })
+        ),
+        reply(
+          buildSuggestionsPayload({
+            totalItems: 0,
+            totalPages: 0,
+            items: []
+          })
         )
       ],
       "POST /api/v1/suggestions/confirmations": reply({
@@ -762,8 +1149,13 @@ describe("SuggestionsRoutePage", () => {
 
     renderPage();
 
-    expect(await screen.findByText("Face 2: Blair (82.0%)")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Exclude Blair" }));
+    expect(await screen.findByLabelText("Choose suggestion for face face-2")).toHaveDisplayValue("Blair");
+    await user.selectOptions(screen.getByLabelText("Add excluded person"), "person-2");
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/v1/suggestions/faces?page=1&page_size=24&excluded_person_ids=person-2"
+      );
+    });
     await user.click(screen.getByRole("button", { name: "Confirm faces" }));
 
     await waitFor(() => {
@@ -773,7 +1165,10 @@ describe("SuggestionsRoutePage", () => {
           "Content-Type": "application/json",
           "X-Face-Validation-Role": "contributor"
         },
-        body: JSON.stringify({ face_ids: ["face-1"] })
+        body: JSON.stringify({
+          face_ids: ["face-1"],
+          assignments: [{ face_id: "face-1", person_id: "person-1" }]
+        })
       });
     });
   });

--- a/apps/ui/src/pages/SuggestionsRoutePage.tsx
+++ b/apps/ui/src/pages/SuggestionsRoutePage.tsx
@@ -1,143 +1,17 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactPaginate from "react-paginate";
-import { Link } from "react-router-dom";
-import { FaceBBoxOverlay, buildFaceOverlayRegions } from "./FaceBBoxOverlay";
-import {
-  loadSuggestionsFilterState,
-  saveSuggestionsFilterState
-} from "./suggestions/suggestionsRouteMemory";
+
+import { SuggestionsFilters } from "./suggestions/SuggestionsFilters";
+import { SuggestionsGrid } from "./suggestions/SuggestionsGrid";
+import { fetchPeopleDirectory, fetchSuggestionsPage } from "./suggestions/api";
+import { loadSuggestionsFilterState, saveSuggestionsFilterState } from "./suggestions/suggestionsRouteMemory";
+import type { PersonRecord, SuggestionPhoto, SuggestionListPayload } from "./suggestions/types";
+import { useSuggestionsActions } from "./suggestions/useSuggestionsActions";
 
 const PAGE_SIZE = 24;
 
-type SuggestionThumbnail = {
-  mime_type: string;
-  width: number;
-  height: number;
-  data_base64: string;
-};
-
-type TopSuggestion = {
-  person_id: string;
-  display_name: string;
-  confidence: number;
-};
-
-type SuggestedFace = {
-  face_id: string;
-  bbox_x?: number | null;
-  bbox_y?: number | null;
-  bbox_w?: number | null;
-  bbox_h?: number | null;
-  bbox_space_width?: number | null;
-  bbox_space_height?: number | null;
-  top_suggestion: TopSuggestion;
-};
-
-type SuggestionPhoto = {
-  photo_id: string;
-  path: string;
-  thumbnail: SuggestionThumbnail | null;
-  faces: SuggestedFace[];
-};
-
-type SuggestionListPayload = {
-  page: {
-    page: number;
-    page_size: number;
-    total_items: number;
-    total_pages: number;
-  };
-  items: SuggestionPhoto[];
-};
-
-type SuggestionConfirmPayload = {
-  assigned: Array<{
-    face_id: string;
-    photo_id: string;
-    person_id: string;
-  }>;
-  skipped: Array<{
-    face_id: string;
-    reason: string;
-  }>;
-};
-
-type PersonRecord = {
-  person_id: string;
-  display_name: string;
-};
-
-function formatConfidence(confidence: number): string {
-  if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
-    return "0.0%";
-  }
-  return `${(confidence * 100).toFixed(1)}%`;
-}
-
-function formatDisplayPath(path: string): string {
-  const marker = "/storage-sources/";
-  const markerIndex = path.indexOf(marker);
-  if (markerIndex < 0) {
-    return path;
-  }
-
-  const pathAfterMarker = path.slice(markerIndex + marker.length);
-  const firstSlashAfterSourceId = pathAfterMarker.indexOf("/");
-  if (firstSlashAfterSourceId < 0) {
-    return path;
-  }
-
-  const sourceRelativePath = pathAfterMarker.slice(firstSlashAfterSourceId + 1).trim();
-  if (!sourceRelativePath) {
-    return path;
-  }
-
-  return `.../${sourceRelativePath}`;
-}
-
 function flattenFaceIds(items: SuggestionPhoto[]): string[] {
   return items.flatMap((photo) => photo.faces.map((face) => face.face_id));
-}
-
-async function fetchSuggestionsPage(
-  page: number,
-  minConfidenceThreshold: number
-): Promise<SuggestionListPayload> {
-  const params = new URLSearchParams({
-    page: String(page),
-    page_size: String(PAGE_SIZE)
-  });
-  if (minConfidenceThreshold > 0) {
-    params.set("min_confidence", String(minConfidenceThreshold));
-  }
-  const response = await fetch(`/api/v1/suggestions/faces?${params.toString()}`);
-  if (!response.ok) {
-    throw new Error(`Suggestions request failed (${response.status})`);
-  }
-  return (await response.json()) as SuggestionListPayload;
-}
-
-async function fetchPeopleDirectory(): Promise<PersonRecord[]> {
-  const response = await fetch("/api/v1/people");
-  if (!response.ok) {
-    throw new Error(`People request failed (${response.status})`);
-  }
-  return (await response.json()) as PersonRecord[];
-}
-
-async function confirmSuggestions(faceIds: string[]): Promise<SuggestionConfirmPayload> {
-  const response = await fetch("/api/v1/suggestions/confirmations", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "X-Face-Validation-Role": "contributor"
-    },
-    body: JSON.stringify({ face_ids: faceIds })
-  });
-  if (!response.ok) {
-    throw new Error(`Confirm request failed (${response.status})`);
-  }
-  return (await response.json()) as SuggestionConfirmPayload;
 }
 
 export function SuggestionsRoutePage() {
@@ -152,31 +26,46 @@ export function SuggestionsRoutePage() {
   const [peopleDirectory, setPeopleDirectory] = useState<PersonRecord[]>([]);
   const [payload, setPayload] = useState<SuggestionListPayload | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [isConfirming, setIsConfirming] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [message, setMessage] = useState<string | null>(null);
   const [selectedFaceIds, setSelectedFaceIds] = useState<Set<string>>(new Set());
+  const [faceChoiceDrafts, setFaceChoiceDrafts] = useState<Map<string, string>>(new Map());
+  const [excludedPersonPickerValue, setExcludedPersonPickerValue] = useState("");
 
   const minConfidenceThreshold = minConfidencePercent / 100;
   const excludedPersonIdSet = useMemo(() => new Set(excludedPersonIds), [excludedPersonIds]);
 
-  async function load(targetPage: number) {
-    setIsLoading(true);
-    setError(null);
-    try {
-      const nextPayload = await fetchSuggestionsPage(targetPage, minConfidenceThreshold);
-      setPayload(nextPayload);
-      setSelectedFaceIds(new Set(flattenFaceIds(nextPayload.items)));
-    } catch (caughtError: unknown) {
-      setError(caughtError instanceof Error ? caughtError.message : "Could not load suggestions.");
-    } finally {
-      setIsLoading(false);
-    }
-  }
+  const loadPage = useCallback(
+    async (targetPage: number) => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const nextPayload = await fetchSuggestionsPage(
+          targetPage,
+          PAGE_SIZE,
+          minConfidenceThreshold,
+          excludedPersonIds
+        );
+        setPayload(nextPayload);
+        setSelectedFaceIds(new Set(flattenFaceIds(nextPayload.items)));
+        const nextDrafts = new Map<string, string>();
+        for (const photo of nextPayload.items) {
+          for (const face of photo.faces) {
+            nextDrafts.set(face.face_id, face.top_suggestion.display_name);
+          }
+        }
+        setFaceChoiceDrafts(nextDrafts);
+      } catch (caughtError: unknown) {
+        setError(caughtError instanceof Error ? caughtError.message : "Could not load suggestions.");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [excludedPersonIds, minConfidenceThreshold]
+  );
 
   useEffect(() => {
-    void load(page);
-  }, [page, minConfidenceThreshold]);
+    void loadPage(page);
+  }, [loadPage, page]);
 
   useEffect(() => {
     let isCanceled = false;
@@ -204,25 +93,11 @@ export function SuggestionsRoutePage() {
   useEffect(() => {
     saveSuggestionsFilterState({
       minConfidencePercent,
-      excludedPersonIds
+      excludedPersonIds,
     });
   }, [excludedPersonIds, minConfidencePercent]);
 
-  const visibleItems = useMemo(() => {
-    if (!payload) {
-      return [] as SuggestionPhoto[];
-    }
-    return payload.items
-      .map((photo) => ({
-        ...photo,
-        faces: photo.faces.filter((face) => !excludedPersonIdSet.has(face.top_suggestion.person_id))
-      }))
-      .filter((photo) => photo.faces.length > 0);
-  }, [excludedPersonIdSet, payload]);
-
-  const currentPageFaceIdsOrdered = useMemo(() => {
-    return flattenFaceIds(visibleItems);
-  }, [visibleItems]);
+  const currentPageFaceIdsOrdered = useMemo(() => flattenFaceIds(payload?.items ?? []), [payload]);
 
   const selectedFaceIdsOrdered = useMemo(() => {
     const selected = selectedFaceIds;
@@ -234,46 +109,51 @@ export function SuggestionsRoutePage() {
     [excludedPersonIdSet, peopleDirectory]
   );
 
+  const availablePeopleToExclude = useMemo(
+    () => peopleDirectory.filter((person) => !excludedPersonIdSet.has(person.person_id)),
+    [excludedPersonIdSet, peopleDirectory]
+  );
+
   const totalPages = payload?.page.total_pages ?? 0;
-  const totalItems = visibleItems.length;
+  const totalItems = payload?.page.total_items ?? 0;
   const normalizedTotalPages = Number.isInteger(totalPages) && totalPages > 0 ? totalPages : 1;
   const normalizedRequestedPage = Number.isInteger(page) && page > 0 ? page : 1;
   const clampedRequestedPage = Math.min(normalizedRequestedPage, normalizedTotalPages);
   const canGoPrevious = !isLoading && totalPages > 0 && clampedRequestedPage > 1;
   const canGoNext = !isLoading && totalPages > 0 && clampedRequestedPage < totalPages;
 
-  async function handleConfirmFaces() {
-    if (isConfirming || selectedFaceIdsOrdered.length === 0) {
-      return;
-    }
+  const {
+    isConfirming,
+    message,
+    faceActionInFlightIds,
+    handleConfirmFaces,
+    handleConfirmSingleFace,
+    handleMarkFaceUnknown,
+    handleDismissFalsePositive,
+  } = useSuggestionsActions({
+    isLoading,
+    page,
+    payloadItems: payload?.items ?? [],
+    peopleDirectory,
+    currentPageFaceIdsOrdered,
+    selectedFaceIds,
+    faceChoiceDrafts,
+    loadPage,
+    setPeopleDirectory,
+  });
 
-    setIsConfirming(true);
-    setMessage(null);
-    try {
-      const checkedFaceIdsOnCurrentPage = currentPageFaceIdsOrdered.filter((faceId) =>
-        selectedFaceIds.has(faceId)
-      );
-      const result = await confirmSuggestions(checkedFaceIdsOnCurrentPage);
-      const assignedCount = result.assigned.length;
-      const label = assignedCount === 1 ? "face suggestion" : "face suggestions";
-      setMessage(`Confirmed ${assignedCount} ${label}.`);
-      await load(page);
-    } catch (caughtError: unknown) {
-      setMessage(
-        caughtError instanceof Error ? caughtError.message : "Could not confirm face suggestions."
-      );
-    } finally {
-      setIsConfirming(false);
-    }
-  }
-
-  function toggleExcludedPerson(personId: string) {
+  function addExcludedPerson(personId: string) {
     setExcludedPersonIds((current) => {
       if (current.includes(personId)) {
-        return current.filter((entry) => entry !== personId);
+        return current;
       }
       return [...current, personId];
     });
+    setPage(1);
+  }
+
+  function removeExcludedPerson(personId: string) {
+    setExcludedPersonIds((current) => current.filter((entry) => entry !== personId));
     setPage(1);
   }
 
@@ -286,66 +166,22 @@ export function SuggestionsRoutePage() {
           <p>{`Pending photos: ${totalItems}`}</p>
         </div>
         <div className="suggestions-header-actions">
-          <div className="suggestions-filter-group">
-            <label className="suggestions-confidence-filter">
-              <span>{`Minimum certainty: ${minConfidencePercent}%`}</span>
-              <input
-                type="range"
-                min={0}
-                max={100}
-                step={1}
-                value={minConfidencePercent}
-                aria-label="Minimum suggestion certainty"
-                onChange={(event) => {
-                  setMinConfidencePercent(Number(event.currentTarget.value));
-                  setPage(1);
-                }}
-                disabled={isLoading || isConfirming}
-              />
-            </label>
-            {peopleDirectory.length > 0 ? (
-              <div className="suggestions-people-filter">
-                <p className="suggestions-filter-label">Exclude people</p>
-                <ul className="search-chip-list suggestions-active-filters" aria-label="Excluded people filters">
-                  {peopleDirectory.map((person) => {
-                    const excluded = excludedPersonIdSet.has(person.person_id);
-                    return (
-                      <li key={person.person_id}>
-                        <button
-                          type="button"
-                          className={excluded ? "search-chip search-chip-active" : "search-chip"}
-                          aria-pressed={excluded}
-                          aria-label={`Exclude ${person.display_name}`}
-                          onClick={() => toggleExcludedPerson(person.person_id)}
-                          disabled={isLoading || isConfirming}
-                        >
-                          {person.display_name}
-                        </button>
-                      </li>
-                    );
-                  })}
-                </ul>
-                {excludedPeople.length > 0 ? (
-                  <ul className="search-chip-list suggestions-active-filters" aria-label="Active excluded people">
-                    {excludedPeople.map((person) => (
-                      <li key={person.person_id}>
-                        <button
-                          type="button"
-                          className="search-chip search-chip-active"
-                          aria-label={`Remove excluded person ${person.display_name}`}
-                          onClick={() => toggleExcludedPerson(person.person_id)}
-                          disabled={isLoading || isConfirming}
-                        >
-                          {`excluded: ${person.display_name}`}
-                          <span aria-hidden="true"> ×</span>
-                        </button>
-                      </li>
-                    ))}
-                  </ul>
-                ) : null}
-              </div>
-            ) : null}
-          </div>
+          <SuggestionsFilters
+            minConfidencePercent={minConfidencePercent}
+            isLoading={isLoading}
+            isConfirming={isConfirming}
+            peopleDirectory={peopleDirectory}
+            availablePeopleToExclude={availablePeopleToExclude}
+            excludedPeople={excludedPeople}
+            excludedPersonPickerValue={excludedPersonPickerValue}
+            onMinConfidenceChange={(value) => {
+              setMinConfidencePercent(value);
+              setPage(1);
+            }}
+            onExcludedPersonPickerValueChange={setExcludedPersonPickerValue}
+            onAddExcludedPerson={addExcludedPerson}
+            onRemoveExcludedPerson={removeExcludedPerson}
+          />
           <button
             type="button"
             className="suggestions-confirm-button"
@@ -366,7 +202,7 @@ export function SuggestionsRoutePage() {
           <button
             type="button"
             onClick={() => {
-              void load(page);
+              void loadPage(page);
             }}
           >
             Retry
@@ -375,111 +211,46 @@ export function SuggestionsRoutePage() {
       ) : null}
       {message ? <p>{message}</p> : null}
 
-      {!isLoading && !error && payload && visibleItems.length === 0 ? (
+      {!isLoading && !error && payload && payload.items.length === 0 ? (
         <p className="suggestions-empty">No pending suggestions.</p>
       ) : null}
 
       {!isLoading && !error && payload ? (
-        <ol className="suggestions-grid" aria-label="Suggestion photo list">
-          {visibleItems.map((photo) => {
-            const numberedFaces = photo.faces.map((face, index) => ({
-              ...face,
-              faceNumber: index + 1
-            }));
-            const faceNumberById = new Map(
-              numberedFaces.map((face) => [face.face_id, face.faceNumber] as const)
-            );
-            const overlayRegions =
-              photo.thumbnail
-                ? buildFaceOverlayRegions(
-                    numberedFaces.map((face) => ({
-                      face_id: face.face_id,
-                      person_id: null,
-                      bbox_x: face.bbox_x ?? null,
-                      bbox_y: face.bbox_y ?? null,
-                      bbox_w: face.bbox_w ?? null,
-                      bbox_h: face.bbox_h ?? null,
-                      bbox_space_width: face.bbox_space_width ?? null,
-                      bbox_space_height: face.bbox_space_height ?? null
-                    })),
-                    photo.thumbnail.width,
-                    photo.thumbnail.height
-                  )
-                : [];
-            const thumbnailShellStyle = photo.thumbnail
-              ? { aspectRatio: `${photo.thumbnail.width} / ${photo.thumbnail.height}` }
-              : undefined;
-            return (
-              <li key={photo.photo_id} className="suggestions-card">
-                <div className="suggestions-thumbnail-shell" style={thumbnailShellStyle}>
-                  <Link
-                    className="suggestions-thumbnail-link"
-                    to={`/library/${photo.photo_id}`}
-                    aria-label={`Open details for ${photo.path}`}
-                  >
-                    {photo.thumbnail ? (
-                      <img
-                        className="suggestions-thumbnail"
-                        src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
-                        width={photo.thumbnail.width}
-                        height={photo.thumbnail.height}
-                        alt={`Preview of ${photo.path}`}
-                      />
-                    ) : (
-                      <div className="suggestions-thumbnail suggestions-thumbnail-placeholder" aria-hidden="true">
-                        No preview
-                      </div>
-                    )}
-                    <FaceBBoxOverlay
-                      regions={overlayRegions}
-                      ariaLabel={`Suggested face regions for ${photo.path}`}
-                      renderRegionContent={(region) => (
-                        <span className="suggestions-face-overlay-badge" aria-hidden="true">
-                          {faceNumberById.get(region.faceId) ?? "?"}
-                        </span>
-                      )}
-                    />
-                  </Link>
-                </div>
-                <div className="suggestions-card-body">
-                  <p className="suggestions-path" title={photo.path}>
-                    {formatDisplayPath(photo.path)}
-                  </p>
-                  <ul className="suggestions-face-list">
-                    {photo.faces.map((face, index) => {
-                      const isSelected = selectedFaceIds.has(face.face_id);
-                      const faceNumber = index + 1;
-                      return (
-                        <li key={face.face_id}>
-                          <label>
-                            <input
-                              type="checkbox"
-                              aria-label={`Confirm suggestion for face ${face.face_id}`}
-                              checked={isSelected}
-                              onChange={() => {
-                                setSelectedFaceIds((current) => {
-                                  const next = new Set(current);
-                                  if (next.has(face.face_id)) {
-                                    next.delete(face.face_id);
-                                  } else {
-                                    next.add(face.face_id);
-                                  }
-                                  return next;
-                                });
-                              }}
-                              disabled={isLoading || isConfirming}
-                            />
-                            <span>{`Face ${faceNumber}: ${face.top_suggestion.display_name} (${formatConfidence(face.top_suggestion.confidence)})`}</span>
-                          </label>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </div>
-              </li>
-            );
-          })}
-        </ol>
+        <SuggestionsGrid
+          items={payload.items}
+          selectedFaceIds={selectedFaceIds}
+          faceActionInFlightIds={faceActionInFlightIds}
+          faceChoiceDrafts={faceChoiceDrafts}
+          isLoading={isLoading}
+          isConfirming={isConfirming}
+          onToggleFaceSelected={(faceId) => {
+            setSelectedFaceIds((current) => {
+              const next = new Set(current);
+              if (next.has(faceId)) {
+                next.delete(faceId);
+              } else {
+                next.add(faceId);
+              }
+              return next;
+            });
+          }}
+          onFaceChoiceChange={(faceId, value) => {
+            setFaceChoiceDrafts((current) => {
+              const next = new Map(current);
+              next.set(faceId, value);
+              return next;
+            });
+          }}
+          onConfirmSingleFace={(face) => {
+            void handleConfirmSingleFace(face);
+          }}
+          onMarkFaceUnknown={(face) => {
+            void handleMarkFaceUnknown(face);
+          }}
+          onDismissFalsePositive={(face) => {
+            void handleDismissFalsePositive(face);
+          }}
+        />
       ) : null}
 
       <nav className="browse-pagination" aria-label="Suggestion pagination">

--- a/apps/ui/src/pages/suggestions/SuggestionFaceRow.tsx
+++ b/apps/ui/src/pages/suggestions/SuggestionFaceRow.tsx
@@ -1,0 +1,114 @@
+import { type SuggestedFace } from "./types";
+import { formatConfidence } from "./formatting";
+
+type SuggestionFaceRowProps = {
+  face: SuggestedFace;
+  faceNumber: number;
+  isSelected: boolean;
+  isLoading: boolean;
+  isConfirming: boolean;
+  isFaceActionInFlight: boolean;
+  choiceDraft: string;
+  onToggleSelected: (faceId: string) => void;
+  onChoiceChange: (faceId: string, value: string) => void;
+  onConfirmFace: (face: SuggestedFace) => void;
+  onMarkUnknown: (face: SuggestedFace) => void;
+  onDismissFalsePositive: (face: SuggestedFace) => void;
+};
+
+export function SuggestionFaceRow({
+  face,
+  faceNumber,
+  isSelected,
+  isLoading,
+  isConfirming,
+  isFaceActionInFlight,
+  choiceDraft,
+  onToggleSelected,
+  onChoiceChange,
+  onConfirmFace,
+  onMarkUnknown,
+  onDismissFalsePositive,
+}: SuggestionFaceRowProps) {
+  const availableSuggestions = (
+    Array.isArray(face.suggestions) && face.suggestions.length > 0
+      ? face.suggestions
+      : [{ ...face.top_suggestion, rank: 1 }]
+  )
+    .slice()
+    .sort((left, right) => {
+      if (right.confidence !== left.confidence) {
+        return right.confidence - left.confidence;
+      }
+      const leftRank = typeof left.rank === "number" ? left.rank : Number.MAX_SAFE_INTEGER;
+      const rightRank = typeof right.rank === "number" ? right.rank : Number.MAX_SAFE_INTEGER;
+      if (leftRank !== rightRank) {
+        return leftRank - rightRank;
+      }
+      return left.display_name.localeCompare(right.display_name);
+    });
+  const faceChoiceListId = `suggestions-face-choice-${face.face_id}`;
+
+  return (
+    <li>
+      <label className="suggestions-face-choice-row">
+        <input
+          type="checkbox"
+          aria-label={`Confirm suggestion for face ${face.face_id}`}
+          checked={isSelected}
+          onChange={() => onToggleSelected(face.face_id)}
+          disabled={isLoading || isConfirming || isFaceActionInFlight}
+        />
+        <span>{`Face ${faceNumber}`}</span>
+        <input
+          list={faceChoiceListId}
+          value={choiceDraft}
+          onChange={(event) => {
+            onChoiceChange(face.face_id, event.currentTarget.value);
+          }}
+          disabled={isLoading || isConfirming || isFaceActionInFlight}
+          aria-label={`Choose suggestion for face ${face.face_id}`}
+          className="suggestions-face-choice-input"
+        />
+        <datalist id={faceChoiceListId}>
+          {availableSuggestions.map((suggestion) => (
+            <option
+              key={`${face.face_id}-${suggestion.person_id}`}
+              value={suggestion.display_name}
+            >
+              {formatConfidence(suggestion.confidence)}
+            </option>
+          ))}
+        </datalist>
+      </label>
+      <div className="suggestions-face-actions">
+        <button
+          type="button"
+          className="suggestions-face-confirm-button"
+          onClick={() => onConfirmFace(face)}
+          disabled={isLoading || isConfirming || isFaceActionInFlight}
+        >
+          Confirm face
+        </button>
+        <button
+          type="button"
+          className="suggestions-face-secondary-button"
+          onClick={() => onMarkUnknown(face)}
+          disabled={isLoading || isConfirming || isFaceActionInFlight}
+          aria-label={`Mark face ${face.face_id} as unknown`}
+        >
+          Mark unknown
+        </button>
+        <button
+          type="button"
+          className="suggestions-face-secondary-button"
+          onClick={() => onDismissFalsePositive(face)}
+          disabled={isLoading || isConfirming || isFaceActionInFlight}
+          aria-label={`Discard face ${face.face_id} as false positive`}
+        >
+          False positive
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/apps/ui/src/pages/suggestions/SuggestionsFilters.tsx
+++ b/apps/ui/src/pages/suggestions/SuggestionsFilters.tsx
@@ -1,0 +1,96 @@
+import type { PersonRecord } from "./types";
+
+type SuggestionsFiltersProps = {
+  minConfidencePercent: number;
+  isLoading: boolean;
+  isConfirming: boolean;
+  peopleDirectory: PersonRecord[];
+  availablePeopleToExclude: PersonRecord[];
+  excludedPeople: PersonRecord[];
+  excludedPersonPickerValue: string;
+  onMinConfidenceChange: (value: number) => void;
+  onExcludedPersonPickerValueChange: (value: string) => void;
+  onAddExcludedPerson: (personId: string) => void;
+  onRemoveExcludedPerson: (personId: string) => void;
+};
+
+export function SuggestionsFilters({
+  minConfidencePercent,
+  isLoading,
+  isConfirming,
+  peopleDirectory,
+  availablePeopleToExclude,
+  excludedPeople,
+  excludedPersonPickerValue,
+  onMinConfidenceChange,
+  onExcludedPersonPickerValueChange,
+  onAddExcludedPerson,
+  onRemoveExcludedPerson
+}: SuggestionsFiltersProps) {
+  return (
+    <div className="suggestions-filter-group">
+      <label className="suggestions-confidence-filter">
+        <span>{`Minimum certainty: ${minConfidencePercent}%`}</span>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          step={1}
+          value={minConfidencePercent}
+          aria-label="Minimum suggestion certainty"
+          onChange={(event) => {
+            onMinConfidenceChange(Number(event.currentTarget.value));
+          }}
+          disabled={isLoading || isConfirming}
+        />
+      </label>
+      {peopleDirectory.length > 0 ? (
+        <div className="suggestions-people-filter">
+          <p className="suggestions-filter-label">Exclude people</p>
+          <label className="suggestions-exclude-picker-label" htmlFor="suggestions-exclude-person-picker">
+            <span>Add excluded person</span>
+            <select
+              id="suggestions-exclude-person-picker"
+              aria-label="Add excluded person"
+              value={excludedPersonPickerValue}
+              onChange={(event) => {
+                const personId = event.currentTarget.value;
+                onExcludedPersonPickerValueChange("");
+                if (!personId) {
+                  return;
+                }
+                onAddExcludedPerson(personId);
+              }}
+              disabled={isLoading || isConfirming || availablePeopleToExclude.length === 0}
+            >
+              <option value="">Select person</option>
+              {availablePeopleToExclude.map((person) => (
+                <option key={person.person_id} value={person.person_id}>
+                  {person.display_name}
+                </option>
+              ))}
+            </select>
+          </label>
+          {excludedPeople.length > 0 ? (
+            <ul className="search-chip-list suggestions-active-filters" aria-label="Active excluded people">
+              {excludedPeople.map((person) => (
+                <li key={person.person_id}>
+                  <button
+                    type="button"
+                    className="search-chip search-chip-active"
+                    aria-label={`Remove excluded person ${person.display_name}`}
+                    onClick={() => onRemoveExcludedPerson(person.person_id)}
+                    disabled={isLoading || isConfirming}
+                  >
+                    {`excluded: ${person.display_name}`}
+                    <span aria-hidden="true"> ×</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/ui/src/pages/suggestions/SuggestionsGrid.tsx
+++ b/apps/ui/src/pages/suggestions/SuggestionsGrid.tsx
@@ -1,0 +1,147 @@
+import { Link } from "react-router-dom";
+import { FaceBBoxOverlay, buildFaceOverlayRegions } from "../FaceBBoxOverlay";
+import { buildFaceZoomStyle, formatDisplayPath } from "./formatting";
+import { SuggestionFaceRow } from "./SuggestionFaceRow";
+import type { SuggestionPhoto, SuggestedFace } from "./types";
+
+type SuggestionsGridProps = {
+  items: SuggestionPhoto[];
+  selectedFaceIds: Set<string>;
+  faceActionInFlightIds: Set<string>;
+  faceChoiceDrafts: Map<string, string>;
+  isLoading: boolean;
+  isConfirming: boolean;
+  onToggleFaceSelected: (faceId: string) => void;
+  onFaceChoiceChange: (faceId: string, value: string) => void;
+  onConfirmSingleFace: (face: SuggestedFace) => void;
+  onMarkFaceUnknown: (face: SuggestedFace) => void;
+  onDismissFalsePositive: (face: SuggestedFace) => void;
+};
+
+export function SuggestionsGrid({
+  items,
+  selectedFaceIds,
+  faceActionInFlightIds,
+  faceChoiceDrafts,
+  isLoading,
+  isConfirming,
+  onToggleFaceSelected,
+  onFaceChoiceChange,
+  onConfirmSingleFace,
+  onMarkFaceUnknown,
+  onDismissFalsePositive,
+}: SuggestionsGridProps) {
+  return (
+    <ol className="suggestions-grid" aria-label="Suggestion photo list">
+      {items.map((photo) => {
+        const numberedFaces = photo.faces.map((face, index) => ({
+          ...face,
+          faceNumber: index + 1,
+        }));
+        const faceById = new Map(numberedFaces.map((face) => [face.face_id, face] as const));
+        const faceNumberById = new Map(
+          numberedFaces.map((face) => [face.face_id, face.faceNumber] as const)
+        );
+        const overlayRegions = photo.thumbnail
+          ? buildFaceOverlayRegions(
+              numberedFaces.map((face) => ({
+                face_id: face.face_id,
+                person_id: null,
+                bbox_x: face.bbox_x ?? null,
+                bbox_y: face.bbox_y ?? null,
+                bbox_w: face.bbox_w ?? null,
+                bbox_h: face.bbox_h ?? null,
+                bbox_space_width: face.bbox_space_width ?? null,
+                bbox_space_height: face.bbox_space_height ?? null,
+              })),
+              photo.thumbnail.width,
+              photo.thumbnail.height
+            )
+          : [];
+        const thumbnailShellStyle = photo.thumbnail
+          ? { aspectRatio: `${photo.thumbnail.width} / ${photo.thumbnail.height}` }
+          : undefined;
+
+        return (
+          <li key={photo.photo_id} className="suggestions-card">
+            <div className="suggestions-thumbnail-shell" style={thumbnailShellStyle}>
+              <Link
+                className="suggestions-thumbnail-link"
+                to={`/library/${photo.photo_id}`}
+                aria-label={`Open details for ${photo.path}`}
+              >
+                {photo.thumbnail ? (
+                  <img
+                    className="suggestions-thumbnail"
+                    src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
+                    width={photo.thumbnail.width}
+                    height={photo.thumbnail.height}
+                    alt={`Preview of ${photo.path}`}
+                  />
+                ) : (
+                  <div className="suggestions-thumbnail suggestions-thumbnail-placeholder" aria-hidden="true">
+                    No preview
+                  </div>
+                )}
+                <FaceBBoxOverlay
+                  regions={overlayRegions}
+                  allowRegionHover
+                  ariaLabel={`Suggested face regions for ${photo.path}`}
+                  renderRegionContent={(region) => {
+                    const matchingFace = faceById.get(region.faceId);
+                    const zoomStyle =
+                      photo.thumbnail && matchingFace
+                        ? buildFaceZoomStyle(region, photo.thumbnail)
+                        : null;
+                    return (
+                      <span className="suggestions-face-overlay-marker" aria-hidden="true">
+                        <span className="suggestions-face-overlay-badge">
+                          {faceNumberById.get(region.faceId) ?? "?"}
+                        </span>
+                        {photo.thumbnail && zoomStyle ? (
+                          <span className="suggestions-face-overlay-zoom" style={zoomStyle.frame}>
+                            <img
+                              src={`data:${photo.thumbnail.mime_type};base64,${photo.thumbnail.data_base64}`}
+                              width={photo.thumbnail.width}
+                              height={photo.thumbnail.height}
+                              style={zoomStyle.image}
+                              alt=""
+                            />
+                          </span>
+                        ) : null}
+                      </span>
+                    );
+                  }}
+                />
+              </Link>
+            </div>
+            <div className="suggestions-card-body">
+              <p className="suggestions-path" title={photo.path}>
+                {formatDisplayPath(photo.path)}
+              </p>
+              <ul className="suggestions-face-list">
+                {numberedFaces.map((face) => (
+                  <SuggestionFaceRow
+                    key={face.face_id}
+                    face={face}
+                    faceNumber={face.faceNumber}
+                    isSelected={selectedFaceIds.has(face.face_id)}
+                    isLoading={isLoading}
+                    isConfirming={isConfirming}
+                    isFaceActionInFlight={faceActionInFlightIds.has(face.face_id)}
+                    choiceDraft={faceChoiceDrafts.get(face.face_id) ?? face.top_suggestion.display_name}
+                    onToggleSelected={onToggleFaceSelected}
+                    onChoiceChange={onFaceChoiceChange}
+                    onConfirmFace={onConfirmSingleFace}
+                    onMarkUnknown={onMarkFaceUnknown}
+                    onDismissFalsePositive={onDismissFalsePositive}
+                  />
+                ))}
+              </ul>
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/apps/ui/src/pages/suggestions/api.ts
+++ b/apps/ui/src/pages/suggestions/api.ts
@@ -1,0 +1,62 @@
+import type { PersonRecord, SuggestionConfirmPayload, SuggestionListPayload } from "./types";
+
+export async function fetchSuggestionsPage(
+  page: number,
+  pageSize: number,
+  minConfidenceThreshold: number,
+  excludedPersonIds: string[]
+): Promise<SuggestionListPayload> {
+  const params = new URLSearchParams({
+    page: String(page),
+    page_size: String(pageSize)
+  });
+  if (minConfidenceThreshold > 0) {
+    params.set("min_confidence", String(minConfidenceThreshold));
+  }
+  for (const personId of excludedPersonIds) {
+    params.append("excluded_person_ids", personId);
+  }
+  const response = await fetch(`/api/v1/suggestions/faces?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Suggestions request failed (${response.status})`);
+  }
+  return (await response.json()) as SuggestionListPayload;
+}
+
+export async function fetchPeopleDirectory(): Promise<PersonRecord[]> {
+  const response = await fetch("/api/v1/people");
+  if (!response.ok) {
+    throw new Error(`People request failed (${response.status})`);
+  }
+  return (await response.json()) as PersonRecord[];
+}
+
+export async function confirmSuggestions(
+  faceIds: string[],
+  assignments: Array<{ face_id: string; person_id: string }>
+): Promise<SuggestionConfirmPayload> {
+  const response = await fetch("/api/v1/suggestions/confirmations", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Face-Validation-Role": "contributor"
+    },
+    body: JSON.stringify({ face_ids: faceIds, assignments })
+  });
+  if (!response.ok) {
+    throw new Error(`Confirm request failed (${response.status})`);
+  }
+  return (await response.json()) as SuggestionConfirmPayload;
+}
+
+export async function readErrorDetail(response: Response): Promise<string | null> {
+  try {
+    const payload = (await response.json()) as { detail?: unknown };
+    if (typeof payload.detail === "string" && payload.detail.trim().length > 0) {
+      return payload.detail;
+    }
+  } catch {
+    // Fall through to fallback message.
+  }
+  return null;
+}

--- a/apps/ui/src/pages/suggestions/formatting.ts
+++ b/apps/ui/src/pages/suggestions/formatting.ts
@@ -1,0 +1,61 @@
+import type { CSSProperties } from "react";
+import type { SuggestionThumbnail } from "./types";
+
+export function formatConfidence(confidence: number): string {
+  if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+    return "0.0%";
+  }
+  return `${(confidence * 100).toFixed(1)}%`;
+}
+
+export function formatDisplayPath(path: string): string {
+  const marker = "/storage-sources/";
+  const markerIndex = path.indexOf(marker);
+  if (markerIndex < 0) {
+    return path;
+  }
+
+  const pathAfterMarker = path.slice(markerIndex + marker.length);
+  const firstSlashAfterSourceId = pathAfterMarker.indexOf("/");
+  if (firstSlashAfterSourceId < 0) {
+    return path;
+  }
+
+  const sourceRelativePath = pathAfterMarker.slice(firstSlashAfterSourceId + 1).trim();
+  if (!sourceRelativePath) {
+    return path;
+  }
+
+  return `.../${sourceRelativePath}`;
+}
+
+export function buildFaceZoomStyle(
+  faceRegion: { leftPercent: number; topPercent: number; widthPercent: number; heightPercent: number },
+  thumbnail: SuggestionThumbnail
+): { frame: CSSProperties; image: CSSProperties } {
+  const leftPx = (faceRegion.leftPercent / 100) * thumbnail.width;
+  const topPx = (faceRegion.topPercent / 100) * thumbnail.height;
+  const widthPx = (faceRegion.widthPercent / 100) * thumbnail.width;
+  const heightPx = (faceRegion.heightPercent / 100) * thumbnail.height;
+  const padding = 10;
+  const cropLeft = Math.max(0, Math.floor(leftPx - padding));
+  const cropTop = Math.max(0, Math.floor(topPx - padding));
+  const cropRight = Math.min(thumbnail.width, Math.ceil(leftPx + widthPx + padding));
+  const cropBottom = Math.min(thumbnail.height, Math.ceil(topPx + heightPx + padding));
+  const cropWidth = Math.max(1, cropRight - cropLeft);
+  const cropHeight = Math.max(1, cropBottom - cropTop);
+  const maxPreviewSize = 170;
+  const baseScale = Math.min(maxPreviewSize / cropWidth, maxPreviewSize / cropHeight);
+  const scale = Math.max(1.8, Math.min(4.5, baseScale));
+  return {
+    frame: {
+      width: `${Math.round(cropWidth * scale)}px`,
+      height: `${Math.round(cropHeight * scale)}px`
+    },
+    image: {
+      width: `${Math.round(thumbnail.width * scale)}px`,
+      height: `${Math.round(thumbnail.height * scale)}px`,
+      transform: `translate(${-Math.round(cropLeft * scale)}px, ${-Math.round(cropTop * scale)}px)`
+    }
+  };
+}

--- a/apps/ui/src/pages/suggestions/types.ts
+++ b/apps/ui/src/pages/suggestions/types.ts
@@ -1,0 +1,72 @@
+export type SuggestionThumbnail = {
+  mime_type: string;
+  width: number;
+  height: number;
+  data_base64: string;
+};
+
+export type TopSuggestion = {
+  person_id: string;
+  display_name: string;
+  confidence: number;
+};
+
+export type RankedSuggestion = TopSuggestion & {
+  rank?: number;
+};
+
+export type SuggestedFace = {
+  face_id: string;
+  bbox_x?: number | null;
+  bbox_y?: number | null;
+  bbox_w?: number | null;
+  bbox_h?: number | null;
+  bbox_space_width?: number | null;
+  bbox_space_height?: number | null;
+  top_suggestion: TopSuggestion;
+  suggestions: RankedSuggestion[];
+};
+
+export type SuggestionPhoto = {
+  photo_id: string;
+  path: string;
+  thumbnail: SuggestionThumbnail | null;
+  faces: SuggestedFace[];
+};
+
+export type SuggestionListPayload = {
+  page: {
+    page: number;
+    page_size: number;
+    total_items: number;
+    total_pages: number;
+  };
+  items: SuggestionPhoto[];
+};
+
+export type SuggestionConfirmPayload = {
+  assigned: Array<{
+    face_id: string;
+    photo_id: string;
+    person_id: string;
+  }>;
+  skipped: Array<{
+    face_id: string;
+    reason: string;
+  }>;
+};
+
+export type PersonRecord = {
+  person_id: string;
+  display_name: string;
+};
+
+export const UNKNOWN_FACE_CHOICE_LABEL = "Human face (name unknown)";
+export const NOT_A_FACE_CHOICE_LABEL = "Not a face (false positive)";
+
+export type FaceChoiceResolution =
+  | { kind: "assign_person"; personId: string }
+  | { kind: "create_person_and_assign"; displayName: string }
+  | { kind: "unknown_human" }
+  | { kind: "dismiss_false_positive" }
+  | { kind: "empty" };

--- a/apps/ui/src/pages/suggestions/useSuggestionsActions.ts
+++ b/apps/ui/src/pages/suggestions/useSuggestionsActions.ts
@@ -1,0 +1,291 @@
+import { useState, type Dispatch, type SetStateAction } from "react";
+
+import { confirmSuggestions, readErrorDetail } from "./api";
+import {
+  NOT_A_FACE_CHOICE_LABEL,
+  UNKNOWN_FACE_CHOICE_LABEL,
+  type FaceChoiceResolution,
+  type PersonRecord,
+  type SuggestionPhoto,
+  type SuggestedFace,
+} from "./types";
+
+type UseSuggestionsActionsArgs = {
+  isLoading: boolean;
+  page: number;
+  payloadItems: SuggestionPhoto[];
+  peopleDirectory: PersonRecord[];
+  currentPageFaceIdsOrdered: string[];
+  selectedFaceIds: Set<string>;
+  faceChoiceDrafts: Map<string, string>;
+  loadPage: (page: number) => Promise<void>;
+  setPeopleDirectory: Dispatch<SetStateAction<PersonRecord[]>>;
+};
+
+function resolveFaceChoice(
+  face: SuggestedFace,
+  rawChoice: string,
+  peopleDirectory: PersonRecord[]
+): FaceChoiceResolution {
+  const trimmedChoice = rawChoice.trim();
+  if (trimmedChoice.length === 0) {
+    return { kind: "empty" };
+  }
+
+  const normalizedChoice = trimmedChoice.toLowerCase();
+  if (normalizedChoice === UNKNOWN_FACE_CHOICE_LABEL.toLowerCase()) {
+    return { kind: "unknown_human" };
+  }
+  if (normalizedChoice === NOT_A_FACE_CHOICE_LABEL.toLowerCase()) {
+    return { kind: "dismiss_false_positive" };
+  }
+
+  const suggestionMatch = face.suggestions.find(
+    (suggestion) => suggestion.display_name.toLowerCase() === normalizedChoice
+  );
+  if (suggestionMatch) {
+    return { kind: "assign_person", personId: suggestionMatch.person_id };
+  }
+
+  const personMatch = peopleDirectory.find(
+    (person) => person.display_name.toLowerCase() === normalizedChoice
+  );
+  if (personMatch) {
+    return { kind: "assign_person", personId: personMatch.person_id };
+  }
+
+  return { kind: "create_person_and_assign", displayName: trimmedChoice };
+}
+
+export function useSuggestionsActions({
+  isLoading,
+  page,
+  payloadItems,
+  peopleDirectory,
+  currentPageFaceIdsOrdered,
+  selectedFaceIds,
+  faceChoiceDrafts,
+  loadPage,
+  setPeopleDirectory,
+}: UseSuggestionsActionsArgs) {
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [faceActionInFlightIds, setFaceActionInFlightIds] = useState<Set<string>>(new Set());
+
+  async function runFaceAction(
+    faceId: string,
+    action: () => Promise<void>,
+    fallbackErrorMessage: string
+  ) {
+    if (isLoading || isConfirming || faceActionInFlightIds.has(faceId)) {
+      return;
+    }
+
+    setFaceActionInFlightIds((current) => new Set(current).add(faceId));
+    setMessage(null);
+    try {
+      await action();
+      await loadPage(page);
+    } catch (caughtError: unknown) {
+      setMessage(
+        caughtError instanceof Error && caughtError.message.trim().length > 0
+          ? caughtError.message
+          : fallbackErrorMessage
+      );
+    } finally {
+      setFaceActionInFlightIds((current) => {
+        const next = new Set(current);
+        next.delete(faceId);
+        return next;
+      });
+    }
+  }
+
+  async function submitDismissFalsePositive(faceId: string) {
+    const response = await fetch(`/api/v1/faces/${faceId}/dismissals`, {
+      method: "POST",
+      headers: {
+        "X-Face-Validation-Role": "contributor",
+      },
+    });
+    if (!response.ok) {
+      const detail = await readErrorDetail(response);
+      throw new Error(detail ?? `Face dismissal failed (${response.status}).`);
+    }
+  }
+
+  async function submitUnknownHuman(faceId: string) {
+    const response = await fetch(`/api/v1/faces/${faceId}/unknown-identities`, {
+      method: "POST",
+      headers: {
+        "X-Face-Validation-Role": "contributor",
+      },
+    });
+    if (!response.ok) {
+      const detail = await readErrorDetail(response);
+      throw new Error(detail ?? `Unknown-person assignment failed (${response.status}).`);
+    }
+  }
+
+  async function handleConfirmFaces() {
+    if (isConfirming || currentPageFaceIdsOrdered.length === 0) {
+      return;
+    }
+
+    setIsConfirming(true);
+    setMessage(null);
+    try {
+      const faceById = new Map(
+        payloadItems.flatMap((photo) => photo.faces.map((face) => [face.face_id, face] as const))
+      );
+      const selectedAssignments = currentPageFaceIdsOrdered
+        .filter((faceId) => selectedFaceIds.has(faceId))
+        .map((faceId) => {
+          const face = faceById.get(faceId);
+          if (!face) {
+            return null;
+          }
+          const draft = faceChoiceDrafts.get(faceId) ?? face.top_suggestion.display_name;
+          const resolution = resolveFaceChoice(face, draft, peopleDirectory);
+          if (resolution.kind !== "assign_person") {
+            return null;
+          }
+          const isSuggested = face.suggestions.some(
+            (suggestion) => suggestion.person_id === resolution.personId
+          );
+          if (!isSuggested) {
+            return null;
+          }
+          return { face_id: faceId, person_id: resolution.personId };
+        })
+        .filter((value): value is { face_id: string; person_id: string } => value !== null);
+
+      if (selectedAssignments.length === 0) {
+        setMessage("No checked faces are set to a suggested person. Use Confirm face for custom actions.");
+        return;
+      }
+
+      const result = await confirmSuggestions(
+        selectedAssignments.map((assignment) => assignment.face_id),
+        selectedAssignments
+      );
+      const assignedCount = result.assigned.length;
+      const label = assignedCount === 1 ? "face suggestion" : "face suggestions";
+      setMessage(`Confirmed ${assignedCount} ${label}.`);
+      await loadPage(page);
+    } catch (caughtError: unknown) {
+      setMessage(
+        caughtError instanceof Error ? caughtError.message : "Could not confirm face suggestions."
+      );
+    } finally {
+      setIsConfirming(false);
+    }
+  }
+
+  async function handleConfirmSingleFace(face: SuggestedFace) {
+    const draft = faceChoiceDrafts.get(face.face_id) ?? face.top_suggestion.display_name;
+    const resolution = resolveFaceChoice(face, draft, peopleDirectory);
+    if (resolution.kind === "empty") {
+      setMessage("Choose or type a value before confirming this face.");
+      return;
+    }
+
+    if (resolution.kind === "dismiss_false_positive") {
+      await runFaceAction(
+        face.face_id,
+        async () => {
+          await submitDismissFalsePositive(face.face_id);
+          setMessage("Face flagged as not a face.");
+        },
+        "Could not flag face as false positive."
+      );
+      return;
+    }
+
+    if (resolution.kind === "unknown_human") {
+      await runFaceAction(
+        face.face_id,
+        async () => {
+          await submitUnknownHuman(face.face_id);
+          setMessage("Face marked as human with unknown name.");
+        },
+        "Could not mark face as unknown."
+      );
+      return;
+    }
+
+    await runFaceAction(
+      face.face_id,
+      async () => {
+        let personId = "";
+        if (resolution.kind === "create_person_and_assign") {
+          const createResponse = await fetch("/api/v1/people", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ display_name: resolution.displayName }),
+          });
+          if (!createResponse.ok) {
+            const detail = await readErrorDetail(createResponse);
+            throw new Error(detail ?? `Create person failed (${createResponse.status}).`);
+          }
+          const createdPerson = (await createResponse.json()) as PersonRecord;
+          personId = createdPerson.person_id;
+          setPeopleDirectory((current) => [...current, createdPerson]);
+        } else {
+          personId = resolution.personId;
+        }
+
+        const assignResponse = await fetch(`/api/v1/faces/${face.face_id}/assignments`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Face-Validation-Role": "contributor",
+          },
+          body: JSON.stringify({ person_id: personId }),
+        });
+        if (!assignResponse.ok) {
+          const detail = await readErrorDetail(assignResponse);
+          throw new Error(detail ?? `Face assignment failed (${assignResponse.status}).`);
+        }
+
+        setMessage("Face confirmed.");
+      },
+      "Could not confirm face."
+    );
+  }
+
+  async function handleMarkFaceUnknown(face: SuggestedFace) {
+    await runFaceAction(
+      face.face_id,
+      async () => {
+        await submitUnknownHuman(face.face_id);
+        setMessage("Face marked as human with unknown name.");
+      },
+      "Could not mark face as unknown."
+    );
+  }
+
+  async function handleDismissFalsePositive(face: SuggestedFace) {
+    await runFaceAction(
+      face.face_id,
+      async () => {
+        await submitDismissFalsePositive(face.face_id);
+        setMessage("Face flagged as not a face.");
+      },
+      "Could not flag face as false positive."
+    );
+  }
+
+  return {
+    isConfirming,
+    message,
+    faceActionInFlightIds,
+    setMessage,
+    handleConfirmFaces,
+    handleConfirmSingleFace,
+    handleMarkFaceUnknown,
+    handleDismissFalsePositive,
+  };
+}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -67,6 +67,22 @@
   color: #334155;
 }
 
+.suggestions-exclude-picker-label {
+  display: grid;
+  gap: 0.25rem;
+  font-size: 0.78rem;
+  color: #334155;
+}
+
+.suggestions-exclude-picker-label select {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  background: #ffffff;
+  color: #0f172a;
+  padding: 0.3rem 0.42rem;
+  font: inherit;
+}
+
 .suggestions-active-filters {
   align-items: flex-start;
 }
@@ -86,16 +102,23 @@
 }
 
 .suggestions-card {
+  position: relative;
   border: 1px solid #dbe4ee;
   border-radius: 0.65rem;
   background: #fff;
-  overflow: hidden;
+  overflow: visible;
+}
+
+.suggestions-card:hover,
+.suggestions-card:focus-within {
+  z-index: 10;
 }
 
 .suggestions-thumbnail-shell {
   position: relative;
   aspect-ratio: 4 / 3;
   background: #e2e8f0;
+  overflow: visible;
 }
 
 .suggestions-thumbnail-link {
@@ -143,12 +166,73 @@
   gap: 0.35rem;
 }
 
-.suggestions-face-list label {
+.suggestions-face-list li {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.suggestions-face-list label,
+.suggestions-face-choice-row {
   display: flex;
   align-items: center;
   gap: 0.4rem;
   font-size: 0.82rem;
   color: #0f172a;
+}
+
+.suggestions-face-list select {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.42rem;
+  padding: 0.2rem 0.35rem;
+  font: inherit;
+  font-size: 0.78rem;
+  color: #0f172a;
+  background: #ffffff;
+  max-width: 100%;
+}
+
+.suggestions-face-choice-input {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.42rem;
+  padding: 0.2rem 0.35rem;
+  font: inherit;
+  font-size: 0.78rem;
+  color: #0f172a;
+  background: #ffffff;
+  max-width: 100%;
+}
+
+.suggestions-face-confirm-button {
+  justify-self: start;
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.42rem;
+  padding: 0.22rem 0.48rem;
+  font: inherit;
+  font-size: 0.78rem;
+}
+
+.suggestions-face-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.suggestions-face-secondary-button {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #334155;
+  border-radius: 0.42rem;
+  padding: 0.22rem 0.48rem;
+  font: inherit;
+  font-size: 0.78rem;
+}
+
+.suggestions-face-overlay-marker {
+  position: relative;
+  display: inline-flex;
 }
 
 .suggestions-face-overlay-badge {
@@ -167,6 +251,43 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+}
+
+.suggestions-face-overlay-zoom {
+  position: absolute;
+  right: calc(100% + 0.35rem);
+  bottom: calc(100% + 0.35rem);
+  width: 0;
+  height: 0;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  overflow: hidden;
+  background: #f8fafc;
+  box-shadow: 0 10px 24px rgb(15 23 42 / 28%);
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 120ms ease, transform 120ms ease;
+  pointer-events: none;
+  z-index: 20;
+}
+
+.suggestions-face-overlay-zoom img {
+  display: block;
+  max-width: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.detail-face-overlay.is-hoverable:hover,
+.detail-face-overlay.is-hoverable:focus-within {
+  z-index: 12;
+}
+
+.detail-face-overlay:hover .suggestions-face-overlay-zoom,
+.detail-face-overlay:focus-within .suggestions-face-overlay-zoom {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .suggestions-pagination {
@@ -1071,6 +1192,10 @@ body {
   cursor: pointer;
 }
 
+.detail-face-overlay.is-hoverable {
+  pointer-events: auto;
+}
+
 .detail-face-overlay-provenance-button {
   pointer-events: auto;
   position: absolute;
@@ -1244,6 +1369,22 @@ body {
   border: 1px solid #fecaca;
   background: #fff1f2;
   color: #b91c1c;
+  border-radius: 0.45rem;
+  padding: 0.38rem 0.62rem;
+  font: inherit;
+}
+
+.face-assignment-modal-unlabeled-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.face-assignment-modal-unknown {
+  justify-self: start;
+  border: 1px solid #bae6fd;
+  background: #eff6ff;
+  color: #1d4ed8;
   border-radius: 0.45rem;
   padding: 0.38rem 0.62rem;
   font: inherit;


### PR DESCRIPTION
## Summary
- add support for marking a detected face as human-but-unknown and as false positive in assignment flows
- move excluded-people filtering to the server-side suggestions query and expose excluded IDs through the suggestions API
- refactor suggestions page into subcomponents/hooks (`SuggestionsFilters`, `SuggestionsGrid`, `SuggestionFaceRow`, `useSuggestionsActions`) with shared suggestion types/api/formatting helpers
- improve suggestion face controls: selectable suggested names ordered by likelihood, typed custom names, per-face confirm actions, and dedicated unknown/false-positive buttons
- add zoomed face preview on hover and adjust stacking/overflow so zoom tooltips render above neighboring cards
- expand API/UI tests to cover new endpoints, server-side filtering, and updated suggestions workflows

## Testing
- `npm --prefix apps/ui test -- SuggestionsRoutePage`
- `npm --prefix apps/ui test -- SuggestionsRoutePage FaceBBoxOverlay`
- `npm --prefix apps/ui run build`
- `npm --prefix apps/ui test`
- `uv run pytest apps/api/tests/test_face_suggestion_review_api.py apps/api/tests/test_face_assignment_api.py`