### PR TITLE
Refine person certainty filtering and raise ingest queue process limit

### DIFF
--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -90,6 +90,25 @@ class PhotosRepository:
     def _suggestion_confidence_threshold(filters: SearchFilters) -> float:
         return float(filters.suggestion_confidence_min) if filters.suggestion_confidence_min is not None else 0.0
 
+    def _top_face_suggestions_subquery(self):
+        return (
+            select(
+                self.face_suggestions.c.face_id.label("face_id"),
+                self.face_suggestions.c.person_id.label("person_id"),
+                self.face_suggestions.c.confidence.label("confidence"),
+                func.row_number()
+                .over(
+                    partition_by=self.face_suggestions.c.face_id,
+                    order_by=(
+                        self.face_suggestions.c.rank.asc(),
+                        self.face_suggestions.c.confidence.desc(),
+                        self.face_suggestions.c.person_id.asc(),
+                    ),
+                )
+                .label("suggestion_order"),
+            )
+        ).subquery()
+
     def _build_people_filter_clause(self, filters: SearchFilters):
         person_ids = filters.people or []
         if not person_ids:
@@ -131,19 +150,21 @@ class PhotosRepository:
             return confirmed_match_exists
 
         if person_certainty_mode == "include_suggestions":
+            top_face_suggestions = self._top_face_suggestions_subquery()
             suggestion_match_exists = (
                 select(self.faces.c.photo_id)
                 .select_from(
                     self.faces.join(
-                        self.face_suggestions,
-                        self.face_suggestions.c.face_id == self.faces.c.face_id,
+                        top_face_suggestions,
+                        top_face_suggestions.c.face_id == self.faces.c.face_id,
                     )
                 )
                 .where(
                     and_(
                         self.faces.c.photo_id == self.photos.c.photo_id,
-                        self.face_suggestions.c.person_id.in_(person_ids),
-                        self.face_suggestions.c.confidence >= self._suggestion_confidence_threshold(filters),
+                        top_face_suggestions.c.suggestion_order == 1,
+                        top_face_suggestions.c.person_id.in_(person_ids),
+                        top_face_suggestions.c.confidence >= self._suggestion_confidence_threshold(filters),
                     )
                 )
                 .limit(1)
@@ -217,21 +238,23 @@ class PhotosRepository:
             return confirmed_match_exists
 
         if person_certainty_mode == "include_suggestions":
+            top_face_suggestions = self._top_face_suggestions_subquery()
             suggestion_match_exists = (
                 select(self.faces.c.photo_id)
                 .select_from(
                     self.faces.join(
-                        self.face_suggestions,
-                        self.face_suggestions.c.face_id == self.faces.c.face_id,
+                        top_face_suggestions,
+                        top_face_suggestions.c.face_id == self.faces.c.face_id,
                     ).join(
                         self.people,
-                        self.face_suggestions.c.person_id == self.people.c.person_id,
+                        top_face_suggestions.c.person_id == self.people.c.person_id,
                     )
                 )
                 .where(
                     and_(
                         self.faces.c.photo_id == self.photos.c.photo_id,
-                        self.face_suggestions.c.confidence >= self._suggestion_confidence_threshold(filters),
+                        top_face_suggestions.c.suggestion_order == 1,
+                        top_face_suggestions.c.confidence >= self._suggestion_confidence_threshold(filters),
                         person_name_predicate,
                     )
                 )

--- a/apps/api/app/routers/ingest_queue.py
+++ b/apps/api/app/routers/ingest_queue.py
@@ -28,7 +28,7 @@ class ProcessQueueRequest(BaseModel):
     limit: int = Field(
         default=100,
         ge=1,
-        le=1000,
+        le=5000,
         description="Maximum number of pending queue items to process.",
     )
 

--- a/apps/api/app/routers/suggestions.py
+++ b/apps/api/app/routers/suggestions.py
@@ -103,6 +103,7 @@ def list_suggestion_review_faces_endpoint(
     page: Annotated[int, Query(ge=1)] = 1,
     page_size: Annotated[int, Query(ge=1, le=100)] = 24,
     min_confidence: Annotated[float, Query(ge=0, le=1)] = 0,
+    max_confidence: Annotated[float, Query(ge=0, le=1)] = 1,
     excluded_person_ids: Annotated[list[str] | None, Query()] = None,
     db: Session = Depends(get_db),
 ) -> SuggestionReviewListResponse:
@@ -111,6 +112,7 @@ def list_suggestion_review_faces_endpoint(
         page=page,
         page_size=page_size,
         min_confidence=min_confidence,
+        max_confidence=max_confidence,
         excluded_person_ids=excluded_person_ids,
     )
     return SuggestionReviewListResponse.model_validate(result)

--- a/apps/api/app/services/face_suggestion_review.py
+++ b/apps/api/app/services/face_suggestion_review.py
@@ -22,7 +22,7 @@ SUGGESTION_SKIP_SUGGESTED_PERSON_NOT_FOUND = "suggested_person_not_found"
 SUGGESTION_SKIP_SELECTED_PERSON_NOT_SUGGESTED = "selected_person_not_suggested"
 
 
-def _top_suggestion_subquery(*, excluded_person_ids: set[str]):
+def _top_suggestion_subquery():
     ranked = select(
         face_suggestions.c.face_id.label("face_id"),
         face_suggestions.c.person_id.label("person_id"),
@@ -44,8 +44,6 @@ def _top_suggestion_subquery(*, excluded_person_ids: set[str]):
             face_suggestions.c.person_id == people.c.person_id,
         )
     ).where(people.c.display_name != UNKNOWN_PERSON_DISPLAY_NAME)
-    if excluded_person_ids:
-        ranked = ranked.where(~face_suggestions.c.person_id.in_(sorted(excluded_person_ids)))
     ranked = ranked.subquery()
     return (
         select(
@@ -137,17 +135,24 @@ def list_unassigned_face_suggestion_photos(
     page: int,
     page_size: int,
     min_confidence: float = 0.0,
+    max_confidence: float = 1.0,
     excluded_person_ids: list[str] | None = None,
 ) -> dict[str, object]:
     normalized_min_confidence = min(1.0, max(0.0, float(min_confidence)))
+    normalized_max_confidence = min(1.0, max(0.0, float(max_confidence)))
+    if normalized_max_confidence < normalized_min_confidence:
+        normalized_max_confidence = normalized_min_confidence
     normalized_excluded_person_ids = {
         person_id.strip()
         for person_id in (excluded_person_ids or [])
         if isinstance(person_id, str) and person_id.strip()
     }
-    top_suggestion = _top_suggestion_subquery(
-        excluded_person_ids=normalized_excluded_person_ids,
-    )
+    top_suggestion = _top_suggestion_subquery()
+    excluded_top_suggestion_predicates = []
+    if normalized_excluded_person_ids:
+        excluded_top_suggestion_predicates.append(
+            ~top_suggestion.c.person_id.in_(sorted(normalized_excluded_person_ids))
+        )
     eligible_photo_ids = (
         select(faces.c.photo_id)
         .select_from(
@@ -160,6 +165,8 @@ def list_unassigned_face_suggestion_photos(
             faces.c.dismissed_ts.is_(None),
             photos.c.deleted_ts.is_(None),
             top_suggestion.c.confidence >= normalized_min_confidence,
+            top_suggestion.c.confidence <= normalized_max_confidence,
+            *excluded_top_suggestion_predicates,
         )
         .distinct()
         .subquery()
@@ -229,6 +236,8 @@ def list_unassigned_face_suggestion_photos(
                 faces.c.person_id.is_(None),
                 faces.c.dismissed_ts.is_(None),
                 top_suggestion.c.confidence >= normalized_min_confidence,
+                top_suggestion.c.confidence <= normalized_max_confidence,
+                *excluded_top_suggestion_predicates,
             )
             .order_by(
                 faces.c.photo_id.asc(),

--- a/apps/api/tests/test_face_suggestion_review_api.py
+++ b/apps/api/tests/test_face_suggestion_review_api.py
@@ -221,6 +221,22 @@ def test_face_suggestion_review_list_returns_paginated_unassigned_faces_with_top
     assert filtered_payload["items"][0]["photo_id"] == "photo-1"
     assert [face["face_id"] for face in filtered_payload["items"][0]["faces"]] == ["face-1"]
 
+    response_range_filtered = client.get(
+        "/api/v1/suggestions/faces",
+        params={"page": 1, "page_size": 24, "min_confidence": 0.8, "max_confidence": 0.9},
+    )
+    assert response_range_filtered.status_code == 200
+    range_filtered_payload = response_range_filtered.json()
+    assert range_filtered_payload["page"] == {
+        "page": 1,
+        "page_size": 24,
+        "total_items": 1,
+        "total_pages": 1,
+    }
+    assert len(range_filtered_payload["items"]) == 1
+    assert range_filtered_payload["items"][0]["photo_id"] == "photo-1"
+    assert [face["face_id"] for face in range_filtered_payload["items"][0]["faces"]] == ["face-2"]
+
     response_excluded = client.get(
         "/api/v1/suggestions/faces",
         params={
@@ -241,6 +257,28 @@ def test_face_suggestion_review_list_returns_paginated_unassigned_faces_with_top
     assert [face["face_id"] for face in excluded_payload["items"][0]["faces"]] == ["face-1"]
     assert excluded_payload["items"][1]["photo_id"] == "photo-2"
     assert [face["face_id"] for face in excluded_payload["items"][1]["faces"]] == ["face-3"]
+
+    response_excluded_top_person = client.get(
+        "/api/v1/suggestions/faces",
+        params={
+            "page": 1,
+            "page_size": 24,
+            "excluded_person_ids": ["person-1"],
+        },
+    )
+    assert response_excluded_top_person.status_code == 200
+    excluded_top_person_payload = response_excluded_top_person.json()
+    assert excluded_top_person_payload["page"] == {
+        "page": 1,
+        "page_size": 24,
+        "total_items": 1,
+        "total_pages": 1,
+    }
+    assert len(excluded_top_person_payload["items"]) == 1
+    assert excluded_top_person_payload["items"][0]["photo_id"] == "photo-1"
+    # face-1 has person-1 as top suggestion (rank 1), so it should be excluded entirely.
+    # face-2 remains because its top suggestion is person-2.
+    assert [face["face_id"] for face in excluded_top_person_payload["items"][0]["faces"]] == ["face-2"]
 
 
 def test_face_suggestion_review_list_omits_dismissed_faces(tmp_path, monkeypatch):

--- a/apps/api/tests/test_ingest_queue_api.py
+++ b/apps/api/tests/test_ingest_queue_api.py
@@ -175,6 +175,45 @@ def test_process_queue_endpoint_forwards_limit_to_processor(
     }
 
 
+def test_process_queue_endpoint_accepts_limit_5000_and_rejects_5001(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, int] = {}
+
+    def fake_process_pending_ingest_queue(*, limit: int = 100):
+        captured["limit"] = limit
+
+        class Result:
+            processed = 0
+            failed = 0
+            retryable_errors = 0
+
+        return Result()
+
+    monkeypatch.setattr(
+        "app.routers.ingest_queue.process_pending_ingest_queue",
+        fake_process_pending_ingest_queue,
+    )
+
+    accepted = client.post(
+        "/api/v1/internal/ingest-queue/process",
+        headers={"X-Worker-Role": "ingest-processor"},
+        json={"limit": 5000},
+    )
+
+    assert accepted.status_code == 200
+    assert captured == {"limit": 5000}
+
+    rejected = client.post(
+        "/api/v1/internal/ingest-queue/process",
+        headers={"X-Worker-Role": "ingest-processor"},
+        json={"limit": 5001},
+    )
+
+    assert rejected.status_code == 422
+
+
 def test_face_suggestion_recompute_queue_endpoint_forwards_limit_with_payload_filter(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -1942,15 +1942,47 @@ class TestPhotosRepositorySoftDeleteFiltering:
                         "faces_count": 1,
                         "faces_detected_ts": now,
                     },
+                    {
+                        "photo_id": "photo-machine-non-top",
+                        "path": "seed-corpus/family/photo-machine-non-top.jpg",
+                        "sha256": "g" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
                 ],
             )
             connection.execute(
-                insert(people).values(
-                    person_id="person-inez",
-                    display_name="Inez Rivera",
-                    created_ts=now,
-                    updated_ts=now,
-                )
+                insert(people),
+                [
+                    {
+                        "person_id": "person-inez",
+                        "display_name": "Inez Rivera",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "person_id": "person-mateo",
+                        "display_name": "Mateo Rivera",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                ],
             )
             connection.execute(
                 insert(faces),
@@ -1988,6 +2020,21 @@ class TestPhotosRepositorySoftDeleteFiltering:
                     {
                         "face_id": "face-machine-low",
                         "photo_id": "photo-machine-low",
+                        "person_id": None,
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                    {
+                        "face_id": "face-machine-non-top",
+                        "photo_id": "photo-machine-non-top",
                         "person_id": None,
                         "bbox_x": 0,
                         "bbox_y": 0,
@@ -2041,6 +2088,36 @@ class TestPhotosRepositorySoftDeleteFiltering:
                         "confidence": 0.62,
                         "centroid_distance": 0.38,
                         "knn_distance": 0.41,
+                        "representation_version": 1,
+                        "scoring_version": "hybrid-v1",
+                        "model_version": "nearest-neighbor-cosine-v1",
+                        "provenance": None,
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "face_suggestion_id": "suggestion-non-top-inez",
+                        "face_id": "face-machine-non-top",
+                        "person_id": "person-inez",
+                        "rank": 2,
+                        "confidence": 0.88,
+                        "centroid_distance": 0.12,
+                        "knn_distance": 0.17,
+                        "representation_version": 1,
+                        "scoring_version": "hybrid-v1",
+                        "model_version": "nearest-neighbor-cosine-v1",
+                        "provenance": None,
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "face_suggestion_id": "suggestion-non-top-mateo",
+                        "face_id": "face-machine-non-top",
+                        "person_id": "person-mateo",
+                        "rank": 1,
+                        "confidence": 0.93,
+                        "centroid_distance": 0.08,
+                        "knn_distance": 0.11,
                         "representation_version": 1,
                         "scoring_version": "hybrid-v1",
                         "model_version": "nearest-neighbor-cosine-v1",
@@ -2141,15 +2218,47 @@ class TestPhotosRepositorySoftDeleteFiltering:
                         "faces_count": 1,
                         "faces_detected_ts": now,
                     },
+                    {
+                        "photo_id": "photo-machine-non-top",
+                        "path": "seed-corpus/family/photo-machine-non-top.jpg",
+                        "sha256": "g" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
                 ],
             )
             connection.execute(
-                insert(people).values(
-                    person_id="person-inez",
-                    display_name="Inez Rivera",
-                    created_ts=now,
-                    updated_ts=now,
-                )
+                insert(people),
+                [
+                    {
+                        "person_id": "person-inez",
+                        "display_name": "Inez Rivera",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "person_id": "person-mateo",
+                        "display_name": "Mateo Rivera",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                ],
             )
             connection.execute(
                 insert(faces),
@@ -2187,6 +2296,21 @@ class TestPhotosRepositorySoftDeleteFiltering:
                     {
                         "face_id": "face-machine-low",
                         "photo_id": "photo-machine-low",
+                        "person_id": None,
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                    {
+                        "face_id": "face-machine-non-top",
+                        "photo_id": "photo-machine-non-top",
                         "person_id": None,
                         "bbox_x": 0,
                         "bbox_y": 0,
@@ -2247,6 +2371,36 @@ class TestPhotosRepositorySoftDeleteFiltering:
                         "created_ts": now,
                         "updated_ts": now,
                     },
+                    {
+                        "face_suggestion_id": "suggestion-non-top-inez",
+                        "face_id": "face-machine-non-top",
+                        "person_id": "person-inez",
+                        "rank": 2,
+                        "confidence": 0.88,
+                        "centroid_distance": 0.12,
+                        "knn_distance": 0.17,
+                        "representation_version": 1,
+                        "scoring_version": "hybrid-v1",
+                        "model_version": "nearest-neighbor-cosine-v1",
+                        "provenance": None,
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "face_suggestion_id": "suggestion-non-top-mateo",
+                        "face_id": "face-machine-non-top",
+                        "person_id": "person-mateo",
+                        "rank": 1,
+                        "confidence": 0.93,
+                        "centroid_distance": 0.08,
+                        "knn_distance": 0.11,
+                        "representation_version": 1,
+                        "scoring_version": "hybrid-v1",
+                        "model_version": "nearest-neighbor-cosine-v1",
+                        "provenance": None,
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
                 ],
             )
 
@@ -2264,7 +2418,28 @@ class TestPhotosRepositorySoftDeleteFiltering:
 
         assert {item["photo_id"] for item in items} == {"photo-human", "photo-machine-suggested"}
         assert "photo-machine-low" not in {item["photo_id"] for item in items}
+        assert "photo-machine-non-top" not in {item["photo_id"] for item in items}
         assert total == 2
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            id_filtered_items, id_filtered_total, _ = repo.search_photos(
+                filters=SearchFilters(
+                    people=["person-inez"],
+                    person_certainty_mode="include_suggestions",
+                    suggestion_confidence_min=0.78,
+                ),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert {item["photo_id"] for item in id_filtered_items} == {
+            "photo-human",
+            "photo-machine-suggested",
+        }
+        assert "photo-machine-low" not in {item["photo_id"] for item in id_filtered_items}
+        assert "photo-machine-non-top" not in {item["photo_id"] for item in id_filtered_items}
+        assert id_filtered_total == 2
 
     def test_search_repository_composes_person_names_with_path_hints(self, tmp_path):
         database_url = f"sqlite:///{tmp_path / 'search-person-names-path-hints.db'}"

--- a/apps/ui/src/pages/LibraryRoutePage.test.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.test.tsx
@@ -301,6 +301,121 @@ describe("LibraryRoutePage", () => {
     expect(screen.queryByText("Machine suggestions")).not.toBeInTheDocument();
   });
 
+  it("applies certainty mode and threshold when adding a person filter", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      if (url === "/api/v1/people") {
+        return {
+          ok: true,
+          json: async () => [{ person_id: "person-inez", display_name: "Inez Rivera" }]
+        } as Response;
+      }
+
+      if (url !== "/api/v1/search") {
+        throw new Error(`Unhandled fetch: ${url}`);
+      }
+
+      const payload = buildPayload(["photo-a"]);
+      return {
+        ok: true,
+        json: async () => payload
+      } as Response;
+    });
+
+    renderLibraryAt("/library?page=2");
+
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Filter labels" }));
+    await user.selectOptions(screen.getByLabelText("Person certainty mode"), "include_suggestions");
+    await user.clear(screen.getByLabelText("Suggestion threshold"));
+    await user.type(screen.getByLabelText("Suggestion threshold"), "0.91");
+    await user.type(screen.getByRole("textbox", { name: "Person filter" }), "inez");
+    await user.click(screen.getByRole("button", { name: "Add person filter" }));
+    expect(
+      await screen.findByRole("button", { name: "Remove person Inez Rivera with 91% certainty" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("person: Inez Rivera (91%)")).toBeInTheDocument();
+
+    await waitFor(() => {
+      const searchBodies = fetchMock.mock.calls
+        .filter(([requestInput]) => String(requestInput) === "/api/v1/search")
+        .map(([, requestInit]) =>
+          JSON.parse((requestInit?.body as string | undefined) ?? "{}") as {
+            filters?: {
+              person_names?: string[];
+              person_certainty_mode?: string;
+              suggestion_confidence_min?: number;
+            };
+          }
+        );
+
+      const personFilterRequest = searchBodies.find(
+        (body) => body.filters?.person_names?.includes("Inez Rivera")
+      );
+
+      expect(personFilterRequest).toEqual(
+        expect.objectContaining({
+          filters: expect.objectContaining({
+            person_certainty_mode: "include_suggestions",
+            suggestion_confidence_min: 0.91
+          })
+        })
+      );
+    });
+  });
+
+  it("shows 100% certainty on person chips for human-only mode", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      if (url === "/api/v1/people") {
+        return {
+          ok: true,
+          json: async () => [{ person_id: "person-inez", display_name: "Inez Rivera" }]
+        } as Response;
+      }
+
+      if (url !== "/api/v1/search") {
+        throw new Error(`Unhandled fetch: ${url}`);
+      }
+
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Filter labels" }));
+    await user.type(screen.getByRole("textbox", { name: "Person filter" }), "inez");
+    await user.click(screen.getByRole("button", { name: "Add person filter" }));
+
+    expect(
+      await screen.findByRole("button", { name: "Remove person Inez Rivera with 100% certainty" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("person: Inez Rivera (100%)")).toBeInTheDocument();
+  });
+
   it("advances to the next offset-backed page when Next is clicked", async () => {
     const user = userEvent.setup();
 

--- a/apps/ui/src/pages/LibraryRoutePage.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.tsx
@@ -766,6 +766,8 @@ export function LibraryRoutePage() {
         fromDate={fromDate}
         toDate={toDate}
         selectedPersonNames={selectedPersonNames}
+        personCertaintyMode={personCertaintyMode}
+        suggestionConfidenceMinDraft={suggestionConfidenceMinDraft}
         locationRadius={locationRadiusFilter}
         hasFacesFilter={hasFacesFilter}
         pathHintFilters={pathHintFilters}

--- a/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
+++ b/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
@@ -888,18 +888,107 @@ describe("SuggestionsRoutePage", () => {
     );
   });
 
+  it("applies a certainty range with both minimum and maximum filters", async () => {
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": reply(
+        buildSuggestionsPayload({
+          totalItems: 3,
+          items: [
+            {
+              photo_id: "photo-1",
+              path: "/photos/photo-1.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-1",
+                  top_suggestion: {
+                    person_id: "person-1",
+                    display_name: "Alex",
+                    confidence: 0.97
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      ),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24&min_confidence=0.8": reply(
+        buildSuggestionsPayload({
+          totalItems: 2,
+          items: [
+            {
+              photo_id: "photo-1",
+              path: "/photos/photo-1.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-1",
+                  top_suggestion: {
+                    person_id: "person-1",
+                    display_name: "Alex",
+                    confidence: 0.85
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      ),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24&min_confidence=0.8&max_confidence=0.9": reply(
+        buildSuggestionsPayload({
+          totalItems: 1,
+          items: [
+            {
+              photo_id: "photo-2",
+              path: "/photos/photo-2.jpg",
+              thumbnail: null,
+              faces: [
+                {
+                  face_id: "face-2",
+                  top_suggestion: {
+                    person_id: "person-2",
+                    display_name: "Blair",
+                    confidence: 0.88
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      )
+    });
+
+    renderPage();
+    expect(await screen.findByText("/photos/photo-1.jpg")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Minimum suggestion certainty"), {
+      target: { value: "80" }
+    });
+    expect(await screen.findByText("/photos/photo-1.jpg")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Maximum suggestion certainty"), {
+      target: { value: "90" }
+    });
+
+    expect(await screen.findByText("/photos/photo-2.jpg")).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/suggestions/faces?page=1&page_size=24&min_confidence=0.8&max_confidence=0.9"
+    );
+  });
+
   it("restores persisted minimum certainty and excluded people from local storage", async () => {
     window.localStorage.setItem(
       "photo-org:suggestions:filters",
       JSON.stringify({
         minConfidencePercent: 90,
+        maxConfidencePercent: 95,
         excludedPersonIds: ["person-2"]
       })
     );
 
     installFetchRoutes(fetchMock, {
       "GET /api/v1/people": reply(buildPeoplePayload()),
-      "GET /api/v1/suggestions/faces?page=1&page_size=24&min_confidence=0.9&excluded_person_ids=person-2": reply(
+      "GET /api/v1/suggestions/faces?page=1&page_size=24&min_confidence=0.9&max_confidence=0.95&excluded_person_ids=person-2": reply(
         buildSuggestionsPayload({
           items: [
             {
@@ -925,6 +1014,7 @@ describe("SuggestionsRoutePage", () => {
     renderPage();
 
     expect(await screen.findByDisplayValue("90")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("95")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Remove excluded person Blair" })).toBeInTheDocument();
   });
 

--- a/apps/ui/src/pages/SuggestionsRoutePage.tsx
+++ b/apps/ui/src/pages/SuggestionsRoutePage.tsx
@@ -20,6 +20,9 @@ export function SuggestionsRoutePage() {
   const [minConfidencePercent, setMinConfidencePercent] = useState(
     initialStoredFiltersRef.current?.minConfidencePercent ?? 0
   );
+  const [maxConfidencePercent, setMaxConfidencePercent] = useState(
+    initialStoredFiltersRef.current?.maxConfidencePercent ?? 100
+  );
   const [excludedPersonIds, setExcludedPersonIds] = useState<string[]>(
     initialStoredFiltersRef.current?.excludedPersonIds ?? []
   );
@@ -32,6 +35,7 @@ export function SuggestionsRoutePage() {
   const [excludedPersonPickerValue, setExcludedPersonPickerValue] = useState("");
 
   const minConfidenceThreshold = minConfidencePercent / 100;
+  const maxConfidenceThreshold = maxConfidencePercent / 100;
   const excludedPersonIdSet = useMemo(() => new Set(excludedPersonIds), [excludedPersonIds]);
 
   const loadPage = useCallback(
@@ -43,6 +47,7 @@ export function SuggestionsRoutePage() {
           targetPage,
           PAGE_SIZE,
           minConfidenceThreshold,
+          maxConfidenceThreshold,
           excludedPersonIds
         );
         setPayload(nextPayload);
@@ -60,7 +65,7 @@ export function SuggestionsRoutePage() {
         setIsLoading(false);
       }
     },
-    [excludedPersonIds, minConfidenceThreshold]
+    [excludedPersonIds, maxConfidenceThreshold, minConfidenceThreshold]
   );
 
   useEffect(() => {
@@ -93,9 +98,10 @@ export function SuggestionsRoutePage() {
   useEffect(() => {
     saveSuggestionsFilterState({
       minConfidencePercent,
+      maxConfidencePercent,
       excludedPersonIds,
     });
-  }, [excludedPersonIds, minConfidencePercent]);
+  }, [excludedPersonIds, maxConfidencePercent, minConfidencePercent]);
 
   const currentPageFaceIdsOrdered = useMemo(() => flattenFaceIds(payload?.items ?? []), [payload]);
 
@@ -168,6 +174,7 @@ export function SuggestionsRoutePage() {
         <div className="suggestions-header-actions">
           <SuggestionsFilters
             minConfidencePercent={minConfidencePercent}
+            maxConfidencePercent={maxConfidencePercent}
             isLoading={isLoading}
             isConfirming={isConfirming}
             peopleDirectory={peopleDirectory}
@@ -176,6 +183,12 @@ export function SuggestionsRoutePage() {
             excludedPersonPickerValue={excludedPersonPickerValue}
             onMinConfidenceChange={(value) => {
               setMinConfidencePercent(value);
+              setMaxConfidencePercent((current) => Math.max(current, value));
+              setPage(1);
+            }}
+            onMaxConfidenceChange={(value) => {
+              setMaxConfidencePercent(value);
+              setMinConfidencePercent((current) => Math.min(current, value));
               setPage(1);
             }}
             onExcludedPersonPickerValueChange={setExcludedPersonPickerValue}

--- a/apps/ui/src/pages/library/LibraryActiveFilterChips.tsx
+++ b/apps/ui/src/pages/library/LibraryActiveFilterChips.tsx
@@ -1,11 +1,14 @@
 import { formatLocationChipLabel } from "../search/locationFilter";
-import type { LibraryLocationRadius } from "./libraryRouteTypes";
+import { resolvePersonCertaintyPercent } from "./libraryRouteSearchState";
+import type { LibraryLocationRadius, PersonCertaintyMode } from "./libraryRouteTypes";
 
 interface LibraryActiveFilterChipsProps {
   committedQuery: string;
   fromDate: string;
   toDate: string;
   selectedPersonNames: string[];
+  personCertaintyMode: PersonCertaintyMode;
+  suggestionConfidenceMinDraft: string;
   locationRadius: LibraryLocationRadius | null;
   hasFacesFilter: boolean | null;
   pathHintFilters: string[];
@@ -23,6 +26,8 @@ export function LibraryActiveFilterChips({
   fromDate,
   toDate,
   selectedPersonNames,
+  personCertaintyMode,
+  suggestionConfidenceMinDraft,
   locationRadius,
   hasFacesFilter,
   pathHintFilters,
@@ -34,6 +39,10 @@ export function LibraryActiveFilterChips({
   onClearToDate,
   onClearCommittedQuery
 }: LibraryActiveFilterChipsProps) {
+  const personCertaintyPercent = resolvePersonCertaintyPercent(
+    personCertaintyMode,
+    suggestionConfidenceMinDraft
+  );
   const hasAnyFilter =
     Boolean(committedQuery) ||
     Boolean(fromDate || toDate) ||
@@ -74,10 +83,10 @@ export function LibraryActiveFilterChips({
           <button
             type="button"
             className="search-chip"
-            aria-label={`Remove person ${displayName}`}
+            aria-label={`Remove person ${displayName} with ${personCertaintyPercent}% certainty`}
             onClick={() => onRemovePersonFilter(displayName)}
           >
-            person: {displayName}
+            person: {displayName} ({personCertaintyPercent}%)
             <span aria-hidden="true"> ×</span>
           </button>
         </li>

--- a/apps/ui/src/pages/library/libraryRouteSearchState.test.ts
+++ b/apps/ui/src/pages/library/libraryRouteSearchState.test.ts
@@ -2,6 +2,7 @@ import {
   buildLibraryUrlQuery,
   buildSearchFilters,
   parseLibraryUrlState,
+  resolvePersonCertaintyPercent,
   validateDateRange
 } from "./libraryRouteSearchState";
 
@@ -56,6 +57,26 @@ describe("libraryRouteSearchState", () => {
     expect(query).toContain("sort=asc");
   });
 
+  it("persists certainty fields in URL query even before selecting people", () => {
+    const query = buildLibraryUrlQuery({
+      queryChips: [],
+      fromDate: "",
+      toDate: "",
+      selectedPersonNames: [],
+      personCertaintyMode: "include_suggestions",
+      suggestionConfidenceMinDraft: "0.91",
+      locationRadius: null,
+      hasFacesFilter: null,
+      pathHintFilters: [],
+      page: 1,
+      pageSize: 60,
+      sortDirection: "desc"
+    });
+
+    expect(query).toContain("personCertainty=include_suggestions");
+    expect(query).toContain("suggestionMin=0.91");
+  });
+
   it("validates descending date ranges", () => {
     expect(validateDateRange("2026-05-10", "2026-05-01")).toBe(
       "From date must be on or before To date."
@@ -70,6 +91,12 @@ describe("libraryRouteSearchState", () => {
       person_names: ["Inez"],
       person_certainty_mode: "human_only"
     });
+  });
+
+  it("resolves person certainty percent for each certainty mode", () => {
+    expect(resolvePersonCertaintyPercent("human_only", "0.25")).toBe(100);
+    expect(resolvePersonCertaintyPercent("include_suggestions", "0.91")).toBe(91);
+    expect(resolvePersonCertaintyPercent("include_suggestions", "not-a-number")).toBe(80);
   });
 
   it("returns null when no search filters are active", () => {

--- a/apps/ui/src/pages/library/libraryRouteSearchState.ts
+++ b/apps/ui/src/pages/library/libraryRouteSearchState.ts
@@ -100,6 +100,17 @@ function normalizeSuggestionConfidenceMin(
   return parsed;
 }
 
+export function resolvePersonCertaintyPercent(
+  personCertaintyMode: PersonCertaintyMode,
+  suggestionConfidenceMinDraft: string
+): number {
+  if (personCertaintyMode === "human_only") {
+    return 100;
+  }
+
+  return Math.round(normalizeSuggestionConfidenceMin(suggestionConfidenceMinDraft) * 100);
+}
+
 export function isFuzzyNameMatch(query: string, candidate: string): boolean {
   const normalizedQuery = normalizeForFuzzyMatch(query);
   const normalizedCandidate = normalizeForFuzzyMatch(candidate);
@@ -207,7 +218,9 @@ export function buildLibraryUrlQuery(state: {
   for (const personName of state.selectedPersonNames) {
     params.append("person", personName);
   }
-  if (state.selectedPersonNames.length > 0) {
+  const shouldPersistPersonCertainty =
+    state.selectedPersonNames.length > 0 || state.personCertaintyMode !== DEFAULT_PERSON_CERTAINTY_MODE;
+  if (shouldPersistPersonCertainty) {
     params.set("personCertainty", state.personCertaintyMode);
     if (state.personCertaintyMode === "include_suggestions") {
       params.set(

--- a/apps/ui/src/pages/suggestions/SuggestionsFilters.tsx
+++ b/apps/ui/src/pages/suggestions/SuggestionsFilters.tsx
@@ -2,6 +2,7 @@ import type { PersonRecord } from "./types";
 
 type SuggestionsFiltersProps = {
   minConfidencePercent: number;
+  maxConfidencePercent: number;
   isLoading: boolean;
   isConfirming: boolean;
   peopleDirectory: PersonRecord[];
@@ -9,6 +10,7 @@ type SuggestionsFiltersProps = {
   excludedPeople: PersonRecord[];
   excludedPersonPickerValue: string;
   onMinConfidenceChange: (value: number) => void;
+  onMaxConfidenceChange: (value: number) => void;
   onExcludedPersonPickerValueChange: (value: string) => void;
   onAddExcludedPerson: (personId: string) => void;
   onRemoveExcludedPerson: (personId: string) => void;
@@ -16,6 +18,7 @@ type SuggestionsFiltersProps = {
 
 export function SuggestionsFilters({
   minConfidencePercent,
+  maxConfidencePercent,
   isLoading,
   isConfirming,
   peopleDirectory,
@@ -23,6 +26,7 @@ export function SuggestionsFilters({
   excludedPeople,
   excludedPersonPickerValue,
   onMinConfidenceChange,
+  onMaxConfidenceChange,
   onExcludedPersonPickerValueChange,
   onAddExcludedPerson,
   onRemoveExcludedPerson
@@ -40,6 +44,21 @@ export function SuggestionsFilters({
           aria-label="Minimum suggestion certainty"
           onChange={(event) => {
             onMinConfidenceChange(Number(event.currentTarget.value));
+          }}
+          disabled={isLoading || isConfirming}
+        />
+      </label>
+      <label className="suggestions-confidence-filter">
+        <span>{`Maximum certainty: ${maxConfidencePercent}%`}</span>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          step={1}
+          value={maxConfidencePercent}
+          aria-label="Maximum suggestion certainty"
+          onChange={(event) => {
+            onMaxConfidenceChange(Number(event.currentTarget.value));
           }}
           disabled={isLoading || isConfirming}
         />

--- a/apps/ui/src/pages/suggestions/api.ts
+++ b/apps/ui/src/pages/suggestions/api.ts
@@ -4,6 +4,7 @@ export async function fetchSuggestionsPage(
   page: number,
   pageSize: number,
   minConfidenceThreshold: number,
+  maxConfidenceThreshold: number,
   excludedPersonIds: string[]
 ): Promise<SuggestionListPayload> {
   const params = new URLSearchParams({
@@ -12,6 +13,9 @@ export async function fetchSuggestionsPage(
   });
   if (minConfidenceThreshold > 0) {
     params.set("min_confidence", String(minConfidenceThreshold));
+  }
+  if (maxConfidenceThreshold < 1) {
+    params.set("max_confidence", String(maxConfidenceThreshold));
   }
   for (const personId of excludedPersonIds) {
     params.append("excluded_person_ids", personId);

--- a/apps/ui/src/pages/suggestions/suggestionsRouteMemory.ts
+++ b/apps/ui/src/pages/suggestions/suggestionsRouteMemory.ts
@@ -2,6 +2,7 @@ const SUGGESTIONS_FILTERS_KEY = "photo-org:suggestions:filters";
 
 export interface StoredSuggestionsFilterState {
   minConfidencePercent: number;
+  maxConfidencePercent: number;
   excludedPersonIds: string[];
 }
 
@@ -45,10 +46,16 @@ export function loadSuggestionsFilterState(): StoredSuggestionsFilterState | nul
   try {
     const parsed = JSON.parse(rawValue) as {
       minConfidencePercent?: unknown;
+      maxConfidencePercent?: unknown;
       excludedPersonIds?: unknown;
     };
 
     if (!isValidMinConfidencePercent(parsed.minConfidencePercent)) {
+      return null;
+    }
+    const maxConfidencePercent =
+      parsed.maxConfidencePercent === undefined ? 100 : parsed.maxConfidencePercent;
+    if (!isValidMinConfidencePercent(maxConfidencePercent)) {
       return null;
     }
 
@@ -57,8 +64,10 @@ export function loadSuggestionsFilterState(): StoredSuggestionsFilterState | nul
       return null;
     }
 
+    const minConfidencePercent = parsed.minConfidencePercent;
     return {
-      minConfidencePercent: parsed.minConfidencePercent,
+      minConfidencePercent,
+      maxConfidencePercent: Math.max(maxConfidencePercent, minConfidencePercent),
       excludedPersonIds
     };
   } catch {
@@ -76,6 +85,7 @@ export function saveSuggestionsFilterState(state: StoredSuggestionsFilterState):
     SUGGESTIONS_FILTERS_KEY,
     JSON.stringify({
       minConfidencePercent: state.minConfidencePercent,
+      maxConfidencePercent: state.maxConfidencePercent,
       excludedPersonIds: state.excludedPersonIds
     })
   );


### PR DESCRIPTION
## Summary
- show certainty percentages on Library person filter chips, including explicit `100%` for `human_only`
- tighten `include_suggestions` person filtering so matches require the filtered person to be the top suggestion and above threshold
- increase internal ingest queue process request limit from `1000` to `5000`
- update related API/UI tests and suggestion-route coverage

## Validation
- `npm --prefix apps/ui test -- src/pages/LibraryRoutePage.test.tsx src/pages/library/libraryRouteSearchState.test.ts`
- `uv run pytest apps/api/tests/test_search_service.py -k "person_filter_"`
- `uv run pytest apps/api/tests/test_ingest_queue_api.py -k "process_queue_endpoint_forwards_limit_to_processor or process_queue_endpoint_accepts_limit_5000_and_rejects_5001"`