### PR TITLE
feat: unify face info payload and photo interaction surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ export PHOTO_ORG_COMPOSE_DATABASE_URL
 export PHOTO_ORG_UI_API_BASE_URL
 export PHOTO_ORG_API_CORS_ALLOWED_ORIGINS
 
-.PHONY: help sync lint test test-all ui-test ui-build test-e2e check pre-push migrate env-create compose-up compose-migrate compose-down compose-down-volumes compose-smoke compose-e2e-smoke print-compose-db-url print-compose-api-base-url print-compose-ui-base-url seed-corpus-check seed-corpus-load ensure-environment
+.PHONY: help sync lint test test-all ui-test ui-test-coverage ui-build test-e2e check pre-push migrate env-create compose-up compose-migrate compose-down compose-down-volumes compose-smoke compose-e2e-smoke print-compose-db-url print-compose-api-base-url print-compose-ui-base-url seed-corpus-check seed-corpus-load ensure-environment
 
 help:
 	@printf '%s\n' \
@@ -70,10 +70,11 @@ help:
 		'make test      - run the current schema/migration/ingest verification slice' \
 		'make test-all  - run the full apps/api pytest suite with the enforced coverage gate' \
 		'make ui-test   - run the apps/ui unit test suite' \
+		'make ui-test-coverage - run the apps/ui unit test suite with enforced coverage thresholds' \
 		'make ui-build  - run the apps/ui production build' \
 		'make test-e2e  - run the seed-corpus end-to-end verification slice' \
 		'make check     - run lint and the focused test slice' \
-		'make pre-push  - run lint, full API tests, plus UI test and UI build checks' \
+		'make pre-push  - run lint, full API tests, plus UI coverage validation and UI build checks' \
 		'make migrate   - apply database migrations through the repo-root wrapper' \
 		'make env-create PHOTO_ORG_ENVIRONMENT=<name> PHOTO_ORG_ENV_STORAGE_MODE=<persistent|ephemeral> - register a local environment with immutable storage mode' \
 		'make compose-up PHOTO_ORG_ENVIRONMENT=<name> - build and start the selected registered environment (postgres + api + ui)' \
@@ -100,6 +101,9 @@ test-all:
 ui-test:
 	npm --prefix apps/ui run test
 
+ui-test-coverage:
+	npm --prefix apps/ui run test:coverage
+
 ui-build:
 	npm --prefix apps/ui run build
 
@@ -108,7 +112,7 @@ test-e2e:
 
 check: lint test
 
-pre-push: lint test-all ui-test ui-build
+pre-push: lint test-all ui-test-coverage ui-build
 
 migrate:
 	./scripts/photo-org migrate

--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -284,8 +284,14 @@ class PhotosRepository:
 
         return None
 
-    def search_photos(self, filters: SearchFilters, sort: SortSpec, page: PageSpec,
-                     text_query: Optional[str] = None) -> Tuple[List[Dict[str, Any]], int, Optional[str]]:
+    def search_photos(
+        self,
+        filters: SearchFilters,
+        sort: SortSpec,
+        page: PageSpec,
+        text_query: Optional[str] = None,
+        include_face_info: bool = False,
+    ) -> Tuple[List[Dict[str, Any]], int, Optional[str]]:
         """
         Main search method that handles all query building and execution.
         Returns: (items, total_count, next_cursor)
@@ -304,7 +310,7 @@ class PhotosRepository:
         rows = list(self.db.execute(query).all())
         
         # Hydrate results with related data
-        items = self._hydrate_items(rows)
+        items = self._hydrate_items(rows, include_face_info=include_face_info)
         
         # Generate next cursor
         next_cursor = self._generate_cursor(items, sort) if items else None
@@ -347,7 +353,7 @@ class PhotosRepository:
         if not rows:
             return None
 
-        item = self._hydrate_items(rows, include_face_regions=True)[0]
+        item = self._hydrate_items(rows, include_face_info=True)[0]
         row = rows[0]
         exif_attributes = self._load_photo_exif_attributes(photo_id)
         exif_unmapped_attributes = self._load_photo_exif_unmapped_attributes(photo_id)
@@ -835,7 +841,7 @@ class PhotosRepository:
             self.photos.c.shot_ts.is_(None),
         )
 
-    def _hydrate_items(self, rows: List[Row], *, include_face_regions: bool = False) -> List[Dict[str, Any]]:
+    def _hydrate_items(self, rows: List[Row], *, include_face_info: bool = False) -> List[Dict[str, Any]]:
         """Hydrate photo rows with related data (tags, people, faces)."""
         if not rows:
             return []
@@ -856,7 +862,7 @@ class PhotosRepository:
 
         # Load faces and people
         face_columns = [self.faces.c.photo_id, self.faces.c.face_id, self.faces.c.person_id]
-        if include_face_regions:
+        if include_face_info:
             face_columns.extend(
                 [
                     self.faces.c.bbox_x,
@@ -876,6 +882,15 @@ class PhotosRepository:
             .order_by(self.faces.c.photo_id, self.faces.c.face_id)
         ).all()
         face_ids = sorted({str(r.face_id) for r in face_rows if r.face_id is not None})
+        assigned_person_ids = sorted({str(r.person_id) for r in face_rows if r.person_id is not None})
+        person_display_name_by_id: Dict[str, str] = {}
+        if assigned_person_ids:
+            for row in self.db.execute(
+                select(self.people.c.person_id, self.people.c.display_name).where(
+                    self.people.c.person_id.in_(assigned_person_ids)
+                )
+            ).all():
+                person_display_name_by_id[str(row.person_id)] = str(row.display_name)
 
         provenance_map: Dict[tuple[str, str], Dict[str, Any]] = {}
         labeled_face_keys = {
@@ -884,7 +899,7 @@ class PhotosRepository:
             if r.person_id is not None and r.face_id is not None
         }
         if labeled_face_keys:
-            face_ids = sorted({face_id for face_id, _ in labeled_face_keys})
+            labeled_face_ids = sorted({face_id for face_id, _ in labeled_face_keys})
             label_rows = (
                 self.db.execute(
                     select(
@@ -898,7 +913,7 @@ class PhotosRepository:
                         self.face_labels.c.updated_ts,
                         self.face_labels.c.face_label_id,
                     )
-                    .where(self.face_labels.c.face_id.in_(face_ids))
+                    .where(self.face_labels.c.face_id.in_(labeled_face_ids))
                     .order_by(
                         self.face_labels.c.face_id,
                         self.face_labels.c.person_id,
@@ -985,8 +1000,28 @@ class PhotosRepository:
                 "confidence": provenance["confidence"] if provenance else None,
                 "suggestions": suggestion_map.get(str(r.face_id), []),
             }
-            if include_face_regions:
+            if include_face_info:
                 bbox_space_width, bbox_space_height = _extract_bbox_space_dimensions(r.provenance)
+                face_id = str(r.face_id) if r.face_id is not None else ""
+                suggestions = suggestion_map.get(face_id, [])
+                if (
+                    not suggestions
+                    and provenance is not None
+                    and r.person_id is not None
+                    and provenance.get("label_source") == "machine_suggested"
+                    and isinstance(provenance.get("confidence"), (float, int))
+                ):
+                    person_id = str(r.person_id)
+                    suggestions = [
+                        {
+                            "person_id": person_id,
+                            "display_name": person_display_name_by_id.get(person_id, person_id),
+                            "rank": 1,
+                            "confidence": float(provenance["confidence"]),
+                            "model_version": provenance.get("model_version"),
+                            "provenance": provenance.get("provenance"),
+                        }
+                    ]
                 face_item.update(
                     {
                         "face_id": r.face_id,
@@ -1001,9 +1036,15 @@ class PhotosRepository:
                         "model_version": provenance["model_version"] if provenance else None,
                         "provenance": provenance["provenance"] if provenance else None,
                         "label_recorded_ts": provenance["label_recorded_ts"] if provenance else None,
-                        "suggestions": suggestion_map.get(str(r.face_id), []),
+                        "suggestions": suggestions,
                     }
                 )
+                if r.person_id is not None:
+                    person_id = str(r.person_id)
+                    face_item["assigned_person"] = {
+                        "person_id": person_id,
+                        "display_name": person_display_name_by_id.get(person_id, person_id),
+                    }
             faces_map[r.photo_id].append(face_item)
 
         original_map = self._load_original_availability(pids)

--- a/apps/api/app/schemas/search_request.py
+++ b/apps/api/app/schemas/search_request.py
@@ -113,5 +113,6 @@ class SearchRequest(BaseModel):
     filters: SearchFilters = SearchFilters()
     sort: SortSpec = SortSpec()
     page: PageSpec = PageSpec()
+    include_face_info: bool = False
     vector: Optional[VectorSpec] = None
     similarity_k: Optional[int] = None

--- a/apps/api/app/schemas/search_response.py
+++ b/apps/api/app/schemas/search_response.py
@@ -2,10 +2,26 @@ from pydantic import BaseModel
 from typing import List, Optional, Dict, Any
 
 
+class AssignedPersonHit(BaseModel):
+    person_id: str
+    display_name: str
+
+
 class FaceHit(BaseModel):
+    face_id: Optional[str] = None
     person_id: Optional[str] = None
+    assigned_person: Optional[AssignedPersonHit] = None
+    bbox_x: Optional[float] = None
+    bbox_y: Optional[float] = None
+    bbox_w: Optional[float] = None
+    bbox_h: Optional[float] = None
+    bbox_space_width: Optional[float] = None
+    bbox_space_height: Optional[float] = None
     label_source: Optional[str] = None
     confidence: Optional[float] = None
+    model_version: Optional[str] = None
+    provenance: Optional[Dict[str, Any]] = None
+    label_recorded_ts: Optional[str] = None
     suggestions: List[Dict[str, Any]] = []
 
 

--- a/apps/api/app/services/search_service.py
+++ b/apps/api/app/services/search_service.py
@@ -10,13 +10,18 @@ class SearchService:
 
     def execute(self, req: SearchRequest) -> SearchResponse:
         """Execute search based on the request and return SearchResponse."""
-        
+        search_kwargs: Dict[str, Any] = {
+            "filters": req.filters,
+            "sort": req.sort,
+            "page": req.page,
+            "text_query": req.q,
+        }
+        if req.include_face_info:
+            search_kwargs["include_face_info"] = True
+
         # Use repository for all data access
         items, total, next_cursor = self.repo.search_photos(
-            filters=req.filters,
-            sort=req.sort,
-            page=req.page,
-            text_query=req.q
+            **search_kwargs
         )
 
         # Get filtered photo IDs for facet computation

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -509,6 +509,152 @@ class TestSearchServiceExecution:
         assert response.facets["date"]["years"] == []
         assert response.facets["duplicates"]["exact"] == 0
 
+    def test_given_include_face_info_when_executing_search_then_passes_flag_to_repository(self):
+        mock_repo = Mock()
+        service = SearchService(repo=mock_repo)
+
+        mock_repo.search_photos.return_value = ([], 0, None)
+        mock_repo.get_filtered_photo_ids.return_value = []
+        mock_repo.compute_facets.return_value = {}
+
+        request = SearchRequest(
+            filters=SearchFilters(),
+            sort=SortSpec(by="shot_ts", dir="desc"),
+            page=PageSpec(limit=50),
+            include_face_info=True,
+        )
+
+        service.execute(request)
+
+        mock_repo.search_photos.assert_called_once_with(
+            filters=request.filters,
+            sort=request.sort,
+            page=request.page,
+            text_query=None,
+            include_face_info=True,
+        )
+
+
+def test_search_repository_include_face_info_keeps_suggestions_for_unlabeled_faces_when_labeled_faces_exist(
+    tmp_path,
+):
+    database_url = f"sqlite:///{tmp_path / 'search-include-face-info-suggestions.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 4, 3, tzinfo=UTC)
+
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                path="seed-corpus/family/image_001.jpg",
+                sha256="a" * 64,
+                phash=None,
+                filesize=100,
+                ext="jpg",
+                created_ts=now,
+                modified_ts=now,
+                shot_ts=now,
+                shot_ts_source=None,
+                camera_make=None,
+                camera_model=None,
+                software=None,
+                orientation=None,
+                gps_latitude=None,
+                gps_longitude=None,
+                gps_altitude=None,
+                updated_ts=now,
+                deleted_ts=None,
+                faces_count=2,
+                faces_detected_ts=now,
+            )
+        )
+        connection.execute(
+            insert(people),
+            [
+                {"person_id": "person-1", "display_name": "Alex", "created_ts": now, "updated_ts": now},
+                {"person_id": "person-2", "display_name": "Blair", "created_ts": now, "updated_ts": now},
+            ],
+        )
+        connection.execute(
+            insert(faces),
+            [
+                {
+                    "face_id": "face-labeled",
+                    "photo_id": "photo-1",
+                    "person_id": "person-1",
+                    "bbox_x": 0,
+                    "bbox_y": 0,
+                    "bbox_w": 10,
+                    "bbox_h": 10,
+                    "bitmap": None,
+                    "embedding": None,
+                    "detector_name": "seed",
+                    "detector_version": "1",
+                    "provenance": None,
+                    "created_ts": now,
+                },
+                {
+                    "face_id": "face-unlabeled",
+                    "photo_id": "photo-1",
+                    "person_id": None,
+                    "bbox_x": 10,
+                    "bbox_y": 10,
+                    "bbox_w": 10,
+                    "bbox_h": 10,
+                    "bitmap": None,
+                    "embedding": None,
+                    "detector_name": "seed",
+                    "detector_version": "1",
+                    "provenance": None,
+                    "created_ts": now,
+                },
+            ],
+        )
+        connection.execute(
+            insert(face_labels).values(
+                face_label_id="label-1",
+                face_id="face-labeled",
+                person_id="person-1",
+                label_source="human_confirmed",
+                confidence=1.0,
+                model_version="recognition-v1",
+                provenance=None,
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        connection.execute(
+                insert(face_suggestions).values(
+                    face_suggestion_id="suggestion-1",
+                    face_id="face-unlabeled",
+                    person_id="person-2",
+                    confidence=0.82,
+                    rank=1,
+                    scoring_version="hybrid-v1",
+                    model_version="recognition-v1",
+                    provenance=None,
+                    created_ts=now,
+                updated_ts=now,
+            )
+        )
+
+    with Session(engine) as session:
+        repo = PhotosRepository(session)
+        items, total, _ = repo.search_photos(
+            filters=SearchFilters(),
+            sort=SortSpec(by="shot_ts", dir="desc"),
+            page=PageSpec(limit=50),
+            include_face_info=True,
+        )
+
+    assert total == 1
+    assert len(items) == 1
+    faces_payload = items[0]["faces"]
+    unlabeled_face = next(face for face in faces_payload if face["face_id"] == "face-unlabeled")
+    assert len(unlabeled_face["suggestions"]) == 1
+    assert unlabeled_face["suggestions"][0]["display_name"] == "Blair"
+
 
 class TestSearchServiceFacetComputation:
     """Test facet computation coordination."""

--- a/apps/ui/src/pages/FaceBBoxOverlay.test.tsx
+++ b/apps/ui/src/pages/FaceBBoxOverlay.test.tsx
@@ -58,6 +58,52 @@ describe("FaceBBoxOverlay", () => {
     expect(regions[0]!.heightPercent).toBeCloseTo(46.666666666666664, 8);
   });
 
+  it("interprets normalized coordinate-space values", () => {
+    const regions = buildFaceOverlayRegions(
+      [
+        {
+          face_id: "face-1",
+          person_id: null,
+          bbox_x: 0.1,
+          bbox_y: 0.2,
+          bbox_w: 0.3,
+          bbox_h: 0.4
+        }
+      ],
+      160,
+      120
+    );
+
+    expect(regions).toHaveLength(1);
+    expect(regions[0]!.leftPercent).toBeCloseTo(10, 8);
+    expect(regions[0]!.topPercent).toBeCloseTo(20, 8);
+    expect(regions[0]!.widthPercent).toBeCloseTo(30, 8);
+    expect(regions[0]!.heightPercent).toBeCloseTo(40, 8);
+  });
+
+  it("treats small numeric coordinates as thumbnail-space pixels when no explicit space is provided", () => {
+    const regions = buildFaceOverlayRegions(
+      [
+        {
+          face_id: "face-1",
+          person_id: null,
+          bbox_x: 10,
+          bbox_y: 20,
+          bbox_w: 30,
+          bbox_h: 40
+        }
+      ],
+      160,
+      120
+    );
+
+    expect(regions).toHaveLength(1);
+    expect(regions[0]!.leftPercent).toBeCloseTo(6.25, 8);
+    expect(regions[0]!.topPercent).toBeCloseTo(16.666666666666668, 8);
+    expect(regions[0]!.widthPercent).toBeCloseTo(18.75, 8);
+    expect(regions[0]!.heightPercent).toBeCloseTo(33.333333333333336, 8);
+  });
+
   it("renders region overlays and optional region content", () => {
     render(
       <FaceBBoxOverlay

--- a/apps/ui/src/pages/FaceBBoxOverlay.tsx
+++ b/apps/ui/src/pages/FaceBBoxOverlay.tsx
@@ -64,6 +64,24 @@ function inferFaceOverlayCoordinateSpace(
     return explicitCoordinateSpace;
   }
 
+  // Some payloads provide normalized [0..1] bbox values.
+  const hasNormalizedCoordinateSpace = faces.some(
+    (face) =>
+      face.bbox_x !== null &&
+      face.bbox_y !== null &&
+      face.bbox_w !== null &&
+      face.bbox_h !== null &&
+      face.bbox_x >= 0 &&
+      face.bbox_y >= 0 &&
+      face.bbox_w > 0 &&
+      face.bbox_h > 0 &&
+      face.bbox_x + face.bbox_w <= 1 &&
+      face.bbox_y + face.bbox_h <= 1
+  );
+  if (hasNormalizedCoordinateSpace) {
+    return { width: 1, height: 1 };
+  }
+
   // Fallback for legacy records without explicit coordinate-space dimensions.
   const coordinateSpace = faces.reduce(
     (acc, face) => {

--- a/apps/ui/src/pages/LibraryRoutePage.test.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.test.tsx
@@ -17,7 +17,14 @@ type SearchResponsePayload = {
       filesize: number;
       people: string[];
       faces: Array<{
+        face_id?: string;
         person_id: string | null;
+        bbox_x?: number | null;
+        bbox_y?: number | null;
+        bbox_w?: number | null;
+        bbox_h?: number | null;
+        bbox_space_width?: number | null;
+        bbox_space_height?: number | null;
         label_source?: "human_confirmed" | "machine_suggested" | null;
         confidence?: number | null;
         suggestions?: Array<{
@@ -302,7 +309,402 @@ describe("LibraryRoutePage", () => {
     expect(screen.queryByRole("button", { name: "Review faces" })).not.toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Select photo photo-a" })).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Show face boxes on all photos" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "Enable album assignment widgets" })
+    ).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "View details" })).not.toBeInTheDocument();
+  });
+
+  it("shows shared album assignment widgets when enabled", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      if (input === "/api/v1/albums") {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              album_id: "album-1",
+              name: "Family",
+              owner_user_id: "operator-1",
+              kind: "editable",
+              created_ts: "2026-05-08T12:00:00Z",
+              updated_ts: "2026-05-08T12:00:00Z",
+              item_count: 3,
+              saved_filter: null
+            }
+          ]
+        } as Response;
+      }
+
+      if (input === "/api/v1/albums/album-1/items") {
+        return {
+          ok: true,
+          json: async () => ({
+            album_id: "album-1",
+            added_photo_ids: ["photo-a"],
+            duplicate_photo_ids: [],
+            missing_photo_ids: []
+          })
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Album actions" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "Enable album assignment widgets" }));
+    expect(await screen.findByRole("region", { name: "Album actions" })).toBeInTheDocument();
+    await user.selectOptions(screen.getByLabelText("Album target"), "album-1");
+    await user.click(screen.getByRole("button", { name: "Add 1 photo" }));
+
+    await waitFor(() => {
+      expect(
+        fetchMock.mock.calls.some(([requestInput]) => String(requestInput) === "/api/v1/albums/album-1/items")
+      ).toBe(true);
+    });
+  });
+
+  it("shows face action widgets when face boxes are enabled", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      const payload = buildPayload(["photo-a"]);
+      payload.hits.items[0].thumbnail = {
+        mime_type: "image/jpeg",
+        width: 120,
+        height: 80,
+        data_base64: "dGh1bWI="
+      };
+      payload.hits.items[0].faces = [
+        {
+          face_id: "face-1",
+          person_id: null
+        }
+      ];
+
+      return {
+        ok: true,
+        json: async () => payload
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Open face 1 actions" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "Show face boxes on all photos" }));
+    expect(await screen.findByRole("button", { name: "Open face 1 actions" })).toBeInTheDocument();
+  });
+
+  it("does not fan out per-photo detail requests when face boxes are enabled", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      const payload = buildPayload(["photo-a", "photo-b"]);
+      payload.hits.items[0].thumbnail = {
+        mime_type: "image/jpeg",
+        width: 120,
+        height: 80,
+        data_base64: "dGh1bWI="
+      };
+      payload.hits.items[1].thumbnail = {
+        mime_type: "image/jpeg",
+        width: 120,
+        height: 80,
+        data_base64: "dGh1bWI="
+      };
+      payload.hits.items[0].faces = [{ face_id: "face-a", person_id: null, bbox_x: 1, bbox_y: 1, bbox_w: 10, bbox_h: 10 }];
+      payload.hits.items[1].faces = [{ face_id: "face-b", person_id: null, bbox_x: 1, bbox_y: 1, bbox_w: 10, bbox_h: 10 }];
+
+      return {
+        ok: true,
+        json: async () => payload
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "Show face boxes on all photos" }));
+
+    await screen.findAllByRole("button", { name: "Open face 1 actions" });
+
+    const detailCalls = fetchMock.mock.calls.filter(([requestInput]) => String(requestInput).startsWith("/api/v1/photos/"));
+    expect(detailCalls).toHaveLength(0);
+  });
+
+  it("requests search face regions when face boxes are enabled", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(async (input: string, init?: RequestInit) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      if (input === "/api/v1/search") {
+        return {
+          ok: true,
+          json: async () => buildPayload(["photo-a"])
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => []
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+
+    const initialSearchCall = fetchMock.mock.calls.find(([requestInput]) => requestInput === "/api/v1/search");
+    expect(initialSearchCall).toBeDefined();
+    const initialSearchBody = JSON.parse(String(initialSearchCall?.[1]?.body ?? "{}")) as Record<string, unknown>;
+    expect(initialSearchBody.include_face_info).toBeUndefined();
+
+    await user.click(screen.getByRole("checkbox", { name: "Show face boxes on all photos" }));
+
+    await waitFor(() => {
+      const searchCalls = fetchMock.mock.calls.filter(([requestInput]) => requestInput === "/api/v1/search");
+      expect(searchCalls.length).toBeGreaterThan(1);
+    });
+
+    const latestSearchCall = fetchMock.mock.calls
+      .filter(([requestInput]) => requestInput === "/api/v1/search")
+      .at(-1);
+    const latestSearchBody = JSON.parse(String(latestSearchCall?.[1]?.body ?? "{}")) as Record<string, unknown>;
+    expect(latestSearchBody.include_face_info).toBe(true);
+  });
+
+  it("keeps face assignment modal open when detail face ids differ from library search payload", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      if (input === "/api/v1/photos/photo-a") {
+        return {
+          ok: true,
+          json: async () => ({
+            ...buildPhotoDetailPayload("photo-a"),
+            faces: [
+              {
+                face_id: "face-real-1",
+                person_id: null,
+                bbox_x: 12,
+                bbox_y: 14,
+                bbox_w: 20,
+                bbox_h: 24,
+                bbox_space_width: 120,
+                bbox_space_height: 80,
+                label_source: null,
+                confidence: null,
+                model_version: null,
+                provenance: null,
+                label_recorded_ts: null,
+                suggestions: []
+              }
+            ],
+            thumbnail: {
+              mime_type: "image/jpeg",
+              width: 120,
+              height: 80,
+              data_base64: "dGh1bWI="
+            }
+          })
+        } as Response;
+      }
+
+      const payload = buildPayload(["photo-a"]);
+      payload.hits.items[0].thumbnail = {
+        mime_type: "image/jpeg",
+        width: 120,
+        height: 80,
+        data_base64: "dGh1bWI="
+      };
+      payload.hits.items[0].faces = [
+        {
+          person_id: null,
+          bbox_x: 0.1,
+          bbox_y: 0.2,
+          bbox_w: 0.2,
+          bbox_h: 0.2
+        }
+      ];
+
+      return {
+        ok: true,
+        json: async () => payload
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "Show face boxes on all photos" }));
+    await user.click(await screen.findByRole("button", { name: "Open face 1 actions" }));
+
+    expect(await screen.findByRole("dialog", { name: "Face assignment" })).toBeInTheDocument();
+    expect(
+      fetchMock.mock.calls.some(([requestInput]) => String(requestInput) === "/api/v1/photos/photo-a")
+    ).toBe(false);
+    expect(screen.getByRole("dialog", { name: "Face assignment" })).toBeInTheDocument();
+  });
+
+  it("updates face label locally after saving assignment from the modal", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      if (url === "/api/v1/people") {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              person_id: "person-1",
+              display_name: "Inez",
+              created_ts: "2026-05-09T12:00:00Z",
+              updated_ts: "2026-05-09T12:00:00Z"
+            }
+          ]
+        } as Response;
+      }
+
+      if (url === "/api/v1/faces/face-1/candidates?enforce_min_confidence=false") {
+        return {
+          ok: true,
+          json: async () => ({
+            face_id: "face-1",
+            candidates: [
+              {
+                person_id: "person-1",
+                display_name: "Inez",
+                matched_face_id: "face-7",
+                distance: 0.11,
+                confidence: 0.88
+              }
+            ],
+            suggestion_policy: {
+              decision: "review_needed",
+              review_threshold: 0.5,
+              auto_accept_threshold: 0.9,
+              top_candidate_confidence: 0.88
+            },
+            review_needed_suggestion: null,
+            auto_applied_assignment: null
+          })
+        } as Response;
+      }
+
+      if (url === "/api/v1/faces/face-1/assignments" && init?.method === "POST") {
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({
+            face_id: "face-1",
+            photo_id: "photo-a",
+            person_id: "person-1"
+          })
+        } as Response;
+      }
+
+      const payload = buildPayload(["photo-a"]);
+      payload.hits.items[0].thumbnail = {
+        mime_type: "image/jpeg",
+        width: 120,
+        height: 80,
+        data_base64: "dGh1bWI="
+      };
+      payload.hits.items[0].faces = [
+        {
+          face_id: "face-1",
+          person_id: null,
+          bbox_x: 10,
+          bbox_y: 10,
+          bbox_w: 30,
+          bbox_h: 30,
+          bbox_space_width: 120,
+          bbox_space_height: 80,
+          suggestions: [
+            {
+              person_id: "person-top",
+              display_name: "Alex",
+              rank: 1,
+              confidence: 0.92,
+              model_version: "recognition-v1",
+              provenance: null
+            }
+          ]
+        }
+      ];
+
+      return {
+        ok: true,
+        json: async () => payload
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "Show face boxes on all photos" }));
+    const openFaceButton = await screen.findByRole("button", { name: "Open face 1 actions" });
+    expect(openFaceButton).toHaveTextContent("Alex");
+
+    await user.click(openFaceButton);
+    expect(await screen.findByRole("dialog", { name: "Face assignment" })).toBeInTheDocument();
+
+    const assignPersonInput = screen.getByLabelText("Assign person");
+    await user.clear(assignPersonInput);
+    await user.type(assignPersonInput, "Inez");
+    await user.click(screen.getByRole("button", { name: "Save and close" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Face assignment" })).not.toBeInTheDocument();
+    });
+    expect(await screen.findByRole("button", { name: "Open face 1 actions" })).toHaveTextContent("Inez");
+    expect(
+      fetchMock.mock.calls.some(([requestInput]) => String(requestInput) === "/api/v1/photos/photo-a")
+    ).toBe(false);
   });
 
   it("deduplicates initial strict-mode service requests", async () => {
@@ -495,7 +897,7 @@ describe("LibraryRoutePage", () => {
     renderLibraryAt("/library");
     expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
 
-    expect(screen.getByText("Faces detected/assigned: 4/2 - 2 suggestions")).toBeInTheDocument();
+    expect(screen.queryByText(/Faces detected\/assigned:/i)).not.toBeInTheDocument();
     expect(screen.queryByText("People assigned (human)")).not.toBeInTheDocument();
     expect(screen.queryByText("Machine suggestions")).not.toBeInTheDocument();
   });

--- a/apps/ui/src/pages/LibraryRoutePage.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.tsx
@@ -8,6 +8,8 @@ import { resolveInitialSessionIdentity } from "../session/sessionIdentity";
 import { LibraryActionBar } from "./library/LibraryActionBar";
 import { LibraryActiveFilterChips } from "./library/LibraryActiveFilterChips";
 import {
+  addPhotosToAlbum,
+  createAlbum,
   DEFAULT_SEARCH_PAGE_LIMIT,
   fetchAlbums,
   fetchPeopleDirectory,
@@ -41,6 +43,7 @@ import {
   adaptLibraryPhoto,
   adaptPhotoDetail
 } from "./photo-interactions/photoInteractionAdapters";
+import type { PhotoSummary } from "./photo-interactions/photoInteractionTypes";
 import { FaceAssignmentModal } from "./photo-interactions/FaceAssignmentModal";
 import { PhotoMetadataFlyout } from "./photo-interactions/PhotoMetadataFlyout";
 import {
@@ -110,6 +113,65 @@ function toEditableAlbumOptions(albums: AlbumRecord[]): Array<{ albumId: string;
     .sort((left, right) => left.albumName.localeCompare(right.albumName, "en-US"));
 }
 
+function isPhotoDetailPayload(value: unknown): value is PhotoDetailPayload {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<PhotoDetailPayload>;
+  return (
+    typeof candidate.photo_id === "string"
+    && typeof candidate.path === "string"
+    && Array.isArray(candidate.faces)
+  );
+}
+
+type FaceAssignmentOverride = {
+  personId: string;
+  displayName: string | null;
+};
+
+function applyFaceAssignmentOverrides(
+  summary: PhotoSummary,
+  overridesByFaceId: Record<string, FaceAssignmentOverride> | undefined
+): PhotoSummary {
+  if (!overridesByFaceId || Object.keys(overridesByFaceId).length === 0) {
+    return summary;
+  }
+
+  let hasChanges = false;
+  const nextFaces = summary.faces.map((face) => {
+    const override = overridesByFaceId[face.faceId];
+    if (!override) {
+      return face;
+    }
+
+    hasChanges = true;
+    return {
+      ...face,
+      personId: override.personId,
+      assignedPerson: override.displayName
+        ? {
+            personId: override.personId,
+            displayName: override.displayName
+          }
+        : null,
+      canAssign: false,
+      canCorrect: true,
+      canDismiss: false,
+      canConfirm: false
+    };
+  });
+
+  if (!hasChanges) {
+    return summary;
+  }
+
+  return {
+    ...summary,
+    faces: nextFaces
+  };
+}
+
 export function LibraryRoutePage() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -175,6 +237,9 @@ export function LibraryRoutePage() {
   const [albumOptions, setAlbumOptions] = useState<Array<{ albumId: string; albumName: string }>>(
     []
   );
+  const [isAlbumInteractionEnabled, setIsAlbumInteractionEnabled] = useState(false);
+  const [isAlbumActionSubmitting, setIsAlbumActionSubmitting] = useState(false);
+  const [albumActionResultByPhotoId, setAlbumActionResultByPhotoId] = useState<Record<string, string>>({});
 
   const [sortDirection, setSortDirection] = useState<SortDirection>(
     initialReturnState?.libraryViewState?.sortDirection
@@ -196,6 +261,9 @@ export function LibraryRoutePage() {
     DEFAULT_PHOTO_INSPECTOR_STATE
   );
   const [photoDetailById, setPhotoDetailById] = useState<Record<string, PhotoDetailPayload>>({});
+  const [faceAssignmentOverridesByPhotoId, setFaceAssignmentOverridesByPhotoId] = useState<
+    Record<string, Record<string, FaceAssignmentOverride>>
+  >({});
   const [loadingPhotoDetailId, setLoadingPhotoDetailId] = useState<string | null>(null);
   const [photoDetailErrorById, setPhotoDetailErrorById] = useState<Record<string, string>>({});
   const pendingReturnFocusPhotoIdRef = useRef<string | null>(
@@ -231,6 +299,16 @@ export function LibraryRoutePage() {
     }
     return next;
   }, [albumOptions]);
+  const albumTargets = useMemo(
+    () =>
+      albumOptions.map((option) => ({
+        albumId: option.albumId,
+        name: option.albumName,
+        kind: "manual" as const,
+        canAcceptManualAdditions: true
+      })),
+    [albumOptions]
+  );
 
   const libraryViewRouteState = useMemo<LibraryViewRouteState>(
     () => ({
@@ -268,7 +346,8 @@ export function LibraryRoutePage() {
     requestedPage,
     pageSize,
     dateRangeError,
-    locationError
+    locationError,
+    includeFaceInfo: photoInspectorState.areFaceBoxesVisible
   });
   const applyParsedUrlState = useCallback(
     (nextParsedState: SearchUrlState, shouldApplyViewState: boolean) => {
@@ -389,10 +468,35 @@ export function LibraryRoutePage() {
   const photoSummaryById = useMemo(() => {
     const next = new Map<string, ReturnType<typeof adaptLibraryPhoto>>();
     for (const photo of photos) {
-      next.set(photo.photo_id, adaptLibraryPhoto(photo));
+      const baseSummary = adaptLibraryPhoto(photo);
+      next.set(
+        photo.photo_id,
+        applyFaceAssignmentOverrides(baseSummary, faceAssignmentOverridesByPhotoId[photo.photo_id])
+      );
     }
     return next;
-  }, [photos]);
+  }, [faceAssignmentOverridesByPhotoId, photos]);
+
+  const photoSurfaceSummaryById = useMemo(() => {
+    const next = new Map<string, ReturnType<typeof adaptLibraryPhoto>>();
+    for (const photo of photos) {
+      const baseSummary = adaptLibraryPhoto(photo);
+      const detailPayload = photoDetailById[photo.photo_id];
+      if (isPhotoDetailPayload(detailPayload)) {
+        const detailSummary = adaptPhotoDetail(detailPayload);
+        next.set(photo.photo_id, {
+          ...baseSummary,
+          faces: detailSummary.faces
+        });
+      } else {
+        next.set(
+          photo.photo_id,
+          applyFaceAssignmentOverrides(baseSummary, faceAssignmentOverridesByPhotoId[photo.photo_id])
+        );
+      }
+    }
+    return next;
+  }, [faceAssignmentOverridesByPhotoId, photoDetailById, photos]);
 
   const visiblePhotoIds = useMemo(() => new Set(photos.map((photo) => photo.photo_id)), [photos]);
 
@@ -403,8 +507,19 @@ export function LibraryRoutePage() {
     });
   }, [visiblePhotoIds]);
 
-  const activeInspectorPhotoId =
-    photoInspectorState.activeMetadataPhotoId ?? photoInspectorState.activeFaceAssignment?.photoId ?? null;
+  useEffect(() => {
+    setFaceAssignmentOverridesByPhotoId((current) => {
+      const nextEntries = Object.entries(current).filter(([photoId]) =>
+        photos.some((photo) => photo.photo_id === photoId)
+      );
+      if (nextEntries.length === Object.keys(current).length) {
+        return current;
+      }
+      return Object.fromEntries(nextEntries);
+    });
+  }, [photos]);
+
+  const activeInspectorPhotoId = photoInspectorState.activeMetadataPhotoId;
 
   const loadPhotoInspectorDetail = useCallback(
     async (photoId: string, force: boolean, signal?: AbortSignal) => {
@@ -531,34 +646,80 @@ export function LibraryRoutePage() {
     photoInspectorState.activeMetadataPhotoId !== null
     && loadingPhotoDetailId === photoInspectorState.activeMetadataPhotoId;
 
-  const activeFaceSummary = useMemo(() => {
+  const activeFaceContext = useMemo(() => {
     const activeFaceAssignment = photoInspectorState.activeFaceAssignment;
     if (!activeFaceAssignment) {
       return null;
     }
 
-    const detail = photoDetailById[activeFaceAssignment.photoId];
+    const summary = photoSummaryById.get(activeFaceAssignment.photoId) ?? null;
+    const detailPayload = photoDetailById[activeFaceAssignment.photoId];
+    const detail = isPhotoDetailPayload(detailPayload) ? adaptPhotoDetail(detailPayload) : null;
+
     if (detail) {
-      return adaptPhotoDetail(detail);
+      const directMatch = detail.faces.find((face) => face.faceId === activeFaceAssignment.faceId) ?? null;
+      if (directMatch) {
+        return {
+          photo: detail,
+          face: directMatch
+        };
+      }
+
+      if (
+        typeof activeFaceAssignment.faceIndex === "number"
+        && activeFaceAssignment.faceIndex >= 0
+        && activeFaceAssignment.faceIndex < detail.faces.length
+      ) {
+        return {
+          photo: detail,
+          face: detail.faces[activeFaceAssignment.faceIndex]
+        };
+      }
     }
 
-    return photoSummaryById.get(activeFaceAssignment.photoId) ?? null;
-  }, [photoDetailById, photoInspectorState.activeFaceAssignment, photoSummaryById]);
-
-  const activeFace = useMemo(() => {
-    const activeFaceAssignment = photoInspectorState.activeFaceAssignment;
-    if (!activeFaceAssignment || !activeFaceSummary) {
+    if (!summary) {
       return null;
     }
 
-    return activeFaceSummary.faces.find((face) => face.faceId === activeFaceAssignment.faceId) ?? null;
-  }, [activeFaceSummary, photoInspectorState.activeFaceAssignment]);
+    const directMatch = summary.faces.find((face) => face.faceId === activeFaceAssignment.faceId) ?? null;
+    if (directMatch) {
+      return {
+        photo: summary,
+        face: directMatch
+      };
+    }
+
+    if (
+      typeof activeFaceAssignment.faceIndex === "number"
+      && activeFaceAssignment.faceIndex >= 0
+      && activeFaceAssignment.faceIndex < summary.faces.length
+    ) {
+      return {
+        photo: summary,
+        face: summary.faces[activeFaceAssignment.faceIndex]
+      };
+    }
+
+    return null;
+  }, [photoDetailById, photoInspectorState.activeFaceAssignment, photoSummaryById]);
 
   function handleFaceUpdated(faceId: string, personId: string) {
     const activeFaceAssignment = photoInspectorState.activeFaceAssignment;
     if (!activeFaceAssignment) {
       return;
     }
+
+    const matchedPerson = peopleDirectory.find((person) => person.person_id === personId) ?? null;
+    setFaceAssignmentOverridesByPhotoId((current) => ({
+      ...current,
+      [activeFaceAssignment.photoId]: {
+        ...(current[activeFaceAssignment.photoId] ?? {}),
+        [faceId]: {
+          personId,
+          displayName: matchedPerson?.display_name ?? null
+        }
+      }
+    }));
 
     setPhotoDetailById((current) => {
       const detail = current[activeFaceAssignment.photoId];
@@ -749,6 +910,81 @@ export function LibraryRoutePage() {
     setPage(nextPage);
   }
 
+  async function handleAddToAlbum(albumId: string, photoIds: string[], sourcePhotoId: string) {
+    if (isAlbumActionSubmitting) {
+      return;
+    }
+
+    const userId = resolveInitialSessionIdentity()?.userId ?? null;
+    setIsAlbumActionSubmitting(true);
+    setAlbumActionResultByPhotoId((current) => {
+      const next = { ...current };
+      delete next[sourcePhotoId];
+      return next;
+    });
+    try {
+      const result = await addPhotosToAlbum(albumId, photoIds, userId);
+      const details: string[] = [];
+      if (result.duplicate_photo_ids.length > 0) {
+        details.push(`${result.duplicate_photo_ids.length} already in album`);
+      }
+      if (result.missing_photo_ids.length > 0) {
+        details.push(`${result.missing_photo_ids.length} missing`);
+      }
+      const summary = `Added ${result.added_photo_ids.length} photo${result.added_photo_ids.length === 1 ? "" : "s"} to album.`;
+      setAlbumActionResultByPhotoId((current) => ({
+        ...current,
+        [sourcePhotoId]: details.length > 0 ? `${summary} (${details.join(", ")}).` : summary
+      }));
+    } catch (caughtError: unknown) {
+      setAlbumActionResultByPhotoId((current) => ({
+        ...current,
+        [sourcePhotoId]:
+          caughtError instanceof Error ? caughtError.message : "Could not add photos to album."
+      }));
+    } finally {
+      setIsAlbumActionSubmitting(false);
+    }
+  }
+
+  async function handleCreateAlbumAndAdd(name: string, photoIds: string[], sourcePhotoId: string) {
+    if (isAlbumActionSubmitting) {
+      return;
+    }
+
+    const userId = resolveInitialSessionIdentity()?.userId ?? null;
+    setIsAlbumActionSubmitting(true);
+    setAlbumActionResultByPhotoId((current) => {
+      const next = { ...current };
+      delete next[sourcePhotoId];
+      return next;
+    });
+    try {
+      const created = await createAlbum({ name, kind: "editable" }, userId);
+      await addPhotosToAlbum(created.album_id, photoIds, userId);
+      setAlbumOptions((current) => {
+        if (current.some((option) => option.albumId === created.album_id)) {
+          return current;
+        }
+        return [...current, { albumId: created.album_id, albumName: created.name }].sort((left, right) =>
+          left.albumName.localeCompare(right.albumName, "en-US")
+        );
+      });
+      setAlbumActionResultByPhotoId((current) => ({
+        ...current,
+        [sourcePhotoId]: `Created album "${created.name}" and added ${photoIds.length} photo${photoIds.length === 1 ? "" : "s"}.`
+      }));
+    } catch (caughtError: unknown) {
+      setAlbumActionResultByPhotoId((current) => ({
+        ...current,
+        [sourcePhotoId]:
+          caughtError instanceof Error ? caughtError.message : "Could not create album."
+      }));
+    } finally {
+      setIsAlbumActionSubmitting(false);
+    }
+  }
+
   return (
     <section aria-labelledby="page-title" className="page browse-page">
       <LibraryRouteHeader
@@ -908,6 +1144,7 @@ export function LibraryRoutePage() {
         selectionState={selectionState}
         activeScopeCount={activeScopeCount}
         areFaceBoxesVisible={photoInspectorState.areFaceBoxesVisible}
+        areAlbumInteractionsVisible={isAlbumInteractionEnabled}
         onSetScope={(scope) =>
           dispatchSelection({
             type: "setScope",
@@ -921,6 +1158,12 @@ export function LibraryRoutePage() {
             type: "setFaceBoxesVisible",
             visible
           });
+        }}
+        onAlbumInteractionsVisibleChange={(visible) => {
+          setIsAlbumInteractionEnabled(visible);
+          if (!visible) {
+            setAlbumActionResultByPhotoId({});
+          }
         }}
       />
 
@@ -972,17 +1215,28 @@ export function LibraryRoutePage() {
         {!error && !isLoading && photos.length > 0 ? (
           <LibraryPhotoGrid
             photos={photos}
+            photoSummaryById={photoSurfaceSummaryById}
             locationSearch={location.search}
             selectionRouteState={selectionRouteState}
             libraryViewRouteState={libraryViewRouteState}
             selectedPhotoIds={selectionState.selectedPhotoIds}
             faceBoxesVisible={photoInspectorState.areFaceBoxesVisible}
             activeMetadataPhotoId={photoInspectorState.activeMetadataPhotoId}
+            albumAssignmentWidgetsVisible={isAlbumInteractionEnabled}
+            albumTargets={albumTargets}
+            albumActionResultByPhotoId={albumActionResultByPhotoId}
+            isAlbumActionSubmitting={isAlbumActionSubmitting}
             onTogglePhotoSelection={(photoId) => {
               dispatchSelection({
                 type: "togglePhotoSelection",
                 photoId
               });
+            }}
+            onAddSinglePhotoToAlbum={(photoId, albumId) => {
+              void handleAddToAlbum(albumId, [photoId], photoId);
+            }}
+            onCreateAlbumAndAddSinglePhoto={(photoId, name) => {
+              void handleCreateAlbumAndAdd(name, [photoId], photoId);
             }}
             onOpenMetadata={(photoId, sourceSurfaceId) => {
               dispatchPhotoInspector({
@@ -991,11 +1245,12 @@ export function LibraryRoutePage() {
                 sourceSurfaceId
               });
             }}
-            onOpenFace={(photoId, faceId, sourceSurfaceId) => {
+            onOpenFace={(photoId, faceId, sourceSurfaceId, faceIndex) => {
               dispatchPhotoInspector({
                 type: "openFaceAssignment",
                 photoId,
                 faceId,
+                faceIndex,
                 sourceSurfaceId
               });
             }}
@@ -1037,9 +1292,9 @@ export function LibraryRoutePage() {
       />
 
       <FaceAssignmentModal
-        isOpen={activeFace !== null}
-        photo={activeFaceSummary}
-        face={activeFace}
+        isOpen={activeFaceContext !== null}
+        photo={activeFaceContext?.photo ?? null}
+        face={activeFaceContext?.face ?? null}
         people={peopleDirectory.map((person) => ({
           person_id: person.person_id,
           display_name: person.display_name

--- a/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
+++ b/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
@@ -245,8 +245,8 @@ describe("SuggestionsRoutePage", () => {
     const overlay = screen.getByRole("list", {
       name: "Detected face regions"
     });
-    expect(within(overlay).getByText("1")).toBeInTheDocument();
-    expect(within(overlay).getByText("2")).toBeInTheDocument();
+    expect(within(overlay).getByText("Alex")).toBeInTheDocument();
+    expect(within(overlay).getByText("Blair")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Previous page" })).toHaveAttribute(
       "aria-disabled",
       "true"

--- a/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
+++ b/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
@@ -256,6 +256,65 @@ describe("SuggestionsRoutePage", () => {
     expect(screen.getByRole("button", { name: "Next page" })).toHaveAttribute("aria-disabled", "false");
   });
 
+  it("supports toggling shared interaction surfaces and opens face assignment from overlay", async () => {
+    const user = userEvent.setup();
+
+    installFetchRoutes(fetchMock, {
+      "GET /api/v1/people": reply(buildPeoplePayload()),
+      "GET /api/v1/albums": reply([]),
+      "GET /api/v1/suggestions/faces?page=1&page_size=24": reply(
+        buildSuggestionsPayload({
+          items: [
+            {
+              photo_id: "photo-1",
+              path: "/photos/photo-1.jpg",
+              thumbnail: {
+                mime_type: "image/jpeg",
+                width: 64,
+                height: 48,
+                data_base64: "ZmFrZS10aHVtYi1ieXRlcw=="
+              },
+              faces: [
+                {
+                  face_id: "face-1",
+                  bbox_x: 10,
+                  bbox_y: 10,
+                  bbox_w: 20,
+                  bbox_h: 20,
+                  top_suggestion: {
+                    person_id: "person-1",
+                    display_name: "Alex",
+                    confidence: 0.97
+                  }
+                }
+              ]
+            }
+          ]
+        })
+      )
+    });
+
+    renderPage();
+
+    expect(await screen.findByLabelText("Enable face assignment interactions")).toBeChecked();
+    expect(screen.getByLabelText("Enable album interactions")).toBeChecked();
+    expect(screen.getByRole("region", { name: "Album actions" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Open face 1 actions" }));
+    expect(await screen.findByRole("dialog", { name: "Face assignment" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Close face assignment modal" }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Face assignment" })).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Enable album interactions"));
+    expect(screen.queryByRole("region", { name: "Album actions" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Enable face assignment interactions"));
+    expect(screen.queryByRole("button", { name: "Open face 1 actions" })).not.toBeInTheDocument();
+  });
+
   it("keeps photo selection separate from selected suggestion faces", async () => {
     const user = userEvent.setup();
 

--- a/apps/ui/src/pages/SuggestionsRoutePage.tsx
+++ b/apps/ui/src/pages/SuggestionsRoutePage.tsx
@@ -7,6 +7,9 @@ import {
   fetchAlbums
 } from "./library/libraryRouteApi";
 import { AlbumActionSurface } from "./photo-interactions/AlbumActionSurface";
+import { FaceAssignmentModal } from "./photo-interactions/FaceAssignmentModal";
+import { PhotoMetadataFlyout } from "./photo-interactions/PhotoMetadataFlyout";
+import { adaptSuggestionPhoto } from "./photo-interactions/photoInteractionAdapters";
 import {
   DEFAULT_PHOTO_INSPECTOR_STATE,
   photoInspectorReducer
@@ -16,6 +19,8 @@ import {
   photoSelectionReducer
 } from "./photo-interactions/photoSelectionState";
 import type { AlbumTarget } from "./photo-interactions/photoInteractionTypes";
+import { fetchPhotoDetail } from "./photo-detail/photoDetailApi";
+import type { PhotoDetailPayload } from "./photo-detail/photoDetailTypes";
 import { BrowsePagination } from "./shared/BrowsePagination";
 
 import { SuggestionsFilters } from "./suggestions/SuggestionsFilters";
@@ -65,6 +70,11 @@ export function SuggestionsRoutePage() {
   const [albumTargets, setAlbumTargets] = useState<AlbumTarget[]>([]);
   const [isAlbumActionSubmitting, setIsAlbumActionSubmitting] = useState(false);
   const [albumActionResultMessage, setAlbumActionResultMessage] = useState<string | null>(null);
+  const [isFaceInteractionEnabled, setIsFaceInteractionEnabled] = useState(true);
+  const [isAlbumInteractionEnabled, setIsAlbumInteractionEnabled] = useState(true);
+  const [photoDetailById, setPhotoDetailById] = useState<Record<string, PhotoDetailPayload>>({});
+  const [photoDetailErrorById, setPhotoDetailErrorById] = useState<Record<string, string>>({});
+  const [loadingPhotoDetailId, setLoadingPhotoDetailId] = useState<string | null>(null);
   const sessionIdentity = resolveInitialSessionIdentity();
   const sessionUserId = sessionIdentity?.userId ?? null;
 
@@ -161,6 +171,62 @@ export function SuggestionsRoutePage() {
     };
   }, [sessionUserId]);
 
+  useEffect(() => {
+    if (isFaceInteractionEnabled) {
+      return;
+    }
+    dispatchPhotoInspector({ type: "closeFaceAssignment" });
+  }, [isFaceInteractionEnabled]);
+
+  const activeInspectorPhotoId =
+    photoInspectorState.activeMetadataPhotoId ?? photoInspectorState.activeFaceAssignment?.photoId ?? null;
+
+  useEffect(() => {
+    if (!activeInspectorPhotoId || photoDetailById[activeInspectorPhotoId]) {
+      return;
+    }
+    let canceled = false;
+    setLoadingPhotoDetailId(activeInspectorPhotoId);
+    setPhotoDetailErrorById((current) => {
+      if (!current[activeInspectorPhotoId]) {
+        return current;
+      }
+      const next = { ...current };
+      delete next[activeInspectorPhotoId];
+      return next;
+    });
+
+    void fetchPhotoDetail(activeInspectorPhotoId)
+      .then((detailPayload) => {
+        if (!canceled) {
+          setPhotoDetailById((current) => ({
+            ...current,
+            [activeInspectorPhotoId]: detailPayload
+          }));
+        }
+      })
+      .catch((caughtError: unknown) => {
+        if (!canceled) {
+          setPhotoDetailErrorById((current) => ({
+            ...current,
+            [activeInspectorPhotoId]:
+              caughtError instanceof Error ? caughtError.message : "Could not load photo detail."
+          }));
+        }
+      })
+      .finally(() => {
+        if (!canceled) {
+          setLoadingPhotoDetailId((current) => (
+            current === activeInspectorPhotoId ? null : current
+          ));
+        }
+      });
+
+    return () => {
+      canceled = true;
+    };
+  }, [activeInspectorPhotoId, photoDetailById]);
+
   const currentPageFaceIdsOrdered = useMemo(() => flattenFaceIds(payload?.items ?? []), [payload]);
   const currentPagePhotoIdsOrdered = useMemo(
     () => (payload?.items ?? []).map((item) => item.photo_id),
@@ -175,6 +241,62 @@ export function SuggestionsRoutePage() {
     const selected = selectedFaceIds;
     return currentPageFaceIdsOrdered.filter((faceId) => selected.has(faceId));
   }, [currentPageFaceIdsOrdered, selectedFaceIds]);
+
+  const summaryByPhotoId = useMemo(() => {
+    const summaries = new Map<string, ReturnType<typeof adaptSuggestionPhoto>>();
+    for (const item of payload?.items ?? []) {
+      summaries.set(item.photo_id, adaptSuggestionPhoto(item));
+    }
+    return summaries;
+  }, [payload?.items]);
+
+  const activeMetadataSummary = useMemo(() => {
+    const photoId = photoInspectorState.activeMetadataPhotoId;
+    if (!photoId) {
+      return null;
+    }
+    const summary = summaryByPhotoId.get(photoId);
+    if (summary) {
+      return {
+        photoId: summary.photoId,
+        title: summary.title,
+        path: summary.path,
+        thumbnail: summary.media.thumbnail
+      };
+    }
+    return {
+      photoId,
+      title: photoId,
+      path: photoId,
+      thumbnail: null
+    };
+  }, [photoInspectorState.activeMetadataPhotoId, summaryByPhotoId]);
+
+  const activeMetadataDetail = photoInspectorState.activeMetadataPhotoId
+    ? photoDetailById[photoInspectorState.activeMetadataPhotoId] ?? null
+    : null;
+  const activeMetadataError = photoInspectorState.activeMetadataPhotoId
+    ? photoDetailErrorById[photoInspectorState.activeMetadataPhotoId] ?? null
+    : null;
+  const isLoadingMetadataDetail =
+    photoInspectorState.activeMetadataPhotoId !== null
+    && loadingPhotoDetailId === photoInspectorState.activeMetadataPhotoId;
+
+  const activeFaceSummary = useMemo(() => {
+    const activeFaceAssignment = photoInspectorState.activeFaceAssignment;
+    if (!activeFaceAssignment || !isFaceInteractionEnabled) {
+      return null;
+    }
+    return summaryByPhotoId.get(activeFaceAssignment.photoId) ?? null;
+  }, [photoInspectorState.activeFaceAssignment, isFaceInteractionEnabled, summaryByPhotoId]);
+
+  const activeFace = useMemo(() => {
+    const activeFaceAssignment = photoInspectorState.activeFaceAssignment;
+    if (!activeFaceAssignment || !activeFaceSummary) {
+      return null;
+    }
+    return activeFaceSummary.faces.find((face) => face.faceId === activeFaceAssignment.faceId) ?? null;
+  }, [activeFaceSummary, photoInspectorState.activeFaceAssignment]);
 
   const excludedPeople = useMemo(
     () => peopleDirectory.filter((person) => excludedPersonIdSet.has(person.person_id)),
@@ -319,16 +441,61 @@ export function SuggestionsRoutePage() {
             onClick={() => {
               void handleConfirmFaces();
             }}
-            disabled={isLoading || isConfirming || selectedFaceIdsOrdered.length === 0}
+            disabled={
+              isLoading
+              || isConfirming
+              || !isFaceInteractionEnabled
+              || selectedFaceIdsOrdered.length === 0
+            }
           >
             Confirm faces
           </button>
         </div>
       </div>
 
-      {isLoading ? <p role="status">Loading suggestions workflow.</p> : null}
+      <section className="suggestions-interaction-toggles" aria-label="Interaction toggles">
+        <label className="suggestions-toggle">
+          <input
+            type="checkbox"
+            checked={isFaceInteractionEnabled}
+            onChange={(event) => {
+              setIsFaceInteractionEnabled(event.currentTarget.checked);
+            }}
+            aria-label="Enable face assignment interactions"
+          />
+          Enable face assignment interactions
+        </label>
+        <label className="suggestions-toggle">
+          <input
+            type="checkbox"
+            checked={photoInspectorState.areFaceBoxesVisible}
+            disabled={!isFaceInteractionEnabled}
+            onChange={(event) => {
+              dispatchPhotoInspector({
+                type: "setFaceBoxesVisible",
+                visible: event.currentTarget.checked
+              });
+            }}
+            aria-label="Show face boxes on all photos"
+          />
+          Show face boxes on all photos
+        </label>
+        <label className="suggestions-toggle">
+          <input
+            type="checkbox"
+            checked={isAlbumInteractionEnabled}
+            onChange={(event) => {
+              setIsAlbumInteractionEnabled(event.currentTarget.checked);
+            }}
+            aria-label="Enable album interactions"
+          />
+          Enable album interactions
+        </label>
+      </section>
+
+      {isLoading ? <p className="suggestions-status" role="status">Loading suggestions workflow.</p> : null}
       {!isLoading && error ? (
-        <div>
+        <div className="suggestions-error">
           <p>{error}</p>
           <button
             type="button"
@@ -340,20 +507,22 @@ export function SuggestionsRoutePage() {
           </button>
         </div>
       ) : null}
-      {message ? <p>{message}</p> : null}
+      {message ? <p className="suggestions-message">{message}</p> : null}
 
-      <AlbumActionSurface
-        albums={albumTargets}
-        selectedPhotoIds={selectedPhotoIdsOrdered}
-        isSubmitting={isAlbumActionSubmitting}
-        resultMessage={albumActionResultMessage}
-        onAddToAlbum={(albumId, photoIds) => {
-          void handleAddToAlbum(albumId, photoIds);
-        }}
-        onCreateAlbumAndAdd={(name, photoIds) => {
-          void handleCreateAlbumAndAdd(name, photoIds);
-        }}
-      />
+      {isAlbumInteractionEnabled ? (
+        <AlbumActionSurface
+          albums={albumTargets}
+          selectedPhotoIds={selectedPhotoIdsOrdered}
+          isSubmitting={isAlbumActionSubmitting}
+          resultMessage={albumActionResultMessage}
+          onAddToAlbum={(albumId, photoIds) => {
+            void handleAddToAlbum(albumId, photoIds);
+          }}
+          onCreateAlbumAndAdd={(name, photoIds) => {
+            void handleCreateAlbumAndAdd(name, photoIds);
+          }}
+        />
+      ) : null}
 
       {!isLoading && !error && payload && payload.items.length === 0 ? (
         <p className="suggestions-empty">No pending suggestions.</p>
@@ -364,7 +533,8 @@ export function SuggestionsRoutePage() {
           items={payload.items}
           selectedPhotoIds={selectionState.selectedPhotoIds}
           selectedFaceIds={selectedFaceIds}
-          faceBoxesVisible={photoInspectorState.areFaceBoxesVisible}
+          faceBoxesVisible={isFaceInteractionEnabled && photoInspectorState.areFaceBoxesVisible}
+          isFaceInteractionEnabled={isFaceInteractionEnabled}
           activeMetadataPhotoId={photoInspectorState.activeMetadataPhotoId}
           faceActionInFlightIds={faceActionInFlightIds}
           faceChoiceDrafts={faceChoiceDrafts}
@@ -395,6 +565,9 @@ export function SuggestionsRoutePage() {
             });
           }}
           onOpenFace={(face, photoId, sourceSurfaceId) => {
+            if (!isFaceInteractionEnabled) {
+              return;
+            }
             dispatchPhotoInspector({
               type: "openFaceAssignment",
               photoId,
@@ -410,12 +583,21 @@ export function SuggestionsRoutePage() {
             });
           }}
           onConfirmSingleFace={(face) => {
+            if (!isFaceInteractionEnabled) {
+              return;
+            }
             void handleConfirmSingleFace(face);
           }}
           onMarkFaceUnknown={(face) => {
+            if (!isFaceInteractionEnabled) {
+              return;
+            }
             void handleMarkFaceUnknown(face);
           }}
           onDismissFalsePositive={(face) => {
+            if (!isFaceInteractionEnabled) {
+              return;
+            }
             void handleDismissFalsePositive(face);
           }}
         />
@@ -428,6 +610,59 @@ export function SuggestionsRoutePage() {
         canGoNext={canGoNext}
         ariaLabel="Suggestion pagination"
         onPageChange={setPage}
+      />
+
+      <PhotoMetadataFlyout
+        isOpen={photoInspectorState.activeMetadataPhotoId !== null}
+        summary={activeMetadataSummary}
+        detail={activeMetadataDetail}
+        isLoadingDetail={isLoadingMetadataDetail}
+        detailError={activeMetadataError}
+        onClose={() => dispatchPhotoInspector({ type: "closeMetadata" })}
+        onRetry={() => {
+          const photoId = photoInspectorState.activeMetadataPhotoId;
+          if (!photoId) {
+            return;
+          }
+          setPhotoDetailById((current) => {
+            const next = { ...current };
+            delete next[photoId];
+            return next;
+          });
+        }}
+      />
+
+      <FaceAssignmentModal
+        isOpen={activeFace !== null}
+        photo={activeFaceSummary}
+        face={activeFace}
+        people={peopleDirectory.map((person) => ({
+          person_id: person.person_id,
+          display_name: person.display_name
+        }))}
+        onClose={() => dispatchPhotoInspector({ type: "closeFaceAssignment" })}
+        onFaceUpdated={() => {
+          dispatchPhotoInspector({ type: "closeFaceAssignment" });
+          void loadPage(page);
+        }}
+        onFaceDismissed={() => {
+          dispatchPhotoInspector({ type: "closeFaceAssignment" });
+          void loadPage(page);
+        }}
+        onPersonCreated={(person) => {
+          setPeopleDirectory((current) => {
+            if (current.some((candidate) => candidate.person_id === person.person_id)) {
+              return current;
+            }
+            return [
+              ...current,
+              {
+                person_id: person.person_id,
+                display_name: person.display_name
+              }
+            ];
+          });
+        }}
       />
     </section>
   );

--- a/apps/ui/src/pages/albums/AlbumDetailInline.tsx
+++ b/apps/ui/src/pages/albums/AlbumDetailInline.tsx
@@ -13,7 +13,7 @@ interface AlbumDetailInlineProps {
   onTogglePhotoSelected: (photoId: string) => void;
   onFaceBoxesVisibleChange: (visible: boolean) => void;
   onOpenMetadata: (photoId: string, sourceSurfaceId: string) => void;
-  onOpenFace: (photoId: string, faceId: string, sourceSurfaceId: string) => void;
+  onOpenFace: (photoId: string, faceId: string, sourceSurfaceId: string, faceIndex?: number) => void;
 }
 
 function adaptAlbumItem(detail: AlbumDetail, item: AlbumDetail["items"][number]): PhotoSummary {

--- a/apps/ui/src/pages/albums/AlbumsGrid.tsx
+++ b/apps/ui/src/pages/albums/AlbumsGrid.tsx
@@ -34,7 +34,7 @@ interface AlbumsGridProps {
   onTogglePhotoSelected: (photoId: string) => void;
   onFaceBoxesVisibleChange: (visible: boolean) => void;
   onOpenMetadata: (photoId: string, sourceSurfaceId: string) => void;
-  onOpenFace: (photoId: string, faceId: string, sourceSurfaceId: string) => void;
+  onOpenFace: (photoId: string, faceId: string, sourceSurfaceId: string, faceIndex?: number) => void;
 }
 
 export function AlbumsGrid({

--- a/apps/ui/src/pages/library/LibraryPhotoGrid.tsx
+++ b/apps/ui/src/pages/library/LibraryPhotoGrid.tsx
@@ -1,10 +1,13 @@
+import { AlbumActionSurface } from "../photo-interactions/AlbumActionSurface";
 import { adaptLibraryPhoto } from "../photo-interactions/photoInteractionAdapters";
 import { PhotoSurface } from "../photo-interactions/PhotoSurface";
+import type { AlbumTarget } from "../photo-interactions/photoInteractionTypes";
 import type { LibraryPhoto } from "./libraryRouteTypes";
 import type { serializeLibrarySelectionState } from "./librarySelection";
 
 interface LibraryPhotoGridProps {
   photos: LibraryPhoto[];
+  photoSummaryById: Map<string, ReturnType<typeof adaptLibraryPhoto>>;
   locationSearch: string;
   selectionRouteState: ReturnType<typeof serializeLibrarySelectionState>;
   selectedPhotoIds: Set<string>;
@@ -12,7 +15,13 @@ interface LibraryPhotoGridProps {
   faceBoxesVisible: boolean;
   activeMetadataPhotoId: string | null;
   onOpenMetadata: (photoId: string, sourceSurfaceId: string) => void;
-  onOpenFace: (photoId: string, faceId: string, sourceSurfaceId: string) => void;
+  onOpenFace: (photoId: string, faceId: string, sourceSurfaceId: string, faceIndex?: number) => void;
+  albumAssignmentWidgetsVisible: boolean;
+  albumTargets: AlbumTarget[];
+  albumActionResultByPhotoId: Record<string, string>;
+  isAlbumActionSubmitting: boolean;
+  onAddSinglePhotoToAlbum: (photoId: string, albumId: string) => void;
+  onCreateAlbumAndAddSinglePhoto: (photoId: string, albumName: string) => void;
   libraryViewRouteState: {
     sortDirection: "asc" | "desc";
     page: number;
@@ -41,48 +50,9 @@ function formatDisplayPath(path: string): string {
   return `.../${sourceRelativePath}`;
 }
 
-function summarizePhotoFaces(photo: LibraryPhoto): {
-  detectedFaces: number;
-  assignedFaces: number;
-  suggestedFaces: number;
-} {
-  const faces = photo.faces ?? [];
-  let assignedFaces = 0;
-  let suggestedFaces = 0;
-
-  faces.forEach((face) => {
-    if (face.person_id) {
-      assignedFaces += 1;
-    }
-
-    if (face.person_id === null) {
-      const hasSuggestions =
-        (face.suggestions?.length ?? 0) > 0
-        || (face.label_source === "machine_suggested" && typeof face.confidence === "number");
-      if (hasSuggestions) {
-        suggestedFaces += 1;
-      }
-    }
-  });
-
-  return {
-    detectedFaces: faces.length,
-    assignedFaces,
-    suggestedFaces
-  };
-}
-
-function formatFaceSummary(metrics: ReturnType<typeof summarizePhotoFaces>): string {
-  const base = `Faces detected/assigned: ${metrics.detectedFaces}/${metrics.assignedFaces}`;
-  if (metrics.suggestedFaces <= 0) {
-    return base;
-  }
-  const noun = metrics.suggestedFaces === 1 ? "suggestion" : "suggestions";
-  return `${base} - ${metrics.suggestedFaces} ${noun}`;
-}
-
 export function LibraryPhotoGrid({
   photos,
+  photoSummaryById,
   locationSearch,
   selectionRouteState,
   selectedPhotoIds,
@@ -91,14 +61,19 @@ export function LibraryPhotoGrid({
   faceBoxesVisible,
   activeMetadataPhotoId,
   onOpenMetadata,
-  onOpenFace
+  onOpenFace,
+  albumAssignmentWidgetsVisible,
+  albumTargets,
+  albumActionResultByPhotoId,
+  isAlbumActionSubmitting,
+  onAddSinglePhotoToAlbum,
+  onCreateAlbumAndAddSinglePhoto
 }: LibraryPhotoGridProps) {
   return (
     <ol className="browse-grid" aria-label="Photo gallery">
       {photos.map((photo) => {
-        const summary = adaptLibraryPhoto(photo);
+        const summary = photoSummaryById.get(photo.photo_id) ?? adaptLibraryPhoto(photo);
         const displayPath = formatDisplayPath(photo.path);
-        const faceSummary = formatFaceSummary(summarizePhotoFaces(photo));
         return (
           <li key={photo.photo_id}>
             <PhotoSurface
@@ -119,7 +94,22 @@ export function LibraryPhotoGrid({
               selectionLabel={`Select photo ${photo.photo_id}`}
               detailLabel={`Open details for ${photo.path}`}
               metadataLabel={`Show metadata for ${summary.title}`}
-              supportingText={faceSummary}
+              albumAssignmentWidget={
+                albumAssignmentWidgetsVisible ? (
+                  <AlbumActionSurface
+                    albums={albumTargets}
+                    selectedPhotoIds={[photo.photo_id]}
+                    isSubmitting={isAlbumActionSubmitting}
+                    resultMessage={albumActionResultByPhotoId[photo.photo_id] ?? null}
+                    onAddToAlbum={(albumId) => {
+                      onAddSinglePhotoToAlbum(photo.photo_id, albumId);
+                    }}
+                    onCreateAlbumAndAdd={(name) => {
+                      onCreateAlbumAndAddSinglePhoto(photo.photo_id, name);
+                    }}
+                  />
+                ) : null
+              }
               onToggleSelected={onTogglePhotoSelection}
               onOpenMetadata={onOpenMetadata}
               onOpenFace={onOpenFace}

--- a/apps/ui/src/pages/library/LibrarySelectionPanel.tsx
+++ b/apps/ui/src/pages/library/LibrarySelectionPanel.tsx
@@ -8,18 +8,22 @@ interface LibrarySelectionPanelProps {
   selectionState: LibrarySelectionState;
   activeScopeCount: number;
   areFaceBoxesVisible: boolean;
+  areAlbumInteractionsVisible: boolean;
   onSetScope: (scope: LibrarySelectionScope) => void;
   onClearExplicitSelection: () => void;
   onFaceBoxesVisibleChange: (visible: boolean) => void;
+  onAlbumInteractionsVisibleChange: (visible: boolean) => void;
 }
 
 export function LibrarySelectionPanel({
   selectionState,
   activeScopeCount,
   areFaceBoxesVisible,
+  areAlbumInteractionsVisible,
   onSetScope,
   onClearExplicitSelection,
-  onFaceBoxesVisibleChange
+  onFaceBoxesVisibleChange,
+  onAlbumInteractionsVisibleChange
 }: LibrarySelectionPanelProps) {
   return (
     <section className="browse-selection-panel" aria-label="Library selection controls">
@@ -75,6 +79,16 @@ export function LibrarySelectionPanel({
           }}
         />
         Show face boxes on all photos
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={areAlbumInteractionsVisible}
+          onChange={(event) => {
+            onAlbumInteractionsVisibleChange(event.currentTarget.checked);
+          }}
+        />
+        Enable album assignment widgets
       </label>
     </section>
   );

--- a/apps/ui/src/pages/library/libraryRouteApi.ts
+++ b/apps/ui/src/pages/library/libraryRouteApi.ts
@@ -88,7 +88,8 @@ export async function fetchLibraryPage(
   pathHints: string[],
   sortDirection: SortDirection,
   offset: number,
-  pageLimit: number
+  pageLimit: number,
+  includeFaceInfo = false
 ): Promise<SearchResponsePayload> {
   const searchFilters = buildSearchFilters(
     fromDate,
@@ -104,6 +105,7 @@ export async function fetchLibraryPage(
   const requestBody = {
     ...(query ? { q: query } : {}),
     ...(searchFilters ? { filters: searchFilters } : {}),
+    ...(includeFaceInfo ? { include_face_info: true } : {}),
     sort: {
       by: "shot_ts",
       dir: sortDirection

--- a/apps/ui/src/pages/library/libraryRouteTypes.ts
+++ b/apps/ui/src/pages/library/libraryRouteTypes.ts
@@ -13,6 +13,10 @@ export type LibraryPhoto = {
   faces?: Array<{
     face_id?: string;
     person_id: string | null;
+    assigned_person?: {
+      person_id: string;
+      display_name: string;
+    } | null;
     bbox_x?: number | null;
     bbox_y?: number | null;
     bbox_w?: number | null;

--- a/apps/ui/src/pages/library/useLibraryResults.ts
+++ b/apps/ui/src/pages/library/useLibraryResults.ts
@@ -29,6 +29,7 @@ interface UseLibraryResultsArgs {
   pageSize: number;
   dateRangeError: string | null;
   locationError: string | null;
+  includeFaceInfo: boolean;
 }
 
 export function useLibraryResults({
@@ -47,6 +48,7 @@ export function useLibraryResults({
   pageSize,
   dateRangeError,
   locationError,
+  includeFaceInfo,
 }: UseLibraryResultsArgs) {
   const [photos, setPhotos] = useState<LibraryPhoto[]>([]);
   const [totalCount, setTotalCount] = useState(0);
@@ -90,7 +92,8 @@ export function useLibraryResults({
       pathHintFilters,
       sortDirection,
       requestOffset,
-      pageSize
+      pageSize,
+      includeFaceInfo
     )
       .then((payload) => {
         if (controller.signal.aborted) {
@@ -133,6 +136,7 @@ export function useLibraryResults({
     sortDirection,
     suggestionConfidenceMinDraft,
     toDate,
+    includeFaceInfo,
   ]);
 
   useEffect(() => {

--- a/apps/ui/src/pages/photo-interactions/AlbumActionSurface.tsx
+++ b/apps/ui/src/pages/photo-interactions/AlbumActionSurface.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import "./photo-interactions.css";
 import type { AlbumTarget } from "./photoInteractionTypes";
 
 interface AlbumActionSurfaceProps {

--- a/apps/ui/src/pages/photo-interactions/FaceAssignmentModal.tsx
+++ b/apps/ui/src/pages/photo-interactions/FaceAssignmentModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import "./photo-interactions.css";
 import {
   FaceLabelingApiError,
   assignFace,

--- a/apps/ui/src/pages/photo-interactions/FaceOverlayLayer.test.tsx
+++ b/apps/ui/src/pages/photo-interactions/FaceOverlayLayer.test.tsx
@@ -20,6 +20,12 @@ const face: PhotoFace = {
   canConfirm: false,
 };
 
+const faceWithoutBBox: PhotoFace = {
+  ...face,
+  faceId: "face-2",
+  bbox: { x: null, y: null, width: null, height: null, spaceWidth: null, spaceHeight: null },
+};
+
 describe("FaceOverlayLayer", () => {
   it("renders face controls and delegates face clicks", async () => {
     const user = userEvent.setup();
@@ -36,7 +42,7 @@ describe("FaceOverlayLayer", () => {
 
     await user.click(screen.getByRole("button", { name: /open face 1 actions/i }));
 
-    expect(onOpenFace).toHaveBeenCalledWith("face-1");
+    expect(onOpenFace).toHaveBeenCalledWith("face-1", 0);
   });
 
   it("renders nothing when face boxes are hidden", () => {
@@ -50,5 +56,84 @@ describe("FaceOverlayLayer", () => {
     );
 
     expect(screen.queryByRole("button", { name: /open face/i })).toBeNull();
+  });
+
+  it("renders fallback face controls when region coordinates are unavailable", async () => {
+    const user = userEvent.setup();
+    const onOpenFace = vi.fn();
+
+    render(
+      <FaceOverlayLayer
+        faces={[faceWithoutBBox]}
+        thumbnailSize={{ width: 100, height: 100 }}
+        visible
+        onOpenFace={onOpenFace}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /open face 1 actions/i }));
+    expect(onOpenFace).toHaveBeenCalledWith("face-2", 0);
+  });
+
+  it("shows question-mark indicator without name text for unknown assignments", () => {
+    render(
+      <FaceOverlayLayer
+        faces={[
+          {
+            ...face,
+            personId: "unknown-person",
+            assignedPerson: { personId: "unknown-person", displayName: "Unknown person" }
+          }
+        ]}
+        thumbnailSize={{ width: 100, height: 100 }}
+        visible
+        onOpenFace={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("Unknown person")).not.toBeInTheDocument();
+    expect(screen.getByText("?")).toBeInTheDocument();
+  });
+
+  it("renders 0 to 3 battery blocks for empty, low, medium, and strong suggestion confidence", () => {
+    render(
+      <FaceOverlayLayer
+        faces={[
+          {
+            ...face,
+            faceId: "face-empty",
+            suggestions: [{ personId: "person-1", displayName: "Alex", rank: 1, confidence: 0.39, modelVersion: null, provenance: null }]
+          },
+          {
+            ...face,
+            faceId: "face-low",
+            suggestions: [{ personId: "person-1", displayName: "Alex", rank: 1, confidence: 0.5, modelVersion: null, provenance: null }]
+          },
+          {
+            ...face,
+            faceId: "face-medium",
+            suggestions: [{ personId: "person-1", displayName: "Alex", rank: 1, confidence: 0.7, modelVersion: null, provenance: null }]
+          },
+          {
+            ...face,
+            faceId: "face-strong",
+            suggestions: [{ personId: "person-1", displayName: "Alex", rank: 1, confidence: 0.9, modelVersion: null, provenance: null }]
+          }
+        ]}
+        thumbnailSize={{ width: 100, height: 100 }}
+        visible
+        onOpenFace={vi.fn()}
+      />
+    );
+
+    const indicators = Array.from(
+      document.querySelectorAll<HTMLElement>(".photo-face-confidence-indicator.is-battery")
+    );
+    expect(indicators).toHaveLength(4);
+
+    const filledCounts = indicators.map((indicator) =>
+      indicator.querySelectorAll(".photo-face-battery-cell.is-filled").length
+    );
+    expect(filledCounts).toEqual([0, 1, 2, 3]);
   });
 });

--- a/apps/ui/src/pages/photo-interactions/FaceOverlayLayer.tsx
+++ b/apps/ui/src/pages/photo-interactions/FaceOverlayLayer.tsx
@@ -1,11 +1,13 @@
 import { FaceBBoxOverlay, buildFaceOverlayRegions } from "../FaceBBoxOverlay";
+import "./photo-interactions.css";
 import type { PhotoFace } from "./photoInteractionTypes";
+import { buildFaceActionSummary, resolveFaceConfidenceIndicator } from "./faceActionSummary";
 
 interface FaceOverlayLayerProps {
   faces: PhotoFace[];
   thumbnailSize: { width: number; height: number } | null;
   visible: boolean;
-  onOpenFace: (faceId: string) => void;
+  onOpenFace: (faceId: string, faceIndex: number) => void;
 }
 
 export function FaceOverlayLayer({
@@ -33,24 +35,79 @@ export function FaceOverlayLayer({
     thumbnailSize.width,
     thumbnailSize.height
   );
+  const faceById = new Map(faces.map((face) => [face.faceId, face] as const));
+
+  function renderFaceIndicator(face: PhotoFace) {
+    const indicator = resolveFaceConfidenceIndicator(face);
+    if (indicator === "assigned") {
+      return <span className="photo-face-confidence-indicator is-assigned" aria-hidden="true">✓</span>;
+    }
+    if (indicator === "unknown") {
+      return <span className="photo-face-confidence-indicator is-unknown" aria-hidden="true">?</span>;
+    }
+
+    const level = indicator === "low" ? 1 : indicator === "medium" ? 2 : indicator === "strong" ? 3 : 0;
+    return (
+      <span className={`photo-face-confidence-indicator is-battery is-${indicator}`} aria-hidden="true">
+        <span className="photo-face-battery-shell">
+          <span className={`photo-face-battery-cell ${level >= 1 ? "is-filled" : ""}`} />
+          <span className={`photo-face-battery-cell ${level >= 2 ? "is-filled" : ""}`} />
+          <span className={`photo-face-battery-cell ${level >= 3 ? "is-filled" : ""}`} />
+        </span>
+        <span className="photo-face-battery-tip" />
+      </span>
+    );
+  }
+
+  function renderFaceChipContent(face: PhotoFace) {
+    const label = buildFaceActionSummary(face);
+    return (
+      <>
+        {renderFaceIndicator(face)}
+        {label ? <span className="photo-face-chip-label">{label}</span> : null}
+      </>
+    );
+  }
+
+  if (regions.length === 0 && faces.length > 0) {
+    return (
+      <ol className="photo-face-fallback-list" aria-label="Detected face regions">
+        {faces.map((face, index) => (
+          <li key={face.faceId}>
+            <button
+              type="button"
+              className="photo-face-fallback-chip-button"
+              aria-label={`Open face ${index + 1} actions`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onOpenFace(face.faceId, index);
+              }}
+            >
+              {renderFaceChipContent(face)}
+            </button>
+          </li>
+        ))}
+      </ol>
+    );
+  }
 
   return (
     <FaceBBoxOverlay
       regions={regions}
       allowRegionHover
       ariaLabel="Detected face regions"
-      onRegionClick={(region) => onOpenFace(region.faceId)}
+      onRegionClick={(region, index) => onOpenFace(region.faceId, index)}
       renderRegionContent={(region, index) => (
         <button
           type="button"
-          className="photo-face-region-button"
+          className="photo-face-region-chip-button"
           aria-label={`Open face ${index + 1} actions`}
           onClick={(event) => {
             event.stopPropagation();
-            onOpenFace(region.faceId);
+            onOpenFace(region.faceId, index);
           }}
         >
-          {index + 1}
+          {renderFaceChipContent(faceById.get(region.faceId) ?? faces[index] ?? faces[0]!)}
         </button>
       )}
     />

--- a/apps/ui/src/pages/photo-interactions/PhotoMetadataFlyout.tsx
+++ b/apps/ui/src/pages/photo-interactions/PhotoMetadataFlyout.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import "./photo-interactions.css";
 import type { PhotoDetailPayload } from "../photo-detail/photoDetailTypes";
 import {
   MISSING_VALUE,

--- a/apps/ui/src/pages/photo-interactions/PhotoSurface.test.tsx
+++ b/apps/ui/src/pages/photo-interactions/PhotoSurface.test.tsx
@@ -27,6 +27,34 @@ const photo: PhotoSummary = {
   defaultFaceBoxesVisible: false,
 };
 
+const photoWithFace: PhotoSummary = {
+  ...photo,
+  faces: [
+    {
+      faceId: "face-1",
+      personId: null,
+      bbox: {
+        x: 10,
+        y: 10,
+        width: 20,
+        height: 20,
+        spaceWidth: 100,
+        spaceHeight: 100,
+      },
+      labelSource: null,
+      confidence: null,
+      modelVersion: null,
+      provenance: null,
+      labelRecordedTs: null,
+      suggestions: [],
+      canAssign: true,
+      canCorrect: false,
+      canDismiss: true,
+      canConfirm: false,
+    },
+  ],
+};
+
 describe("PhotoSurface", () => {
   it("keeps selection, metadata, and detail navigation separate", async () => {
     const user = userEvent.setup();
@@ -79,5 +107,28 @@ describe("PhotoSurface", () => {
     );
 
     expect(screen.getByTestId("photo-surface-photo-1")).toHaveClass("photo-surface-active-metadata");
+  });
+
+  it("opens face actions from the face bbox overlay", async () => {
+    const user = userEvent.setup();
+    const onOpenFace = vi.fn();
+
+    render(
+      <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <PhotoSurface
+          photo={photoWithFace}
+          selected={false}
+          faceBoxesVisible={true}
+          activeMetadata={false}
+          detailTo="/library/photo-1"
+          onToggleSelected={vi.fn()}
+          onOpenMetadata={vi.fn()}
+          onOpenFace={onOpenFace}
+        />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Open face 1 actions" }));
+    expect(onOpenFace).toHaveBeenCalledWith("photo-1", "face-1", "photo-surface-photo-1", 0);
   });
 });

--- a/apps/ui/src/pages/photo-interactions/PhotoSurface.tsx
+++ b/apps/ui/src/pages/photo-interactions/PhotoSurface.tsx
@@ -1,4 +1,6 @@
 import { Link } from "react-router-dom";
+import type { ReactNode } from "react";
+import "./photo-interactions.css";
 import { FaceOverlayLayer } from "./FaceOverlayLayer";
 import type { PhotoSummary } from "./photoInteractionTypes";
 
@@ -13,9 +15,10 @@ interface PhotoSurfaceProps {
   detailLabel?: string;
   metadataLabel?: string;
   supportingText?: string;
+  albumAssignmentWidget?: ReactNode;
   onToggleSelected: (photoId: string) => void;
   onOpenMetadata: (photoId: string, sourceSurfaceId: string) => void;
-  onOpenFace: (photoId: string, faceId: string, sourceSurfaceId: string) => void;
+  onOpenFace: (photoId: string, faceId: string, sourceSurfaceId: string, faceIndex?: number) => void;
 }
 
 export function buildPhotoSurfaceId(photoId: string): string {
@@ -33,6 +36,7 @@ export function PhotoSurface({
   detailLabel,
   metadataLabel,
   supportingText,
+  albumAssignmentWidget,
   onToggleSelected,
   onOpenMetadata,
   onOpenFace,
@@ -83,23 +87,31 @@ export function PhotoSurface({
           faces={photo.faces}
           thumbnailSize={thumbnail ? { width: thumbnail.width, height: thumbnail.height } : null}
           visible={faceBoxesVisible}
-          onOpenFace={(faceId) => onOpenFace(photo.photoId, faceId, surfaceId)}
+          onOpenFace={(faceId, faceIndex) => onOpenFace(photo.photoId, faceId, surfaceId, faceIndex)}
         />
       </div>
 
       <div className="photo-surface-body">
-        <p className="photo-surface-title" title={photo.path}>
-          {photo.title}
-        </p>
+        <div className="photo-surface-title-row">
+          <p className="photo-surface-title" title={photo.path}>
+            {photo.title}
+          </p>
+          <button
+            type="button"
+            className="photo-surface-metadata-icon-button"
+            onClick={() => onOpenMetadata(photo.photoId, surfaceId)}
+            aria-label={metadataLabel ?? `Show metadata for ${photo.title}`}
+            title={metadataLabel ?? `Show metadata for ${photo.title}`}
+          >
+            <span aria-hidden="true">(i)</span>
+          </button>
+        </div>
         {supportingText ? <p className="photo-surface-supporting-text">{supportingText}</p> : null}
-        <button
-          type="button"
-          className="photo-surface-metadata-button"
-          onClick={() => onOpenMetadata(photo.photoId, surfaceId)}
-          aria-label={metadataLabel ?? `Show metadata for ${photo.title}`}
-        >
-          Show metadata
-        </button>
+        {albumAssignmentWidget ? (
+          <div className="photo-surface-album-widget">
+            {albumAssignmentWidget}
+          </div>
+        ) : null}
       </div>
     </article>
   );

--- a/apps/ui/src/pages/photo-interactions/faceActionSummary.test.ts
+++ b/apps/ui/src/pages/photo-interactions/faceActionSummary.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { buildFaceActionSummary, resolveFaceConfidenceIndicator } from "./faceActionSummary";
+import type { PhotoFace } from "./photoInteractionTypes";
+
+function buildFace(overrides: Partial<PhotoFace> = {}): PhotoFace {
+  return {
+    faceId: "face-1",
+    personId: null,
+    assignedPerson: null,
+    bbox: { x: 0.1, y: 0.1, width: 0.2, height: 0.2, spaceWidth: 1, spaceHeight: 1 },
+    labelSource: null,
+    confidence: null,
+    modelVersion: null,
+    provenance: null,
+    labelRecordedTs: null,
+    suggestions: [],
+    canAssign: true,
+    canCorrect: false,
+    canDismiss: true,
+    canConfirm: false,
+    ...overrides
+  };
+}
+
+describe("buildFaceActionSummary", () => {
+  it("formats the top suggestion name for unassigned faces", () => {
+    const summary = buildFaceActionSummary(
+      buildFace({
+        suggestions: [
+          { personId: "person-2", displayName: "Blair", rank: 2, confidence: 0.71, modelVersion: null, provenance: null },
+          { personId: "person-1", displayName: "Alex", rank: 1, confidence: 0.89, modelVersion: null, provenance: null }
+        ]
+      })
+    );
+
+    expect(summary).toBe("Alex");
+  });
+
+  it("formats assigned faces with resolved display names", () => {
+    const summary = buildFaceActionSummary(
+      buildFace({
+        personId: "person-1",
+        labelSource: "machine_suggested",
+        confidence: 0.93,
+        suggestions: [
+          { personId: "person-1", displayName: "Alex", rank: 1, confidence: 0.93, modelVersion: null, provenance: null }
+        ]
+      })
+    );
+
+    expect(summary).toBe("Alex");
+  });
+
+  it("returns person id for human-confirmed assignments when display name is unavailable", () => {
+    const summary = buildFaceActionSummary(
+      buildFace({
+        personId: "person-1",
+        labelSource: "human_confirmed"
+      })
+    );
+
+    expect(summary).toBe("person-1");
+  });
+
+  it("returns no label text for unknown-person assignments", () => {
+    const summary = buildFaceActionSummary(
+      buildFace({
+        personId: "unknown-person",
+        assignedPerson: { personId: "unknown-person", displayName: "Unknown person" }
+      })
+    );
+
+    expect(summary).toBeNull();
+  });
+});
+
+describe("resolveFaceConfidenceIndicator", () => {
+  it("returns unknown for unknown-person assignments", () => {
+    const indicator = resolveFaceConfidenceIndicator(
+      buildFace({
+        personId: "unknown-person",
+        assignedPerson: { personId: "unknown-person", displayName: "Unknown person" }
+      })
+    );
+
+    expect(indicator).toBe("unknown");
+  });
+
+  it("returns assigned for known assignments", () => {
+    const indicator = resolveFaceConfidenceIndicator(
+      buildFace({
+        personId: "person-1",
+        assignedPerson: { personId: "person-1", displayName: "Alex" }
+      })
+    );
+
+    expect(indicator).toBe("assigned");
+  });
+
+  it("maps top-suggestion confidence to battery levels", () => {
+    expect(
+      resolveFaceConfidenceIndicator(
+        buildFace({
+          suggestions: [{ personId: "person-a", displayName: "A", rank: 1, confidence: 0.39, modelVersion: null, provenance: null }]
+        })
+      )
+    ).toBe("empty");
+    expect(
+      resolveFaceConfidenceIndicator(
+        buildFace({
+          suggestions: [{ personId: "person-a", displayName: "A", rank: 1, confidence: 0.5, modelVersion: null, provenance: null }]
+        })
+      )
+    ).toBe("low");
+    expect(
+      resolveFaceConfidenceIndicator(
+        buildFace({
+          suggestions: [{ personId: "person-a", displayName: "A", rank: 1, confidence: 0.7, modelVersion: null, provenance: null }]
+        })
+      )
+    ).toBe("medium");
+    expect(
+      resolveFaceConfidenceIndicator(
+        buildFace({
+          suggestions: [{ personId: "person-a", displayName: "A", rank: 1, confidence: 0.9, modelVersion: null, provenance: null }]
+        })
+      )
+    ).toBe("strong");
+  });
+});

--- a/apps/ui/src/pages/photo-interactions/faceActionSummary.ts
+++ b/apps/ui/src/pages/photo-interactions/faceActionSummary.ts
@@ -1,0 +1,72 @@
+import type { PhotoFace, PhotoFaceSuggestion } from "./photoInteractionTypes";
+
+export type FaceConfidenceIndicator = "unknown" | "assigned" | "empty" | "low" | "medium" | "strong";
+
+export function resolveTopSuggestion(suggestions: PhotoFaceSuggestion[]): PhotoFaceSuggestion | null {
+  if (!Array.isArray(suggestions) || suggestions.length === 0) {
+    return null;
+  }
+
+  return [...suggestions].sort((left, right) => {
+    const leftRank = left.rank ?? Number.MAX_SAFE_INTEGER;
+    const rightRank = right.rank ?? Number.MAX_SAFE_INTEGER;
+    if (leftRank !== rightRank) {
+      return leftRank - rightRank;
+    }
+    if (right.confidence !== left.confidence) {
+      return right.confidence - left.confidence;
+    }
+    return left.displayName.localeCompare(right.displayName, "en-US");
+  })[0] ?? null;
+}
+
+function isUnknownAssigned(face: PhotoFace): boolean {
+  if (!face.personId) {
+    return false;
+  }
+  const assignedDisplayName = face.assignedPerson?.displayName?.toLowerCase() ?? "";
+  const personId = face.personId.toLowerCase();
+  return assignedDisplayName.includes("unknown") || personId.includes("unknown");
+}
+
+export function resolveFaceConfidenceIndicator(face: PhotoFace): FaceConfidenceIndicator {
+  if (isUnknownAssigned(face)) {
+    return "unknown";
+  }
+
+  if (face.personId) {
+    return "assigned";
+  }
+
+  const topSuggestion = resolveTopSuggestion(face.suggestions);
+  if (!topSuggestion) {
+    return "empty";
+  }
+  if (topSuggestion.confidence < 0.4) {
+    return "empty";
+  }
+  if (topSuggestion.confidence < 0.6) {
+    return "low";
+  }
+  if (topSuggestion.confidence < 0.8) {
+    return "medium";
+  }
+  return "strong";
+}
+
+export function buildFaceActionSummary(face: PhotoFace): string | null {
+  if (isUnknownAssigned(face)) {
+    return null;
+  }
+
+  if (face.personId) {
+    const matchingSuggestion = face.suggestions.find((suggestion) => suggestion.personId === face.personId) ?? null;
+    return face.assignedPerson?.displayName ?? matchingSuggestion?.displayName ?? face.personId;
+  }
+
+  const topSuggestion = resolveTopSuggestion(face.suggestions);
+  if (!topSuggestion) {
+    return "Unassigned";
+  }
+  return topSuggestion.displayName;
+}

--- a/apps/ui/src/pages/photo-interactions/photo-interactions.css
+++ b/apps/ui/src/pages/photo-interactions/photo-interactions.css
@@ -1,0 +1,694 @@
+.photo-surface {
+  position: relative;
+  border: 1px solid #d7dde8;
+  border-radius: 8px;
+  background: #fff;
+  overflow: hidden;
+}
+
+.photo-surface-selected {
+  border-color: #2563eb;
+}
+
+.photo-surface-active-metadata {
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgb(37 99 235 / 18%);
+}
+
+.photo-surface-select {
+  position: absolute;
+  z-index: 3;
+  top: 8px;
+  left: 8px;
+}
+
+.photo-surface-media {
+  position: relative;
+  background: #f8fafc;
+}
+
+.photo-surface-link {
+  display: block;
+}
+
+.photo-surface-image,
+.photo-surface-placeholder {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.photo-surface-placeholder {
+  min-height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #64748b;
+}
+
+.photo-surface-body {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.65rem;
+}
+
+.photo-surface-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.photo-surface-title {
+  margin: 0;
+  color: #475569;
+  font-size: 0.8rem;
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.photo-surface-supporting-text {
+  margin: 0;
+  font-size: 0.74rem;
+  color: #0f172a;
+}
+
+.photo-surface-metadata-icon-button {
+  border: 0;
+  background: transparent;
+  color: #94a3b8;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  font-size: 0.72rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.photo-surface-metadata-icon-button:hover,
+.photo-surface-metadata-icon-button:focus-visible {
+  color: #475569;
+  text-decoration: underline;
+}
+
+.photo-face-fallback-list {
+  position: absolute;
+  right: 0.45rem;
+  bottom: 0.45rem;
+  z-index: 3;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  gap: 0.3rem;
+  pointer-events: none;
+}
+
+.photo-face-fallback-list li {
+  pointer-events: auto;
+}
+
+.photo-face-region-chip-button {
+  position: absolute;
+  left: 0;
+  top: 0;
+  transform: translate(-0.35rem, -112%);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  max-width: 10rem;
+  border: 1px solid #93c5fd;
+  border-radius: 999px;
+  background: rgb(239 246 255 / 96%);
+  color: #1e3a8a;
+  font: inherit;
+  font-size: 0.66rem;
+  line-height: 1.1;
+  padding: 0.08rem 0.35rem 0.08rem 0.12rem;
+  white-space: nowrap;
+}
+
+.photo-face-fallback-chip-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  max-width: 10.5rem;
+  border: 1px solid #93c5fd;
+  border-radius: 999px;
+  background: rgb(239 246 255 / 96%);
+  color: #1e3a8a;
+  font: inherit;
+  font-size: 0.66rem;
+  line-height: 1.1;
+  padding: 0.12rem 0.35rem 0.12rem 0.12rem;
+  white-space: nowrap;
+}
+
+.photo-face-chip-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 999px;
+  border: 1px solid #fff;
+  background: rgb(37 99 235 / 92%);
+  color: #fff;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.photo-face-chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.photo-face-confidence-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0.95rem;
+  font-size: 0.7rem;
+  line-height: 1;
+  font-weight: 700;
+}
+
+.photo-face-confidence-indicator.is-assigned {
+  color: #16a34a;
+}
+
+.photo-face-confidence-indicator.is-unknown {
+  color: #334155;
+}
+
+.photo-face-confidence-indicator.is-battery {
+  gap: 0.08rem;
+}
+
+.photo-face-battery-shell {
+  width: 0.8rem;
+  height: 0.42rem;
+  border: 1px solid currentColor;
+  border-radius: 0.08rem;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: stretch;
+  gap: 0.04rem;
+  padding: 0.03rem;
+  box-sizing: border-box;
+}
+
+.photo-face-battery-cell {
+  border-radius: 0.02rem;
+  border: 1px solid currentColor;
+  background: transparent;
+  opacity: 0.45;
+}
+
+.photo-face-battery-cell.is-filled {
+  background: currentColor;
+  border-color: currentColor;
+  opacity: 1;
+}
+
+.photo-face-battery-tip {
+  width: 0.1rem;
+  height: 0.22rem;
+  border-radius: 0.03rem;
+  background: currentColor;
+}
+
+.photo-face-confidence-indicator.is-empty {
+  color: #dc2626;
+}
+
+.photo-face-confidence-indicator.is-low {
+  color: #ea580c;
+}
+
+.photo-face-confidence-indicator.is-medium {
+  color: #ca8a04;
+}
+
+.photo-face-confidence-indicator.is-strong {
+  color: #16a34a;
+}
+
+.photo-surface-face-action-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.photo-surface-face-action-button {
+  border: 1px solid #93c5fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.2rem 0.45rem;
+  font: inherit;
+  font-size: 0.72rem;
+}
+
+.photo-surface-album-widget .album-action-surface {
+  margin-top: 0.25rem;
+  padding: 0.45rem;
+  gap: 0.45rem 0.55rem;
+}
+
+.photo-surface-album-widget .album-action-surface label {
+  min-width: 0;
+}
+
+.album-action-surface {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.65rem;
+  background: #ffffff;
+  padding: 0.7rem 0.8rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem 0.8rem;
+  align-items: end;
+}
+
+.album-action-surface label {
+  display: grid;
+  gap: 0.3rem;
+  font-size: 0.82rem;
+  color: #334155;
+  min-width: 10rem;
+}
+
+.album-action-surface select,
+.album-action-surface input {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  background: #ffffff;
+  color: #0f172a;
+  padding: 0.32rem 0.45rem;
+  font: inherit;
+}
+
+.album-action-surface button {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.35rem 0.55rem;
+  font: inherit;
+}
+
+.album-action-surface button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.album-action-result {
+  margin: 0;
+  color: #1e293b;
+  font-size: 0.84rem;
+}
+
+.detail-panel {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.7rem;
+  background: #ffffff;
+  padding: 0.75rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.detail-panel h2 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1rem;
+}
+
+.detail-path {
+  margin: 0;
+  color: #475569;
+  font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
+.detail-panel dl {
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.detail-panel dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.detail-panel dt {
+  color: #475569;
+  font-size: 0.8rem;
+}
+
+.detail-panel dd {
+  margin: 0;
+  color: #0f172a;
+  font-size: 0.82rem;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.detail-exif-attributes {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.detail-exif-attributes-toggle {
+  justify-self: flex-start;
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.25rem 0.5rem;
+  font: inherit;
+  font-size: 0.78rem;
+}
+
+.detail-exif-attributes-list {
+  margin: 0;
+  display: grid;
+  gap: 0.3rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  background: #f8fafc;
+  padding: 0.45rem;
+}
+
+.detail-exif-attributes-list div {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+.detail-exif-attributes-list dt,
+.detail-exif-attributes-list dd {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+
+.detail-exif-attributes-list dt {
+  color: #334155;
+  text-align: left;
+  overflow-wrap: anywhere;
+}
+
+.detail-exif-attributes-list dd {
+  color: #0f172a;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+
+.detail-flyout-backdrop {
+  display: none;
+}
+
+.face-assignment-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  border: 0;
+  background: rgb(15 23 42 / 55%);
+  z-index: 60;
+  margin: 0;
+  padding: 0;
+}
+
+.face-assignment-modal {
+  position: fixed;
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
+  width: min(48rem, calc(100vw - 2rem));
+  background: #ffffff;
+  border: 1px solid #cbd5e1;
+  border-radius: 0.75rem;
+  box-shadow: 0 24px 56px rgb(15 23 42 / 35%);
+  z-index: 61;
+  padding: 0.85rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.face-assignment-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.7rem;
+}
+
+.face-assignment-modal-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.face-assignment-modal-header button {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #334155;
+  border-radius: 0.45rem;
+  padding: 0.3rem 0.62rem;
+  font: inherit;
+}
+
+.face-assignment-modal-layout {
+  display: grid;
+  grid-template-columns: auto minmax(18rem, 1fr);
+  gap: 0.9rem;
+}
+
+.face-assignment-modal-preview {
+  display: grid;
+  align-content: start;
+  gap: 0.4rem;
+}
+
+.face-assignment-modal-preview p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.78rem;
+}
+
+.face-assignment-modal-crop {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  overflow: hidden;
+  position: relative;
+  background: #f8fafc;
+}
+
+.face-assignment-modal-crop img {
+  display: block;
+  max-width: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.face-assignment-modal-crop-placeholder {
+  border: 1px dashed #cbd5e1;
+  border-radius: 0.45rem;
+  padding: 0.8rem;
+  color: #64748b;
+  font-size: 0.8rem;
+}
+
+.face-assignment-modal-controls {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.face-assignment-modal-controls p {
+  margin: 0;
+  color: #334155;
+  font-size: 0.82rem;
+}
+
+.face-assignment-modal-controls label {
+  color: #475569;
+  font-size: 0.78rem;
+}
+
+.face-assignment-modal-controls input {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.45rem;
+  padding: 0.38rem 0.52rem;
+  font: inherit;
+}
+
+.face-assignment-modal-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.face-assignment-modal-actions button {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.38rem 0.62rem;
+  font: inherit;
+}
+
+.face-assignment-modal-dismiss {
+  justify-self: start;
+  border: 1px solid #fecaca;
+  background: #fff1f2;
+  color: #b91c1c;
+  border-radius: 0.45rem;
+  padding: 0.38rem 0.62rem;
+  font: inherit;
+}
+
+.face-assignment-modal-unlabeled-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.face-assignment-modal-unknown {
+  justify-self: start;
+  border: 1px solid #bae6fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.38rem 0.62rem;
+  font: inherit;
+}
+
+.face-assignment-modal-suggestions {
+  border: 1px solid #bfdbfe;
+  border-radius: 0.55rem;
+  background: #eff6ff;
+  padding: 0.55rem 0.62rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.face-assignment-modal-suggestions h4 {
+  margin: 0;
+  font-size: 0.83rem;
+  color: #1e3a8a;
+}
+
+.face-assignment-modal-suggestions p {
+  margin: 0;
+  font-size: 0.79rem;
+  color: #1e293b;
+}
+
+.face-assignment-modal-suggestions ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.face-assignment-modal-suggestions button {
+  border: 1px solid #bfdbfe;
+  background: #ffffff;
+  color: #1e3a8a;
+  border-radius: 0.42rem;
+  padding: 0.28rem 0.44rem;
+  font: inherit;
+  font-size: 0.78rem;
+}
+
+.detail-flyout {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: min(27rem, 92vw);
+  height: 100vh;
+  background: #ffffff;
+  border-left: 1px solid #cbd5e1;
+  box-shadow: -8px 0 24px rgb(15 23 42 / 14%);
+  z-index: 30;
+  transform: translateX(102%);
+  transition: transform 160ms ease;
+  padding: 0.8rem;
+  display: grid;
+  align-content: start;
+  gap: 0.7rem;
+  overflow-y: auto;
+}
+
+.detail-flyout.is-open {
+  transform: translateX(0);
+}
+
+.detail-flyout-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.55rem;
+}
+
+.detail-flyout-header h2 {
+  margin: 0;
+  color: #0f172a;
+  font-size: 1rem;
+}
+
+.detail-flyout-header button {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-radius: 0.45rem;
+  padding: 0.28rem 0.52rem;
+  font: inherit;
+}
+
+.detail-ingest-status-detail {
+  margin: 0;
+  color: #334155;
+  font-size: 0.8rem;
+}
+
+@media (max-width: 640px) {
+  .detail-flyout {
+    width: 100vw;
+  }
+
+  .face-assignment-modal {
+    inset: auto 0 0 0;
+    transform: none;
+    width: 100vw;
+    border-radius: 0.75rem 0.75rem 0 0;
+    max-height: calc(100vh - 1.5rem);
+    overflow-y: auto;
+  }
+
+  .face-assignment-modal-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-flyout-backdrop.is-open {
+    display: block;
+    position: fixed;
+    inset: 0;
+    border: 0;
+    background: rgb(15 23 42 / 35%);
+    z-index: 20;
+    padding: 0;
+    margin: 0;
+  }
+}

--- a/apps/ui/src/pages/photo-interactions/photoInspectorState.test.ts
+++ b/apps/ui/src/pages/photo-interactions/photoInspectorState.test.ts
@@ -23,6 +23,7 @@ describe("photoInspectorState", () => {
     expect(retargeted.activeFaceAssignment).toEqual({
       photoId: "photo-1",
       faceId: "face-1",
+      faceIndex: null,
       sourceSurfaceId: "surface-photo-1",
     });
   });

--- a/apps/ui/src/pages/photo-interactions/photoInspectorState.ts
+++ b/apps/ui/src/pages/photo-interactions/photoInspectorState.ts
@@ -1,6 +1,7 @@
 export type ActiveFaceAssignmentTarget = {
   photoId: string;
   faceId: string;
+  faceIndex: number | null;
   sourceSurfaceId: string;
 };
 
@@ -22,7 +23,13 @@ export type PhotoInspectorAction =
   | { type: "openMetadata"; photoId: string; sourceSurfaceId: string }
   | { type: "closeMetadata" }
   | { type: "closeMetadataIfTargetMissing"; visiblePhotoIds: Set<string> }
-  | { type: "openFaceAssignment"; photoId: string; faceId: string; sourceSurfaceId: string }
+  | {
+      type: "openFaceAssignment";
+      photoId: string;
+      faceId: string;
+      faceIndex?: number | null;
+      sourceSurfaceId: string;
+    }
   | { type: "closeFaceAssignment" }
   | { type: "setFaceBoxesVisible"; visible: boolean };
 
@@ -64,6 +71,7 @@ export function photoInspectorReducer(
       activeFaceAssignment: {
         photoId: action.photoId,
         faceId: action.faceId,
+        faceIndex: action.faceIndex ?? null,
         sourceSurfaceId: action.sourceSurfaceId
       }
     };

--- a/apps/ui/src/pages/photo-interactions/photoInteractionAdapters.ts
+++ b/apps/ui/src/pages/photo-interactions/photoInteractionAdapters.ts
@@ -11,6 +11,10 @@ import type {
 type FaceLike = {
   face_id?: string;
   person_id?: string | null;
+  assigned_person?: {
+    person_id: string;
+    display_name: string;
+  } | null;
   bbox_x?: number | null;
   bbox_y?: number | null;
   bbox_w?: number | null;
@@ -101,9 +105,17 @@ function adaptSuggestions(face: FaceLike): PhotoFaceSuggestion[] {
 function adaptFace(face: FaceLike, fallbackFaceId: string): PhotoFace {
   const personId = face.person_id ?? null;
   const labelSource = face.label_source ?? null;
+  const assignedPerson =
+    face.assigned_person && typeof face.assigned_person.person_id === "string"
+      ? {
+          personId: face.assigned_person.person_id,
+          displayName: face.assigned_person.display_name,
+        }
+      : null;
   return {
     faceId: face.face_id ?? fallbackFaceId,
     personId,
+    assignedPerson,
     bbox: {
       x: face.bbox_x ?? null,
       y: face.bbox_y ?? null,

--- a/apps/ui/src/pages/photo-interactions/photoInteractionTypes.ts
+++ b/apps/ui/src/pages/photo-interactions/photoInteractionTypes.ts
@@ -31,6 +31,10 @@ export type PhotoFaceSuggestion = {
 export type PhotoFace = {
   faceId: string;
   personId: string | null;
+  assignedPerson?: {
+    personId: string;
+    displayName: string;
+  } | null;
   bbox: {
     x: number | null;
     y: number | null;

--- a/apps/ui/src/pages/suggestions/SuggestionFaceRow.tsx
+++ b/apps/ui/src/pages/suggestions/SuggestionFaceRow.tsx
@@ -8,6 +8,7 @@ type SuggestionFaceRowProps = {
   isLoading: boolean;
   isConfirming: boolean;
   isFaceActionInFlight: boolean;
+  isInteractionsDisabled: boolean;
   choiceDraft: string;
   onToggleSelected: (faceId: string) => void;
   onChoiceChange: (faceId: string, value: string) => void;
@@ -23,6 +24,7 @@ export function SuggestionFaceRow({
   isLoading,
   isConfirming,
   isFaceActionInFlight,
+  isInteractionsDisabled,
   choiceDraft,
   onToggleSelected,
   onChoiceChange,
@@ -57,7 +59,7 @@ export function SuggestionFaceRow({
           aria-label={`Confirm suggestion for face ${face.face_id}`}
           checked={isSelected}
           onChange={() => onToggleSelected(face.face_id)}
-          disabled={isLoading || isConfirming || isFaceActionInFlight}
+          disabled={isLoading || isConfirming || isFaceActionInFlight || isInteractionsDisabled}
         />
         <span>{`Face ${faceNumber}`}</span>
         <input
@@ -66,7 +68,7 @@ export function SuggestionFaceRow({
           onChange={(event) => {
             onChoiceChange(face.face_id, event.currentTarget.value);
           }}
-          disabled={isLoading || isConfirming || isFaceActionInFlight}
+          disabled={isLoading || isConfirming || isFaceActionInFlight || isInteractionsDisabled}
           aria-label={`Choose suggestion for face ${face.face_id}`}
           className="suggestions-face-choice-input"
         />
@@ -86,7 +88,7 @@ export function SuggestionFaceRow({
           type="button"
           className="suggestions-face-confirm-button"
           onClick={() => onConfirmFace(face)}
-          disabled={isLoading || isConfirming || isFaceActionInFlight}
+          disabled={isLoading || isConfirming || isFaceActionInFlight || isInteractionsDisabled}
         >
           Confirm face
         </button>
@@ -94,7 +96,7 @@ export function SuggestionFaceRow({
           type="button"
           className="suggestions-face-secondary-button"
           onClick={() => onMarkUnknown(face)}
-          disabled={isLoading || isConfirming || isFaceActionInFlight}
+          disabled={isLoading || isConfirming || isFaceActionInFlight || isInteractionsDisabled}
           aria-label={`Mark face ${face.face_id} as unknown`}
         >
           Mark unknown
@@ -103,7 +105,7 @@ export function SuggestionFaceRow({
           type="button"
           className="suggestions-face-secondary-button"
           onClick={() => onDismissFalsePositive(face)}
-          disabled={isLoading || isConfirming || isFaceActionInFlight}
+          disabled={isLoading || isConfirming || isFaceActionInFlight || isInteractionsDisabled}
           aria-label={`Discard face ${face.face_id} as false positive`}
         >
           False positive

--- a/apps/ui/src/pages/suggestions/SuggestionsGrid.tsx
+++ b/apps/ui/src/pages/suggestions/SuggestionsGrid.tsx
@@ -9,6 +9,7 @@ type SuggestionsGridProps = {
   selectedPhotoIds: Set<string>;
   selectedFaceIds: Set<string>;
   faceBoxesVisible: boolean;
+  isFaceInteractionEnabled: boolean;
   activeMetadataPhotoId: string | null;
   faceActionInFlightIds: Set<string>;
   faceChoiceDrafts: Map<string, string>;
@@ -29,6 +30,7 @@ export function SuggestionsGrid({
   selectedPhotoIds,
   selectedFaceIds,
   faceBoxesVisible,
+  isFaceInteractionEnabled,
   activeMetadataPhotoId,
   faceActionInFlightIds,
   faceChoiceDrafts,
@@ -75,6 +77,9 @@ export function SuggestionsGrid({
                 onToggleSelected={onTogglePhotoSelected}
                 onOpenMetadata={onOpenMetadata}
                 onOpenFace={(_photoId, faceId, sourceSurfaceId) => {
+                  if (!isFaceInteractionEnabled) {
+                    return;
+                  }
                   const selectedFace = faceById.get(faceId);
                   if (selectedFace) {
                     onOpenFace(selectedFace, photo.photo_id, sourceSurfaceId);
@@ -93,6 +98,7 @@ export function SuggestionsGrid({
                     isLoading={isLoading}
                     isConfirming={isConfirming}
                     isFaceActionInFlight={faceActionInFlightIds.has(face.face_id)}
+                    isInteractionsDisabled={!isFaceInteractionEnabled}
                     choiceDraft={faceChoiceDrafts.get(face.face_id) ?? face.top_suggestion.display_name}
                     onToggleSelected={onToggleFaceSelected}
                     onChoiceChange={onFaceChoiceChange}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -4,96 +4,6 @@
   background: #f4f7fb;
 }
 
-.photo-surface {
-  position: relative;
-  border: 1px solid #d7dde8;
-  border-radius: 8px;
-  background: #fff;
-  overflow: hidden;
-}
-
-.photo-surface-selected {
-  border-color: #2563eb;
-}
-
-.photo-surface-active-metadata {
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgb(37 99 235 / 18%);
-}
-
-.photo-surface-select {
-  position: absolute;
-  z-index: 3;
-  top: 8px;
-  left: 8px;
-}
-
-.photo-surface-media {
-  position: relative;
-  background: #f8fafc;
-}
-
-.photo-surface-link {
-  display: block;
-}
-
-.photo-surface-image,
-.photo-surface-placeholder {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.photo-surface-placeholder {
-  min-height: 120px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #64748b;
-}
-
-.photo-surface-body {
-  display: grid;
-  gap: 0.35rem;
-  padding: 0.65rem;
-}
-
-.photo-surface-title {
-  margin: 0;
-  color: #475569;
-  font-size: 0.8rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.photo-surface-supporting-text {
-  margin: 0;
-  font-size: 0.74rem;
-  color: #0f172a;
-}
-
-.photo-surface-metadata-button {
-  border: 1px solid #cbd5e1;
-  border-radius: 0.45rem;
-  background: #fff;
-  color: #0f172a;
-  padding: 0.25rem 0.5rem;
-  font: inherit;
-  font-size: 0.78rem;
-  width: fit-content;
-}
-
-.photo-face-region-button {
-  width: 1.75rem;
-  height: 1.75rem;
-  border-radius: 999px;
-  border: 1px solid #fff;
-  background: rgb(37 99 235 / 90%);
-  color: #fff;
-}
-
 .suggestions-page {
   display: grid;
   gap: 1rem;
@@ -117,6 +27,25 @@
   align-items: flex-start;
   gap: 0.8rem;
   flex-wrap: wrap;
+}
+
+.suggestions-interaction-toggles {
+  border: 1px solid #cbd5e1;
+  border-radius: 0.65rem;
+  background: #ffffff;
+  padding: 0.6rem 0.72rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem 1rem;
+  align-items: center;
+}
+
+.suggestions-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #1e293b;
+  font-size: 0.84rem;
 }
 
 .suggestions-confirm-button {
@@ -235,6 +164,37 @@
 .suggestions-confirm-button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.suggestions-status,
+.suggestions-message {
+  margin: 0;
+  color: #334155;
+  font-size: 0.86rem;
+}
+
+.suggestions-error {
+  border: 1px solid #fecaca;
+  border-radius: 0.55rem;
+  background: #fff1f2;
+  color: #b91c1c;
+  padding: 0.55rem 0.62rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.suggestions-error p {
+  margin: 0;
+}
+
+.suggestions-error button {
+  justify-self: start;
+  border: 1px solid #fecaca;
+  background: #ffffff;
+  color: #b91c1c;
+  border-radius: 0.45rem;
+  padding: 0.3rem 0.55rem;
+  font: inherit;
 }
 
 .suggestions-grid {
@@ -1304,105 +1264,6 @@ body {
   font-size: 1rem;
 }
 
-.detail-panel {
-  border: 1px solid #cbd5e1;
-  border-radius: 0.7rem;
-  background: #ffffff;
-  padding: 0.75rem;
-  display: grid;
-  gap: 0.55rem;
-}
-
-.detail-panel h2 {
-  margin: 0;
-  color: #0f172a;
-  font-size: 1rem;
-}
-
-.detail-path {
-  margin: 0;
-  color: #475569;
-  font-size: 0.84rem;
-  overflow-wrap: anywhere;
-}
-
-.detail-panel dl {
-  margin: 0;
-  display: grid;
-  gap: 0.35rem;
-}
-
-.detail-panel dl div {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.6rem;
-}
-
-.detail-panel dt {
-  color: #475569;
-  font-size: 0.8rem;
-}
-
-.detail-panel dd {
-  margin: 0;
-  color: #0f172a;
-  font-size: 0.82rem;
-  text-align: right;
-  overflow-wrap: anywhere;
-}
-
-.detail-exif-attributes {
-  display: grid;
-  gap: 0.4rem;
-}
-
-.detail-exif-attributes-toggle {
-  justify-self: flex-start;
-  border: 1px solid #bfdbfe;
-  background: #eff6ff;
-  color: #1d4ed8;
-  border-radius: 0.45rem;
-  padding: 0.25rem 0.5rem;
-  font: inherit;
-  font-size: 0.78rem;
-}
-
-.detail-exif-attributes-list {
-  margin: 0;
-  display: grid;
-  gap: 0.3rem;
-  border: 1px solid #e2e8f0;
-  border-radius: 0.5rem;
-  background: #f8fafc;
-  padding: 0.45rem;
-}
-
-.detail-exif-attributes-list div {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 0.75rem;
-}
-
-.detail-exif-attributes-list dt,
-.detail-exif-attributes-list dd {
-  margin: 0;
-  font-size: 0.75rem;
-  line-height: 1.35;
-}
-
-.detail-exif-attributes-list dt {
-  color: #334155;
-  text-align: left;
-  overflow-wrap: anywhere;
-}
-
-.detail-exif-attributes-list dd {
-  color: #0f172a;
-  text-align: right;
-  overflow-wrap: anywhere;
-}
-
 .detail-media-controls {
   display: flex;
   flex-wrap: wrap;
@@ -1539,247 +1400,6 @@ body {
   gap: 0.35rem;
   color: #334155;
   font-size: 0.8rem;
-}
-
-.detail-flyout-backdrop {
-  display: none;
-}
-
-.face-assignment-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  border: 0;
-  background: rgb(15 23 42 / 55%);
-  z-index: 60;
-  margin: 0;
-  padding: 0;
-}
-
-.face-assignment-modal {
-  position: fixed;
-  inset: 50% auto auto 50%;
-  transform: translate(-50%, -50%);
-  width: min(48rem, calc(100vw - 2rem));
-  background: #ffffff;
-  border: 1px solid #cbd5e1;
-  border-radius: 0.75rem;
-  box-shadow: 0 24px 56px rgb(15 23 42 / 35%);
-  z-index: 61;
-  padding: 0.85rem;
-  display: grid;
-  gap: 0.75rem;
-}
-
-.face-assignment-modal-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.7rem;
-}
-
-.face-assignment-modal-header h3 {
-  margin: 0;
-  font-size: 1rem;
-  color: #0f172a;
-}
-
-.face-assignment-modal-header button {
-  border: 1px solid #cbd5e1;
-  background: #ffffff;
-  color: #334155;
-  border-radius: 0.45rem;
-  padding: 0.3rem 0.62rem;
-  font: inherit;
-}
-
-.face-assignment-modal-layout {
-  display: grid;
-  grid-template-columns: auto minmax(18rem, 1fr);
-  gap: 0.9rem;
-}
-
-.face-assignment-modal-preview {
-  display: grid;
-  align-content: start;
-  gap: 0.4rem;
-}
-
-.face-assignment-modal-preview p {
-  margin: 0;
-  color: #475569;
-  font-size: 0.78rem;
-}
-
-.face-assignment-modal-crop {
-  border: 1px solid #cbd5e1;
-  border-radius: 0.45rem;
-  overflow: hidden;
-  position: relative;
-  background: #f8fafc;
-}
-
-.face-assignment-modal-crop img {
-  display: block;
-  max-width: none;
-  position: absolute;
-  top: 0;
-  left: 0;
-}
-
-.face-assignment-modal-crop-placeholder {
-  border: 1px dashed #cbd5e1;
-  border-radius: 0.45rem;
-  padding: 0.8rem;
-  color: #64748b;
-  font-size: 0.8rem;
-}
-
-.face-assignment-modal-controls {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.face-assignment-modal-controls p {
-  margin: 0;
-  color: #334155;
-  font-size: 0.82rem;
-}
-
-.face-assignment-modal-controls label {
-  color: #475569;
-  font-size: 0.78rem;
-}
-
-.face-assignment-modal-controls input {
-  border: 1px solid #cbd5e1;
-  border-radius: 0.45rem;
-  padding: 0.38rem 0.52rem;
-  font: inherit;
-}
-
-.face-assignment-modal-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-}
-
-.face-assignment-modal-actions button {
-  border: 1px solid #bfdbfe;
-  background: #eff6ff;
-  color: #1d4ed8;
-  border-radius: 0.45rem;
-  padding: 0.38rem 0.62rem;
-  font: inherit;
-}
-
-.face-assignment-modal-dismiss {
-  justify-self: start;
-  border: 1px solid #fecaca;
-  background: #fff1f2;
-  color: #b91c1c;
-  border-radius: 0.45rem;
-  padding: 0.38rem 0.62rem;
-  font: inherit;
-}
-
-.face-assignment-modal-unlabeled-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-}
-
-.face-assignment-modal-unknown {
-  justify-self: start;
-  border: 1px solid #bae6fd;
-  background: #eff6ff;
-  color: #1d4ed8;
-  border-radius: 0.45rem;
-  padding: 0.38rem 0.62rem;
-  font: inherit;
-}
-
-.face-assignment-modal-suggestions {
-  border: 1px solid #bfdbfe;
-  border-radius: 0.55rem;
-  background: #eff6ff;
-  padding: 0.55rem 0.62rem;
-  display: grid;
-  gap: 0.35rem;
-}
-
-.face-assignment-modal-suggestions h4 {
-  margin: 0;
-  font-size: 0.83rem;
-  color: #1e3a8a;
-}
-
-.face-assignment-modal-suggestions p {
-  margin: 0;
-  font-size: 0.79rem;
-  color: #1e293b;
-}
-
-.face-assignment-modal-suggestions ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 0.3rem;
-}
-
-.face-assignment-modal-suggestions button {
-  border: 1px solid #bfdbfe;
-  background: #ffffff;
-  color: #1e3a8a;
-  border-radius: 0.42rem;
-  padding: 0.28rem 0.44rem;
-  font: inherit;
-  font-size: 0.78rem;
-}
-
-.detail-flyout {
-  position: fixed;
-  top: 0;
-  right: 0;
-  width: min(27rem, 92vw);
-  height: 100vh;
-  background: #ffffff;
-  border-left: 1px solid #cbd5e1;
-  box-shadow: -8px 0 24px rgb(15 23 42 / 14%);
-  z-index: 30;
-  transform: translateX(102%);
-  transition: transform 160ms ease;
-  padding: 0.8rem;
-  display: grid;
-  align-content: start;
-  gap: 0.7rem;
-  overflow-y: auto;
-}
-
-.detail-flyout.is-open {
-  transform: translateX(0);
-}
-
-.detail-flyout-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 0.55rem;
-}
-
-.detail-flyout-header h2 {
-  margin: 0;
-  color: #0f172a;
-  font-size: 1rem;
-}
-
-.detail-flyout-header button {
-  border: 1px solid #bfdbfe;
-  background: #eff6ff;
-  color: #1d4ed8;
-  border-radius: 0.45rem;
-  padding: 0.28rem 0.52rem;
-  font: inherit;
 }
 
 .detail-face-actions {
@@ -2020,12 +1640,6 @@ body {
   border-color: #cbd5e1;
   background: #f8fafc;
   color: #334155;
-}
-
-.detail-ingest-status-detail {
-  margin: 0;
-  color: #334155;
-  font-size: 0.8rem;
 }
 
 .feedback-panel {
@@ -2756,31 +2370,4 @@ body {
     grid-template-columns: auto minmax(8rem, 1fr);
   }
 
-  .detail-flyout {
-    width: 100vw;
-  }
-
-  .face-assignment-modal {
-    inset: auto 0 0 0;
-    transform: none;
-    width: 100vw;
-    border-radius: 0.75rem 0.75rem 0 0;
-    max-height: calc(100vh - 1.5rem);
-    overflow-y: auto;
-  }
-
-  .face-assignment-modal-layout {
-    grid-template-columns: 1fr;
-  }
-
-  .detail-flyout-backdrop.is-open {
-    display: block;
-    position: fixed;
-    inset: 0;
-    border: 0;
-    background: rgb(15 23 42 / 35%);
-    z-index: 20;
-    padding: 0;
-    margin: 0;
-  }
 }


### PR DESCRIPTION
## Summary
- add `include_face_info` search support so visible-page photos can include face data (bbox, assigned person, suggestions) in one response instead of per-photo fan-out
- update library/suggestions photo interaction surfaces to consume unified face payloads and remove redundant per-card face chips/details
- refresh face badge behavior and rendering (assigned/unknown icons, confidence battery levels), metadata affordance, and modal/local-state update flow after assignment
- expand backend and UI tests for new payload semantics and face interaction behavior

## Verification
- `uv run --group test python -m pytest apps/api/tests/test_search_service.py`
- `npm --prefix apps/ui test -- FaceOverlayLayer.test.tsx PhotoSurface.test.tsx`
- `npm --prefix apps/ui test -- LibraryRoutePage.test.tsx`
- `npm --prefix apps/ui test -- SuggestionsRoutePage.test.tsx`
