### PR TITLE
[codex] Fix confidence slider drag refresh behavior

### DIFF
--- a/apps/ui/package-lock.json
+++ b/apps/ui/package-lock.json
@@ -8,12 +8,12 @@
       "name": "photo-org-ui",
       "version": "0.1.0",
       "dependencies": {
-        "@radix-ui/react-slider": "^1.3.6",
         "leaflet": "^1.9.4",
         "nuqs": "^2.8.9",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-paginate": "^8.3.0",
+        "react-range": "^1.10.0",
         "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
@@ -907,234 +907,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@radix-ui/number": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
-      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="
-    },
-    "node_modules/@radix-ui/primitive": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
-      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="
-    },
-    "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
-      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-direction": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
-      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slider": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
-      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
-      "dependencies": {
-        "@radix-ui/number": "1.1.1",
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-previous": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
-      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
-      "dependencies": {
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
-      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-previous": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
-      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-size": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
-      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
-      "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1643,13 +1415,13 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1659,7 +1431,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2105,7 +1877,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -3348,6 +3120,15 @@
       },
       "peerDependencies": {
         "react": "^16 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-range": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/react-range/-/react-range-1.10.0.tgz",
+      "integrity": "sha512-kDo0LiBUHIQIP8menx0UoxTnHr7UXBYpIYl/DR9jCaO1o29VwvCLpkP/qOTNQz5hkJadPg1uEM07XJcJ1XGoKw==",
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/react-refresh": {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -18,12 +18,12 @@
     "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
-    "@radix-ui/react-slider": "^1.3.6",
     "leaflet": "^1.9.4",
     "nuqs": "^2.8.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-paginate": "^8.3.0",
+    "react-range": "^1.10.0",
     "react-router-dom": "^6.30.1"
   },
   "devDependencies": {

--- a/apps/ui/src/pages/shared/ConfidenceSlider.test.tsx
+++ b/apps/ui/src/pages/shared/ConfidenceSlider.test.tsx
@@ -16,6 +16,8 @@ describe("ConfidenceSlider", () => {
     expect(thumb.tagName).toBe("DIV");
 
     fireEvent.keyDown(thumb, { key: "ArrowRight" });
+    expect(onValueChange).not.toHaveBeenCalled();
+    fireEvent.keyUp(thumb, { key: "ArrowRight" });
 
     expect(onValueChange).toHaveBeenCalledWith(92);
   });
@@ -33,6 +35,8 @@ describe("ConfidenceSlider", () => {
     const minThumb = screen.getByLabelText("Minimum suggestion certainty");
     expect(minThumb.tagName).toBe("DIV");
     fireEvent.keyDown(minThumb, { key: "ArrowRight" });
+    expect(onValueChange).not.toHaveBeenCalled();
+    fireEvent.keyUp(minThumb, { key: "ArrowRight" });
 
     expect(onValueChange).toHaveBeenCalledWith(31, 80);
   });

--- a/apps/ui/src/pages/shared/ConfidenceSlider.test.tsx
+++ b/apps/ui/src/pages/shared/ConfidenceSlider.test.tsx
@@ -12,7 +12,10 @@ describe("ConfidenceSlider", () => {
 
     expect(screen.getByText("Suggestion threshold: 91%")).toBeInTheDocument();
 
-    fireEvent.keyDown(screen.getByLabelText("Suggestion threshold"), { key: "ArrowRight" });
+    const thumb = screen.getByLabelText("Suggestion threshold");
+    expect(thumb.tagName).toBe("DIV");
+
+    fireEvent.keyDown(thumb, { key: "ArrowRight" });
 
     expect(onValueChange).toHaveBeenCalledWith(92);
   });
@@ -28,6 +31,7 @@ describe("ConfidenceSlider", () => {
     expect(screen.getByText("Maximum certainty: 80%")).toBeInTheDocument();
 
     const minThumb = screen.getByLabelText("Minimum suggestion certainty");
+    expect(minThumb.tagName).toBe("DIV");
     fireEvent.keyDown(minThumb, { key: "ArrowRight" });
 
     expect(onValueChange).toHaveBeenCalledWith(31, 80);

--- a/apps/ui/src/pages/shared/ConfidenceSlider.tsx
+++ b/apps/ui/src/pages/shared/ConfidenceSlider.tsx
@@ -1,4 +1,4 @@
-import * as Slider from "@radix-ui/react-slider";
+import { Range, getTrackBackground } from "react-range";
 
 interface ConfidenceSingleSliderProps {
   value: number;
@@ -39,23 +39,52 @@ export function ConfidenceSingleSlider({
   return (
     <div className="confidence-slider-wrapper">
       <p>{`Suggestion threshold: ${normalizedValue}%`}</p>
-      <Slider.Root
-        className="confidence-slider"
+      <Range
         min={0}
         max={100}
         step={1}
-        value={[normalizedValue]}
+        values={[normalizedValue]}
         disabled={disabled}
-        onValueChange={(next) => {
+        onChange={(next) => {
           const [first = normalizedValue] = next;
           onValueChange(clampPercent(first));
         }}
-      >
-        <Slider.Track className="confidence-slider-track">
-          <Slider.Range className="confidence-slider-range" />
-        </Slider.Track>
-        <Slider.Thumb className="confidence-slider-thumb" aria-label="Suggestion threshold" />
-      </Slider.Root>
+        renderTrack={({ props, children }) => (
+          <div
+            onMouseDown={props.onMouseDown}
+            onTouchStart={props.onTouchStart}
+            style={props.style}
+            className="confidence-slider"
+            data-disabled={disabled ? "" : undefined}
+          >
+            <div
+              ref={props.ref}
+              className="confidence-slider-track"
+              style={{
+                background: getTrackBackground({
+                  values: [normalizedValue],
+                  colors: ["#3b82f6", "#dbeafe"],
+                  min: 0,
+                  max: 100,
+                }),
+              }}
+            >
+              {children}
+            </div>
+          </div>
+        )}
+        renderThumb={({ props }) => {
+          const { key, ...thumbProps } = props as typeof props & { key?: string };
+          return (
+            <div
+              key={key}
+              {...thumbProps}
+              className="confidence-slider-thumb"
+              aria-label="Suggestion threshold"
+            />
+          );
+        }}
+      />
     </div>
   );
 }
@@ -67,30 +96,59 @@ export function ConfidenceRangeSlider({
   disabled = false,
 }: ConfidenceRangeSliderProps) {
   const [normalizedMin, normalizedMax] = normalizeRange(minValue, maxValue);
+  const sliderValues = [normalizedMin, normalizedMax];
 
   return (
     <div className="confidence-slider-wrapper">
       <p>{`Minimum certainty: ${normalizedMin}%`}</p>
       <p>{`Maximum certainty: ${normalizedMax}%`}</p>
-      <Slider.Root
-        className="confidence-slider"
+      <Range
         min={0}
         max={100}
         step={1}
-        value={[normalizedMin, normalizedMax]}
+        values={sliderValues}
         disabled={disabled}
-        onValueChange={(next) => {
+        onChange={(next) => {
           const [nextMin = normalizedMin, nextMax = normalizedMax] = next;
           const [safeMin, safeMax] = normalizeRange(nextMin, nextMax);
           onValueChange(safeMin, safeMax);
         }}
-      >
-        <Slider.Track className="confidence-slider-track">
-          <Slider.Range className="confidence-slider-range" />
-        </Slider.Track>
-        <Slider.Thumb className="confidence-slider-thumb" aria-label="Minimum suggestion certainty" />
-        <Slider.Thumb className="confidence-slider-thumb" aria-label="Maximum suggestion certainty" />
-      </Slider.Root>
+        renderTrack={({ props, children }) => (
+          <div
+            onMouseDown={props.onMouseDown}
+            onTouchStart={props.onTouchStart}
+            style={props.style}
+            className="confidence-slider"
+            data-disabled={disabled ? "" : undefined}
+          >
+            <div
+              ref={props.ref}
+              className="confidence-slider-track"
+              style={{
+                background: getTrackBackground({
+                  values: sliderValues,
+                  colors: ["#dbeafe", "#3b82f6", "#dbeafe"],
+                  min: 0,
+                  max: 100,
+                }),
+              }}
+            >
+              {children}
+            </div>
+          </div>
+        )}
+        renderThumb={({ props, index }) => {
+          const { key, ...thumbProps } = props as typeof props & { key?: string };
+          return (
+            <div
+              key={key}
+              {...thumbProps}
+              className="confidence-slider-thumb"
+              aria-label={index === 0 ? "Minimum suggestion certainty" : "Maximum suggestion certainty"}
+            />
+          );
+        }}
+      />
     </div>
   );
 }

--- a/apps/ui/src/pages/shared/ConfidenceSlider.tsx
+++ b/apps/ui/src/pages/shared/ConfidenceSlider.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Range, getTrackBackground } from "react-range";
 
 interface ConfidenceSingleSliderProps {
@@ -35,18 +36,27 @@ export function ConfidenceSingleSlider({
   disabled = false,
 }: ConfidenceSingleSliderProps) {
   const normalizedValue = clampPercent(value);
+  const [draftValue, setDraftValue] = useState(normalizedValue);
+
+  useEffect(() => {
+    setDraftValue(normalizedValue);
+  }, [normalizedValue]);
 
   return (
     <div className="confidence-slider-wrapper">
-      <p>{`Suggestion threshold: ${normalizedValue}%`}</p>
+      <p>{`Suggestion threshold: ${draftValue}%`}</p>
       <Range
         min={0}
         max={100}
         step={1}
-        values={[normalizedValue]}
+        values={[draftValue]}
         disabled={disabled}
         onChange={(next) => {
-          const [first = normalizedValue] = next;
+          const [first = draftValue] = next;
+          setDraftValue(clampPercent(first));
+        }}
+        onFinalChange={(next) => {
+          const [first = draftValue] = next;
           onValueChange(clampPercent(first));
         }}
         renderTrack={({ props, children }) => (
@@ -62,7 +72,7 @@ export function ConfidenceSingleSlider({
               className="confidence-slider-track"
               style={{
                 background: getTrackBackground({
-                  values: [normalizedValue],
+                  values: [draftValue],
                   colors: ["#3b82f6", "#dbeafe"],
                   min: 0,
                   max: 100,
@@ -96,20 +106,30 @@ export function ConfidenceRangeSlider({
   disabled = false,
 }: ConfidenceRangeSliderProps) {
   const [normalizedMin, normalizedMax] = normalizeRange(minValue, maxValue);
-  const sliderValues = [normalizedMin, normalizedMax];
+  const [draftRange, setDraftRange] = useState<[number, number]>([normalizedMin, normalizedMax]);
+  const [draftMin, draftMax] = draftRange;
+
+  useEffect(() => {
+    setDraftRange([normalizedMin, normalizedMax]);
+  }, [normalizedMin, normalizedMax]);
 
   return (
     <div className="confidence-slider-wrapper">
-      <p>{`Minimum certainty: ${normalizedMin}%`}</p>
-      <p>{`Maximum certainty: ${normalizedMax}%`}</p>
+      <p>{`Minimum certainty: ${draftMin}%`}</p>
+      <p>{`Maximum certainty: ${draftMax}%`}</p>
       <Range
         min={0}
         max={100}
         step={1}
-        values={sliderValues}
+        values={draftRange}
         disabled={disabled}
         onChange={(next) => {
-          const [nextMin = normalizedMin, nextMax = normalizedMax] = next;
+          const [nextMin = draftMin, nextMax = draftMax] = next;
+          const [safeMin, safeMax] = normalizeRange(nextMin, nextMax);
+          setDraftRange([safeMin, safeMax]);
+        }}
+        onFinalChange={(next) => {
+          const [nextMin = draftMin, nextMax = draftMax] = next;
           const [safeMin, safeMax] = normalizeRange(nextMin, nextMax);
           onValueChange(safeMin, safeMax);
         }}
@@ -126,7 +146,7 @@ export function ConfidenceRangeSlider({
               className="confidence-slider-track"
               style={{
                 background: getTrackBackground({
-                  values: sliderValues,
+                  values: draftRange,
                   colors: ["#dbeafe", "#3b82f6", "#dbeafe"],
                   min: 0,
                   max: 100,

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -55,6 +55,61 @@
   gap: 0.65rem;
 }
 
+.confidence-slider-wrapper {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.confidence-slider-wrapper p {
+  margin: 0;
+  color: #334155;
+  font-size: 0.8rem;
+}
+
+.confidence-slider {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: min(18rem, 100%);
+  height: 1.2rem;
+  touch-action: none;
+  user-select: none;
+}
+
+.confidence-slider-track {
+  position: relative;
+  flex: 1;
+  height: 0.36rem;
+  border-radius: 999px;
+  background: #dbeafe;
+}
+
+.confidence-slider-range {
+  position: absolute;
+  height: 100%;
+  border-radius: 999px;
+  background: #3b82f6;
+}
+
+.confidence-slider-thumb {
+  display: block;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  border: 2px solid #1d4ed8;
+  background: #ffffff;
+  box-shadow: 0 0 0 1px rgb(255 255 255 / 70%), 0 1px 2px rgb(15 23 42 / 22%);
+}
+
+.confidence-slider-thumb:focus-visible {
+  outline: 2px solid #60a5fa;
+  outline-offset: 2px;
+}
+
+.confidence-slider[data-disabled] {
+  opacity: 0.55;
+}
+
 .suggestions-people-filter {
   display: grid;
   gap: 0.45rem;


### PR DESCRIPTION
## Summary
- migrate certainty slider UI controls to `react-range` for consistent range/single slider behavior
- fix confidence slider interaction so value changes are buffered while dragging and only committed on `onFinalChange`
- keep visual feedback live during drag by rendering labels/tracks from draft slider state
- update slider tests to assert callbacks fire on key release (`keyup`) instead of key press (`keydown`)

## Root Cause
The slider callback was wired to `onChange`, which fires during pointer down and drag movement. That triggered parent refresh effects too early, interrupting drag interactions.

## Validation
- `npm --prefix apps/ui test -- src/pages/shared/ConfidenceSlider.test.tsx`