### PR TITLE
Fix library toggle persistence and location radius drag behavior

### DIFF
--- a/apps/api/app/repositories/photos_repo.py
+++ b/apps/api/app/repositories/photos_repo.py
@@ -23,6 +23,7 @@ from app.domain.facets import (
     FacetValue,
 )
 from app.core.pagination import iso_utc
+from app.services.people import UNKNOWN_PERSON_DISPLAY_NAME
 
 
 def _coerce_positive_int(value: object) -> int | None:
@@ -123,6 +124,111 @@ class PhotosRepository:
             .limit(1)
             .exists()
         )
+
+    def _faces_count_clause(self, faces_filter):
+        clauses = []
+        active_face_count = (
+            select(func.count())
+            .select_from(self.faces)
+            .where(
+                and_(
+                    self.faces.c.photo_id == self.photos.c.photo_id,
+                    self.faces.c.dismissed_ts.is_(None),
+                )
+            )
+            .scalar_subquery()
+        )
+        if faces_filter.min_count is not None:
+            clauses.append(active_face_count >= faces_filter.min_count)
+        if faces_filter.max_count is not None:
+            clauses.append(active_face_count <= faces_filter.max_count)
+        if not clauses:
+            return None
+        return and_(*clauses)
+
+    def _faces_top_certainty_clause(self, faces_filter):
+        min_certainty = faces_filter.top_certainty_min
+        max_certainty = faces_filter.top_certainty_max
+        if min_certainty is None and max_certainty is None:
+            return None
+
+        active_faces = self.faces.alias("active_faces")
+        top_face_suggestions = self._top_face_suggestions_subquery()
+        human_confirmed_assignment_exists = (
+            select(self.face_labels.c.face_id)
+            .where(
+                and_(
+                    self.face_labels.c.face_id == active_faces.c.face_id,
+                    self.face_labels.c.person_id == active_faces.c.person_id,
+                    self.face_labels.c.label_source == "human_confirmed",
+                )
+            )
+            .limit(1)
+            .exists()
+        )
+
+        effective_top_certainty = case(
+            (human_confirmed_assignment_exists, 1.0),
+            else_=top_face_suggestions.c.confidence,
+        )
+        certainty_clauses = []
+        if min_certainty is not None:
+            certainty_clauses.append(effective_top_certainty >= min_certainty)
+        if max_certainty is not None:
+            certainty_clauses.append(effective_top_certainty <= max_certainty)
+
+        matching_face_exists = (
+            select(active_faces.c.photo_id)
+            .select_from(
+                active_faces.outerjoin(
+                    top_face_suggestions,
+                    and_(
+                        top_face_suggestions.c.face_id == active_faces.c.face_id,
+                        top_face_suggestions.c.suggestion_order == 1,
+                    ),
+                )
+            )
+            .where(
+                and_(
+                    active_faces.c.photo_id == self.photos.c.photo_id,
+                    active_faces.c.dismissed_ts.is_(None),
+                    *certainty_clauses,
+                )
+            )
+            .limit(1)
+        )
+        return matching_face_exists.exists()
+
+    def _unknown_person_clause(self, faces_filter):
+        if faces_filter.has_unknown_person is not True:
+            return None
+
+        unknown_person_match_exists = (
+            select(self.faces.c.photo_id)
+            .select_from(
+                self.faces.join(
+                    self.people,
+                    self.faces.c.person_id == self.people.c.person_id,
+                ).join(
+                    self.face_labels,
+                    and_(
+                        self.face_labels.c.face_id == self.faces.c.face_id,
+                        self.face_labels.c.person_id == self.faces.c.person_id,
+                    ),
+                )
+            )
+            .where(
+                and_(
+                    self.faces.c.photo_id == self.photos.c.photo_id,
+                    self.faces.c.dismissed_ts.is_(None),
+                    self.people.c.display_name == UNKNOWN_PERSON_DISPLAY_NAME,
+                    self.face_labels.c.label_source == "human_confirmed",
+                )
+            )
+            .limit(1)
+            .exists()
+        )
+        return unknown_person_match_exists
 
     def _build_people_filter_clause(self, filters: SearchFilters):
         person_ids = filters.people or []
@@ -723,6 +829,19 @@ class PhotosRepository:
                 self.faces.c.photo_id == self.photos.c.photo_id
             ).limit(1)
             where_conditions.append(~faces_subquery.exists())
+
+        if filters.faces is not None:
+            faces_count_clause = self._faces_count_clause(filters.faces)
+            if faces_count_clause is not None:
+                where_conditions.append(faces_count_clause)
+
+            faces_top_certainty_clause = self._faces_top_certainty_clause(filters.faces)
+            if faces_top_certainty_clause is not None:
+                where_conditions.append(faces_top_certainty_clause)
+
+            unknown_person_clause = self._unknown_person_clause(filters.faces)
+            if unknown_person_clause is not None:
+                where_conditions.append(unknown_person_clause)
         
         people_clause = self._build_people_filter_clause(filters)
         if people_clause is not None:

--- a/apps/api/app/schemas/search_request.py
+++ b/apps/api/app/schemas/search_request.py
@@ -75,6 +75,37 @@ class LocationRadiusFilter(BaseModel):
         return value
 
 
+class FaceFilters(BaseModel):
+    min_count: Optional[int] = Field(default=None, ge=0)
+    max_count: Optional[int] = Field(default=None, ge=0)
+    top_certainty_min: Optional[float] = None
+    top_certainty_max: Optional[float] = None
+    has_unknown_person: Optional[bool] = None
+
+    @field_validator("top_certainty_min", "top_certainty_max")
+    @classmethod
+    def validate_top_certainty_bounds(cls, value: Optional[float]) -> Optional[float]:
+        if value is None:
+            return None
+        if not math.isfinite(value):
+            raise ValueError("top certainty bounds must be finite")
+        if value < 0 or value > 1:
+            raise ValueError("top certainty bounds must be between 0 and 1")
+        return value
+
+    @model_validator(mode="after")
+    def validate_face_ranges(self) -> "FaceFilters":
+        if self.min_count is not None and self.max_count is not None and self.min_count > self.max_count:
+            raise ValueError("min_count must be <= max_count")
+        if (
+            self.top_certainty_min is not None
+            and self.top_certainty_max is not None
+            and self.top_certainty_min > self.top_certainty_max
+        ):
+            raise ValueError("top_certainty_min must be <= top_certainty_max")
+        return self
+
+
 class SearchFilters(BaseModel):
     date: Optional[DateFilter] = None
     camera_make: Optional[List[str]] = None
@@ -90,6 +121,7 @@ class SearchFilters(BaseModel):
     person_certainty_mode: Optional[Literal["human_only", "include_suggestions"]] = None
     suggestion_confidence_min: Optional[float] = None
     location_radius: Optional[LocationRadiusFilter] = None
+    faces: Optional[FaceFilters] = None
 
     @field_validator("suggestion_confidence_min")
     @classmethod

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -119,6 +119,30 @@ def test_location_radius_validation_rejects_non_finite_values(location_radius):
         SearchFilters(location_radius=location_radius)
 
 
+def test_faces_filter_validation_rejects_negative_counts():
+    with pytest.raises(ValidationError) as exc_info:
+        SearchFilters(faces={"min_count": -1})
+
+    assert "greater than or equal to 0" in str(exc_info.value)
+
+
+def test_faces_filter_validation_rejects_invalid_certainty_bounds():
+    with pytest.raises(ValidationError) as exc_info:
+        SearchFilters(faces={"top_certainty_min": 1.2})
+
+    assert "top certainty bounds must be between 0 and 1" in str(exc_info.value)
+
+
+def test_faces_filter_validation_rejects_inverted_ranges():
+    with pytest.raises(ValidationError) as count_exc:
+        SearchFilters(faces={"min_count": 5, "max_count": 2})
+    assert "min_count must be <= max_count" in str(count_exc.value)
+
+    with pytest.raises(ValidationError) as certainty_exc:
+        SearchFilters(faces={"top_certainty_min": 0.9, "top_certainty_max": 0.1})
+    assert "top_certainty_min must be <= top_certainty_max" in str(certainty_exc.value)
+
+
 def test_page_spec_validation_supports_offset_and_rejects_cursor_offset_conflict():
     page = PageSpec(limit=50, offset=120)
     assert page.offset == 120

--- a/apps/api/tests/test_search_service.py
+++ b/apps/api/tests/test_search_service.py
@@ -1913,6 +1913,540 @@ class TestPhotosRepositorySoftDeleteFiltering:
         assert [item["photo_id"] for item in items] == ["birthday-no-faces"]
         assert total == 1
 
+    def test_faces_filter_count_range_filters_results(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-faces-count-range.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 5, 10, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "photo-zero",
+                        "path": "seed-corpus/family/photo-zero.jpg",
+                        "sha256": "0" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 0,
+                        "faces_detected_ts": None,
+                    },
+                    {
+                        "photo_id": "photo-one",
+                        "path": "seed-corpus/family/photo-one.jpg",
+                        "sha256": "1" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                    {
+                        "photo_id": "photo-two",
+                        "path": "seed-corpus/family/photo-two.jpg",
+                        "sha256": "2" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 2,
+                        "faces_detected_ts": now,
+                    },
+                    {
+                        "photo_id": "photo-dismissed",
+                        "path": "seed-corpus/family/photo-dismissed.jpg",
+                        "sha256": "3" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(faces),
+                [
+                    {
+                        "face_id": "face-photo-one-1",
+                        "photo_id": "photo-one",
+                        "person_id": None,
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                        "dismissed_ts": None,
+                    },
+                    {
+                        "face_id": "face-photo-two-1",
+                        "photo_id": "photo-two",
+                        "person_id": None,
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                        "dismissed_ts": None,
+                    },
+                    {
+                        "face_id": "face-photo-two-2",
+                        "photo_id": "photo-two",
+                        "person_id": None,
+                        "bbox_x": 10,
+                        "bbox_y": 10,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                        "dismissed_ts": None,
+                    },
+                    {
+                        "face_id": "face-photo-dismissed-1",
+                        "photo_id": "photo-dismissed",
+                        "person_id": None,
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                        "dismissed_ts": now,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            min_only_items, _, _ = repo.search_photos(
+                filters=SearchFilters(faces={"min_count": 1}),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert {item["photo_id"] for item in min_only_items} == {"photo-one", "photo-two"}
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            max_only_items, _, _ = repo.search_photos(
+                filters=SearchFilters(faces={"max_count": 1}),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert {item["photo_id"] for item in max_only_items} == {
+            "photo-zero",
+            "photo-one",
+            "photo-dismissed",
+        }
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            exact_items, total, _ = repo.search_photos(
+                filters=SearchFilters(faces={"min_count": 1, "max_count": 1}),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in exact_items] == ["photo-one"]
+        assert total == 1
+
+    def test_faces_filter_top_certainty_any_face_semantics(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-faces-top-certainty-any-face.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 5, 10, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "photo-any-face-match",
+                        "path": "seed-corpus/family/photo-any-face-match.jpg",
+                        "sha256": "4" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 2,
+                        "faces_detected_ts": now,
+                    },
+                    {
+                        "photo_id": "photo-no-match",
+                        "path": "seed-corpus/family/photo-no-match.jpg",
+                        "sha256": "5" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(people).values(
+                    person_id="person-inez",
+                    display_name="Inez Rivera",
+                    created_ts=now,
+                    updated_ts=now,
+                )
+            )
+            connection.execute(
+                insert(faces),
+                [
+                    {
+                        "face_id": "face-human-confirmed",
+                        "photo_id": "photo-any-face-match",
+                        "person_id": "person-inez",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                    {
+                        "face_id": "face-low-suggestion-same-photo",
+                        "photo_id": "photo-any-face-match",
+                        "person_id": None,
+                        "bbox_x": 10,
+                        "bbox_y": 10,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                    {
+                        "face_id": "face-medium-suggestion",
+                        "photo_id": "photo-no-match",
+                        "person_id": None,
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(face_labels).values(
+                    face_label_id="face-label-human-confirmed",
+                    face_id="face-human-confirmed",
+                    person_id="person-inez",
+                    label_source="human_confirmed",
+                    confidence=1.0,
+                    model_version="manual",
+                    provenance=None,
+                    created_ts=now,
+                    updated_ts=now,
+                )
+            )
+            connection.execute(
+                insert(face_suggestions),
+                [
+                    {
+                        "face_suggestion_id": "face-suggestion-low",
+                        "face_id": "face-low-suggestion-same-photo",
+                        "person_id": "person-inez",
+                        "rank": 1,
+                        "confidence": 0.20,
+                        "centroid_distance": 0.8,
+                        "knn_distance": 0.8,
+                        "representation_version": 1,
+                        "scoring_version": "hybrid-v1",
+                        "model_version": "nearest-neighbor-cosine-v1",
+                        "provenance": None,
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "face_suggestion_id": "face-suggestion-medium",
+                        "face_id": "face-medium-suggestion",
+                        "person_id": "person-inez",
+                        "rank": 1,
+                        "confidence": 0.45,
+                        "centroid_distance": 0.55,
+                        "knn_distance": 0.55,
+                        "representation_version": 1,
+                        "scoring_version": "hybrid-v1",
+                        "model_version": "nearest-neighbor-cosine-v1",
+                        "provenance": None,
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(faces={"top_certainty_min": 0.9, "top_certainty_max": 1.0}),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["photo-any-face-match"]
+        assert total == 1
+
+    def test_faces_filter_unknown_person_matches_at_least_one_unknown_assigned_face(self, tmp_path):
+        database_url = f"sqlite:///{tmp_path / 'search-faces-unknown-person.db'}"
+        upgrade_database(database_url)
+        engine = create_engine(database_url, future=True)
+        now = datetime(2026, 5, 10, tzinfo=UTC)
+
+        with engine.begin() as connection:
+            connection.execute(
+                insert(photos),
+                [
+                    {
+                        "photo_id": "photo-unknown",
+                        "path": "seed-corpus/family/photo-unknown.jpg",
+                        "sha256": "6" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                    {
+                        "photo_id": "photo-known",
+                        "path": "seed-corpus/family/photo-known.jpg",
+                        "sha256": "7" * 64,
+                        "phash": None,
+                        "filesize": 100,
+                        "ext": "jpg",
+                        "created_ts": now,
+                        "modified_ts": now,
+                        "shot_ts": now,
+                        "shot_ts_source": None,
+                        "camera_make": None,
+                        "camera_model": None,
+                        "software": None,
+                        "orientation": None,
+                        "gps_latitude": None,
+                        "gps_longitude": None,
+                        "gps_altitude": None,
+                        "updated_ts": now,
+                        "deleted_ts": None,
+                        "faces_count": 1,
+                        "faces_detected_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(people),
+                [
+                    {
+                        "person_id": "person-unknown",
+                        "display_name": "Unknown person",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "person_id": "person-known",
+                        "display_name": "Known Person",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(faces),
+                [
+                    {
+                        "face_id": "face-unknown",
+                        "photo_id": "photo-unknown",
+                        "person_id": "person-unknown",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                    {
+                        "face_id": "face-known",
+                        "photo_id": "photo-known",
+                        "person_id": "person-known",
+                        "bbox_x": 0,
+                        "bbox_y": 0,
+                        "bbox_w": 10,
+                        "bbox_h": 10,
+                        "bitmap": None,
+                        "embedding": None,
+                        "detector_name": "seed",
+                        "detector_version": "1",
+                        "provenance": None,
+                        "created_ts": now,
+                    },
+                ],
+            )
+            connection.execute(
+                insert(face_labels),
+                [
+                    {
+                        "face_label_id": "face-label-unknown",
+                        "face_id": "face-unknown",
+                        "person_id": "person-unknown",
+                        "label_source": "human_confirmed",
+                        "confidence": 1.0,
+                        "model_version": "manual",
+                        "provenance": None,
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "face_label_id": "face-label-known",
+                        "face_id": "face-known",
+                        "person_id": "person-known",
+                        "label_source": "human_confirmed",
+                        "confidence": 1.0,
+                        "model_version": "manual",
+                        "provenance": None,
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                ],
+            )
+
+        with Session(engine) as session:
+            repo = PhotosRepository(session)
+            items, total, _ = repo.search_photos(
+                filters=SearchFilters(faces={"has_unknown_person": True}),
+                sort=SortSpec(by="shot_ts", dir="desc"),
+                page=PageSpec(limit=50),
+            )
+
+        assert [item["photo_id"] for item in items] == ["photo-unknown"]
+        assert total == 1
+
     def test_search_repository_filters_by_person_names(self, tmp_path):
         database_url = f"sqlite:///{tmp_path / 'search-person-names.db'}"
         upgrade_database(database_url)

--- a/apps/ui/src/pages/LibraryRoutePage.test.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.test.tsx
@@ -300,6 +300,7 @@ describe("LibraryRoutePage", () => {
     expect(screen.getByRole("button", { name: "Location filter type" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Album filter type" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Path hints filter type" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Faces filter type" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Has faces filter type" })).toBeInTheDocument();
     expect(screen.queryByLabelText("From date")).not.toBeInTheDocument();
 
@@ -390,6 +391,52 @@ describe("LibraryRoutePage", () => {
 
     await user.click(screen.getByRole("button", { name: "Date filter type" }));
     expect(screen.getByLabelText("From date")).toHaveValue("2024-01-01");
+  });
+
+  it("renders faces range sliders and unknown checkbox in faces panel", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    await screen.findByRole("heading", { name: "Library", level: 1 });
+
+    await user.click(screen.getByRole("button", { name: "Faces filter type" }));
+    expect(screen.getByText("Face count range")).toBeInTheDocument();
+    expect(screen.getByText("Top certainty range")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Has face assigned to unknown person" })).toBeInTheDocument();
+  });
+
+  it("shows infinity label when max faces handle is unbounded", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    await screen.findByRole("heading", { name: "Library", level: 1 });
+
+    await user.click(screen.getByRole("button", { name: "Faces filter type" }));
+    expect(screen.getByText("At most faces: ∞")).toBeInTheDocument();
   });
 
   it("auto-closes date panel when both dates are chosen", async () => {
@@ -1156,6 +1203,114 @@ describe("LibraryRoutePage", () => {
           })
         })
       );
+    });
+  });
+
+  it("sends faces filter payload with count, certainty, and unknown fields", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+      if (url === "/api/v1/people") {
+        return {
+          ok: true,
+          json: async () => []
+        } as Response;
+      }
+      if (url !== "/api/v1/search") {
+        throw new Error(`Unhandled fetch: ${url}`);
+      }
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library?facesMin=2&facesMax=7&facesCertMin=60&facesCertMax=95&facesUnknown=1");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+
+    await waitFor(() => {
+      const searchBodies = fetchMock.mock.calls
+        .filter(([requestInput]) => String(requestInput) === "/api/v1/search")
+        .map(([, requestInit]) =>
+          JSON.parse((requestInit?.body as string | undefined) ?? "{}") as {
+            filters?: {
+              faces?: {
+                min_count?: number;
+                max_count?: number;
+                top_certainty_min?: number;
+                top_certainty_max?: number;
+                has_unknown_person?: boolean;
+              };
+            };
+          }
+        );
+      const matchedRequest = searchBodies.find(
+        (body) =>
+          body.filters?.faces?.min_count === 2 &&
+          body.filters?.faces?.max_count === 7 &&
+          body.filters?.faces?.top_certainty_min === 0.6 &&
+          body.filters?.faces?.top_certainty_max === 0.95 &&
+          body.filters?.faces?.has_unknown_person === true
+      );
+      expect(matchedRequest).toBeDefined();
+    });
+  });
+
+  it("suppresses certainty and unknown fields when faces range is 0..0", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+      if (url === "/api/v1/people") {
+        return {
+          ok: true,
+          json: async () => []
+        } as Response;
+      }
+      if (url !== "/api/v1/search") {
+        throw new Error(`Unhandled fetch: ${url}`);
+      }
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library?facesMin=0&facesMax=0&facesCertMin=65&facesCertMax=95&facesUnknown=1");
+    expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
+
+    await waitFor(() => {
+      const searchBodies = fetchMock.mock.calls
+        .filter(([requestInput]) => String(requestInput) === "/api/v1/search")
+        .map(([, requestInit]) =>
+          JSON.parse((requestInit?.body as string | undefined) ?? "{}") as {
+            filters?: {
+              faces?: {
+                min_count?: number;
+                max_count?: number;
+                top_certainty_min?: number;
+                top_certainty_max?: number;
+                has_unknown_person?: boolean;
+              };
+            };
+          }
+        );
+      const matchedRequest = searchBodies.find(
+        (body) => body.filters?.faces?.min_count === 0 && body.filters?.faces?.max_count === 0
+      );
+      expect(matchedRequest?.filters?.faces).toEqual({
+        min_count: 0,
+        max_count: 0
+      });
     });
   });
 

--- a/apps/ui/src/pages/LibraryRoutePage.test.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.test.tsx
@@ -366,6 +366,27 @@ describe("LibraryRoutePage", () => {
     expect(screen.getByRole("button", { name: "Done album filters" })).toBeInTheDocument();
   });
 
+  it("restores face boxes and album assignment toggles from URL", async () => {
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library?showFaces=1&showAlbumWidgets=1");
+    await screen.findByRole("heading", { name: "Library", level: 1 });
+
+    expect(screen.getByRole("checkbox", { name: "Show face boxes on all photos" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Enable album assignment widgets" })).toBeChecked();
+  });
+
   it("reverts date edits on cancel", async () => {
     const user = userEvent.setup();
     fetchMock.mockImplementation(async (input: string) => {
@@ -1842,10 +1863,12 @@ describe("LibraryRoutePage", () => {
 
     await user.click(screen.getByRole("link", { name: "Back to library" }));
 
-    expect(await screen.findByRole("button", { name: "Page 3" })).toHaveAttribute(
-      "aria-current",
-      "page"
-    );
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Page 3" })).toHaveAttribute(
+        "aria-current",
+        "page"
+      );
+    });
     expect(screen.getByRole("combobox", { name: "Photos per page" })).toHaveValue("24");
   });
 

--- a/apps/ui/src/pages/LibraryRoutePage.test.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.test.tsx
@@ -5,6 +5,10 @@ import { Link, MemoryRouter, Route, Routes, useLocation } from "react-router-dom
 import { LibraryRoutePage } from "./LibraryRoutePage";
 import { buildLibraryViewStateStorageKey } from "./library/libraryRouteMemory";
 
+vi.mock("./search/LocationRadiusPicker", () => ({
+  LocationRadiusPicker: () => <div data-testid="location-radius-picker" />
+}));
+
 type SearchResponsePayload = {
   hits: {
     total: number;
@@ -291,19 +295,31 @@ describe("LibraryRoutePage", () => {
 
     expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
     expect(screen.getByRole("textbox", { name: "Search query" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Filter labels" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Date filter type" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Person filter type" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Location filter type" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Album filter type" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Path hints filter type" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Has faces filter type" })).toBeInTheDocument();
     expect(screen.queryByLabelText("From date")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Filter labels" }));
+    await user.click(screen.getByRole("button", { name: "Date filter type" }));
 
     expect(screen.getByLabelText("From date")).toBeInTheDocument();
     expect(screen.getByLabelText("To date")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: "Person filter" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Person filter type" }));
+
     expect(screen.getByRole("textbox", { name: "Person filter" })).toBeInTheDocument();
     expect(screen.getByLabelText("Person certainty mode")).toBeInTheDocument();
+    expect(screen.queryByLabelText("From date")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Location filter type" }));
+
     expect(screen.getByLabelText("Latitude")).toBeInTheDocument();
     expect(screen.getByLabelText("Longitude")).toBeInTheDocument();
     expect(screen.getByLabelText("Radius (km)")).toBeInTheDocument();
-    expect(screen.getByLabelText("Facet filters")).toBeInTheDocument();
     expect(await screen.findByRole("list", { name: "Photo gallery" })).toBeInTheDocument();
 
     expect(screen.queryByRole("button", { name: "Review faces" })).not.toBeInTheDocument();
@@ -347,6 +363,139 @@ describe("LibraryRoutePage", () => {
     await user.click(screen.getByRole("button", { name: "Album filter type" }));
     expect(screen.queryByLabelText("Person filter")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Done album filters" })).toBeInTheDocument();
+  });
+
+  it("reverts date edits on cancel", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library?from=2024-01-01&to=2024-01-31");
+    await screen.findByRole("heading", { name: "Library", level: 1 });
+
+    await user.click(screen.getByRole("button", { name: "Date filter type" }));
+    await user.clear(screen.getByLabelText("From date"));
+    await user.type(screen.getByLabelText("From date"), "2024-02-01");
+    await user.click(screen.getByRole("button", { name: "Cancel date filters" }));
+
+    await user.click(screen.getByRole("button", { name: "Date filter type" }));
+    expect(screen.getByLabelText("From date")).toHaveValue("2024-01-01");
+  });
+
+  it("auto-closes date panel when both dates are chosen", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    await screen.findByRole("heading", { name: "Library", level: 1 });
+
+    await user.click(screen.getByRole("button", { name: "Date filter type" }));
+    await user.type(screen.getByLabelText("From date"), "2024-01-01");
+    await user.type(screen.getByLabelText("To date"), "2024-01-31");
+
+    expect(screen.queryByLabelText("From date")).not.toBeInTheDocument();
+  });
+
+  it("applies valid location and closes panel on apply", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    await screen.findByRole("heading", { name: "Library", level: 1 });
+
+    await user.click(screen.getByRole("button", { name: "Location filter type" }));
+    await user.type(screen.getByLabelText("Latitude"), "40.7");
+    await user.type(screen.getByLabelText("Longitude"), "-74.0");
+    await user.type(screen.getByLabelText("Radius (km)"), "3");
+    await user.click(screen.getByRole("button", { name: "Apply location filters" }));
+
+    expect(screen.queryByLabelText("Latitude")).not.toBeInTheDocument();
+  });
+
+  it("reverts location edits on cancel", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library?lat=40.7&lng=-74.0&radiusKm=2");
+    await screen.findByRole("heading", { name: "Library", level: 1 });
+
+    await user.click(screen.getByRole("button", { name: "Location filter type" }));
+    await user.clear(screen.getByLabelText("Latitude"));
+    await user.type(screen.getByLabelText("Latitude"), "12.3");
+    await user.click(screen.getByRole("button", { name: "Cancel location filters" }));
+
+    await user.click(screen.getByRole("button", { name: "Location filter type" }));
+    expect(screen.getByLabelText("Latitude")).toHaveValue("40.7");
+  });
+
+  it("cycles has-faces chip any with without any", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    await screen.findByRole("heading", { name: "Library", level: 1 });
+
+    const chip = screen.getByRole("button", { name: "Has faces filter type" });
+    await user.click(chip);
+    expect(screen.getByRole("button", { name: "Remove has faces filter with faces" })).toBeInTheDocument();
+    await user.click(chip);
+    expect(screen.getByRole("button", { name: "Remove has faces filter without faces" })).toBeInTheDocument();
+    await user.click(chip);
+    expect(screen.queryByText(/has faces:/i)).not.toBeInTheDocument();
   });
 
   it("shows shared album assignment widgets when enabled", async () => {
@@ -970,7 +1119,7 @@ describe("LibraryRoutePage", () => {
 
     expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Filter labels" }));
+    await user.click(screen.getByRole("button", { name: "Person filter type" }));
     await user.selectOptions(screen.getByLabelText("Person certainty mode"), "include_suggestions");
     const suggestionThresholdSlider = screen.getByRole("slider", { name: "Suggestion threshold" });
     suggestionThresholdSlider.focus();
@@ -1062,7 +1211,7 @@ describe("LibraryRoutePage", () => {
     expect(await screen.findByText("album: Family Trip")).toBeInTheDocument();
     expect(screen.queryByText("album: album-1")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Filter labels" }));
+    await user.click(screen.getByRole("button", { name: "Album filter type" }));
     expect(screen.getByRole("button", { name: "album: Family Trip" })).toBeInTheDocument();
   });
 
@@ -1098,7 +1247,7 @@ describe("LibraryRoutePage", () => {
     renderLibraryAt("/library");
     expect(await screen.findByRole("heading", { name: "Library", level: 1 })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Filter labels" }));
+    await user.click(screen.getByRole("button", { name: "Person filter type" }));
     await user.type(screen.getByRole("textbox", { name: "Person filter" }), "inez");
     await user.click(screen.getByRole("button", { name: "Add person filter" }));
 

--- a/apps/ui/src/pages/LibraryRoutePage.test.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.test.tsx
@@ -498,9 +498,9 @@ describe("LibraryRoutePage", () => {
       expect(searchCalls.length).toBeGreaterThan(1);
     });
 
-    const latestSearchCall = fetchMock.mock.calls
-      .filter(([requestInput]) => requestInput === "/api/v1/search")
-      .at(-1);
+    const searchCalls = fetchMock.mock.calls
+      .filter(([requestInput]) => requestInput === "/api/v1/search");
+    const latestSearchCall = searchCalls[searchCalls.length - 1];
     const latestSearchBody = JSON.parse(String(latestSearchCall?.[1]?.body ?? "{}")) as Record<string, unknown>;
     expect(latestSearchBody.include_face_info).toBe(true);
   });

--- a/apps/ui/src/pages/LibraryRoutePage.test.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.test.tsx
@@ -315,6 +315,40 @@ describe("LibraryRoutePage", () => {
     expect(screen.queryByRole("link", { name: "View details" })).not.toBeInTheDocument();
   });
 
+  it("opens one filter panel at a time from filter chips", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: string) => {
+      if (input === "/api/v1/operations/activity") {
+        return {
+          ok: true,
+          json: async () => ({ ingest_queue: { summary: { processing_count: 0 } } })
+        } as Response;
+      }
+
+      if (input === "/api/v1/albums") {
+        return {
+          ok: true,
+          json: async () => []
+        } as Response;
+      }
+
+      return {
+        ok: true,
+        json: async () => buildPayload(["photo-a"])
+      } as Response;
+    });
+
+    renderLibraryAt("/library");
+    await screen.findByRole("heading", { name: "Library", level: 1 });
+
+    await user.click(screen.getByRole("button", { name: "Person filter type" }));
+    expect(screen.getByLabelText("Person filter")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Album filter type" }));
+    expect(screen.queryByLabelText("Person filter")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Done album filters" })).toBeInTheDocument();
+  });
+
   it("shows shared album assignment widgets when enabled", async () => {
     const user = userEvent.setup();
     fetchMock.mockImplementation(async (input: string) => {

--- a/apps/ui/src/pages/LibraryRoutePage.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.tsx
@@ -198,7 +198,9 @@ export function LibraryRoutePage() {
         radiusDraft: parsedUrlState.radiusDraft,
         hasFacesFilter: parsedUrlState.hasFacesFilter,
         pathHintFilters: parsedUrlState.pathHintFilters,
-        facesFilter: parsedUrlState.facesFilter
+        facesFilter: parsedUrlState.facesFilter,
+        areFaceBoxesVisible: parsedUrlState.areFaceBoxesVisible,
+        areAlbumAssignmentWidgetsVisible: parsedUrlState.areAlbumAssignmentWidgetsVisible
       }),
     [parsedUrlState]
   );
@@ -240,7 +242,9 @@ export function LibraryRoutePage() {
   const [albumOptions, setAlbumOptions] = useState<Array<{ albumId: string; albumName: string }>>(
     []
   );
-  const [isAlbumInteractionEnabled, setIsAlbumInteractionEnabled] = useState(false);
+  const [isAlbumInteractionEnabled, setIsAlbumInteractionEnabled] = useState(
+    parsedUrlState.areAlbumAssignmentWidgetsVisible
+  );
   const [isAlbumActionSubmitting, setIsAlbumActionSubmitting] = useState(false);
   const [albumActionResultByPhotoId, setAlbumActionResultByPhotoId] = useState<Record<string, string>>({});
 
@@ -261,7 +265,10 @@ export function LibraryRoutePage() {
   );
   const [photoInspectorState, dispatchPhotoInspector] = useReducer(
     photoInspectorReducer,
-    DEFAULT_PHOTO_INSPECTOR_STATE
+    {
+      ...DEFAULT_PHOTO_INSPECTOR_STATE,
+      areFaceBoxesVisible: parsedUrlState.areFaceBoxesVisible
+    }
   );
   const [photoDetailById, setPhotoDetailById] = useState<Record<string, PhotoDetailPayload>>({});
   const [faceAssignmentOverridesByPhotoId, setFaceAssignmentOverridesByPhotoId] = useState<
@@ -373,6 +380,11 @@ export function LibraryRoutePage() {
       setHasFacesFilter(nextParsedState.hasFacesFilter);
       setPathHintFilters(nextParsedState.pathHintFilters);
       setFacesFilter(nextParsedState.facesFilter);
+      dispatchPhotoInspector({
+        type: "setFaceBoxesVisible",
+        visible: nextParsedState.areFaceBoxesVisible
+      });
+      setIsAlbumInteractionEnabled(nextParsedState.areAlbumAssignmentWidgetsVisible);
       setFallbackPathHintCounts(nextParsedState.pathHintFilters);
       if (shouldApplyViewState) {
         setSortDirection(nextParsedState.sortDirection);
@@ -399,6 +411,8 @@ export function LibraryRoutePage() {
     hasFacesFilter,
     pathHintFilters,
     facesFilter,
+    areFaceBoxesVisible: photoInspectorState.areFaceBoxesVisible,
+    areAlbumAssignmentWidgetsVisible: isAlbumInteractionEnabled,
     sortDirection,
     requestedPage,
     pageSize,

--- a/apps/ui/src/pages/LibraryRoutePage.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.tsx
@@ -69,6 +69,7 @@ import {
 } from "./search/locationFilter";
 import type { LocationRadiusValue } from "./search/types";
 import type {
+  LibraryFacesFilterState,
   PersonCertaintyMode,
   PersonRecord,
   SearchUrlState,
@@ -196,7 +197,8 @@ export function LibraryRoutePage() {
         longitudeDraft: parsedUrlState.longitudeDraft,
         radiusDraft: parsedUrlState.radiusDraft,
         hasFacesFilter: parsedUrlState.hasFacesFilter,
-        pathHintFilters: parsedUrlState.pathHintFilters
+        pathHintFilters: parsedUrlState.pathHintFilters,
+        facesFilter: parsedUrlState.facesFilter
       }),
     [parsedUrlState]
   );
@@ -234,6 +236,7 @@ export function LibraryRoutePage() {
   const [mapMessage, setMapMessage] = useState<string | null>(null);
   const [hasFacesFilter, setHasFacesFilter] = useState<boolean | null>(parsedUrlState.hasFacesFilter);
   const [pathHintFilters, setPathHintFilters] = useState<string[]>(parsedUrlState.pathHintFilters);
+  const [facesFilter, setFacesFilter] = useState<LibraryFacesFilterState>(parsedUrlState.facesFilter);
   const [albumOptions, setAlbumOptions] = useState<Array<{ albumId: string; albumName: string }>>(
     []
   );
@@ -342,6 +345,7 @@ export function LibraryRoutePage() {
     locationRadiusFilter,
     hasFacesFilter,
     pathHintFilters,
+    facesFilter,
     sortDirection,
     requestedPage,
     pageSize,
@@ -368,6 +372,7 @@ export function LibraryRoutePage() {
       setMapMessage(null);
       setHasFacesFilter(nextParsedState.hasFacesFilter);
       setPathHintFilters(nextParsedState.pathHintFilters);
+      setFacesFilter(nextParsedState.facesFilter);
       setFallbackPathHintCounts(nextParsedState.pathHintFilters);
       if (shouldApplyViewState) {
         setSortDirection(nextParsedState.sortDirection);
@@ -393,6 +398,7 @@ export function LibraryRoutePage() {
     locationRadiusFilter,
     hasFacesFilter,
     pathHintFilters,
+    facesFilter,
     sortDirection,
     requestedPage,
     pageSize,
@@ -623,6 +629,7 @@ export function LibraryRoutePage() {
     locationRadiusFilter,
     hasFacesFilter,
     pathHintFilters,
+    facesFilter,
     sortDirection
   });
   useLibraryReturnFocus({
@@ -1042,6 +1049,7 @@ export function LibraryRoutePage() {
             : null
         }
         hasFacesFilter={hasFacesFilter}
+        facesFilter={facesFilter}
         pathHintFilters={pathHintFilters}
         facetHasFacesCounts={facetHasFacesCounts}
         facetPathHintCounts={facetPathHintCounts}
@@ -1103,6 +1111,29 @@ export function LibraryRoutePage() {
         }}
         onTogglePathHintFilter={handleTogglePathHintFilter}
         onClearAllPathHints={handleClearAllPathHints}
+        onFacesCountRangeChange={(minCount, maxCount) => {
+          setFacesFilter((current) => ({
+            ...current,
+            minCount,
+            maxCount
+          }));
+          setPage(1);
+        }}
+        onFacesCertaintyRangeChange={(minCertaintyPct, maxCertaintyPct) => {
+          setFacesFilter((current) => ({
+            ...current,
+            certaintyMinPct: minCertaintyPct,
+            certaintyMaxPct: maxCertaintyPct
+          }));
+          setPage(1);
+        }}
+        onFacesUnknownPersonChange={(hasUnknownPerson) => {
+          setFacesFilter((current) => ({
+            ...current,
+            hasUnknownPerson
+          }));
+          setPage(1);
+        }}
       />
 
       <LibraryActiveFilterChips

--- a/apps/ui/src/pages/albums/albumLibraryQuery.ts
+++ b/apps/ui/src/pages/albums/albumLibraryQuery.ts
@@ -64,6 +64,8 @@ export function buildLibraryQueryForAlbum(album: AlbumRecord): string {
     locationRadius: null,
     hasFacesFilter: null,
     pathHintFilters: [] as string[],
+    areFaceBoxesVisible: false,
+    areAlbumAssignmentWidgetsVisible: false,
     sortDirection: "desc" as const,
     page: 1,
     pageSize: DEFAULT_SEARCH_PAGE_LIMIT

--- a/apps/ui/src/pages/library/LibrarySearchForm.tsx
+++ b/apps/ui/src/pages/library/LibrarySearchForm.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useState, type FormEventHandler } from "react";
-import { ConfidenceSingleSlider } from "../shared/ConfidenceSlider";
+import { ConfidenceRangeSlider, ConfidenceSingleSlider } from "../shared/ConfidenceSlider";
 import type { FacetCountEntry } from "../search/facetFilters";
 import { LocationRadiusPicker } from "../search/LocationRadiusPicker";
 import type { LocationRadiusValue } from "../search/types";
-import type { PersonCertaintyMode, PersonRecord } from "./libraryRouteTypes";
+import type {
+  LibraryFacesFilterState,
+  PersonCertaintyMode,
+  PersonRecord
+} from "./libraryRouteTypes";
 
-type OpenFilterPanel = "date" | "person" | "location" | "album" | "pathHints" | null;
+type OpenFilterPanel = "date" | "person" | "location" | "album" | "pathHints" | "faces" | null;
 
 interface LibrarySearchFormProps {
   queryInput: string;
@@ -22,6 +26,7 @@ interface LibrarySearchFormProps {
   radiusDraft: string;
   locationRadius: LocationRadiusValue | null;
   hasFacesFilter: boolean | null;
+  facesFilter: LibraryFacesFilterState;
   pathHintFilters: string[];
   facetHasFacesCounts: { true: number; false: number };
   facetPathHintCounts: FacetCountEntry[];
@@ -50,6 +55,9 @@ interface LibrarySearchFormProps {
   onClearAllAlbumFilters: () => void;
   onTogglePathHintFilter: (pathHint: string) => void;
   onClearAllPathHints: () => void;
+  onFacesCountRangeChange: (minCount: number, maxCount: number | null) => void;
+  onFacesCertaintyRangeChange: (minCertaintyPct: number, maxCertaintyPct: number) => void;
+  onFacesUnknownPersonChange: (hasUnknownPerson: boolean) => void;
 }
 
 export function LibrarySearchForm({
@@ -67,6 +75,7 @@ export function LibrarySearchForm({
   radiusDraft,
   locationRadius,
   hasFacesFilter,
+  facesFilter,
   pathHintFilters,
   facetHasFacesCounts,
   facetPathHintCounts,
@@ -94,7 +103,10 @@ export function LibrarySearchForm({
   onToggleAlbumFilter,
   onClearAllAlbumFilters,
   onTogglePathHintFilter,
-  onClearAllPathHints
+  onClearAllPathHints,
+  onFacesCountRangeChange,
+  onFacesCertaintyRangeChange,
+  onFacesUnknownPersonChange
 }: LibrarySearchFormProps) {
   const [openFilterPanel, setOpenFilterPanel] = useState<OpenFilterPanel>(null);
   const [dateSnapshot, setDateSnapshot] = useState<{ fromDate: string; toDate: string } | null>(null);
@@ -110,6 +122,9 @@ export function LibrarySearchForm({
   const hasLocationFilter = Boolean(locationRadius || latitudeDraft || longitudeDraft || radiusDraft);
   const hasAlbumFilter = selectedAlbumIds.length > 0;
   const hasPathHintFilter = pathHintFilters.length > 0;
+  const hasFacesAttributeFilter = isFacesAttributeFilterActive(facesFilter);
+  const isZeroFacesOnly = facesFilter.minCount === 0 && facesFilter.maxCount === 0;
+  const facesCountMax = facesFilter.maxCount ?? 10;
 
   useEffect(() => {
     if (openFilterPanel !== "date") {
@@ -199,6 +214,14 @@ export function LibrarySearchForm({
               onClick={() => handleFilterPanelClick("pathHints")}
             >
               Path hints
+            </button>
+            <button
+              type="button"
+              className={hasFacesAttributeFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
+              aria-label="Faces filter type"
+              onClick={() => handleFilterPanelClick("faces")}
+            >
+              Faces
             </button>
             <button
               type="button"
@@ -443,6 +466,60 @@ export function LibrarySearchForm({
             </div>
           </div>
         ) : null}
+
+        {openFilterPanel === "faces" ? (
+          <div className="search-filter-content">
+            <div className="search-faces-panel" aria-label="Faces filters">
+              <p className="search-filter-section-label">Face count range</p>
+              <ConfidenceRangeSlider
+                minBound={0}
+                maxBound={10}
+                minLabel="At least faces"
+                maxLabel="At most faces"
+                minValue={facesFilter.minCount}
+                maxValue={facesCountMax}
+                minValueFormatter={(value) => String(value)}
+                maxValueFormatter={(value) => (value === 10 ? "∞" : String(value))}
+                minThumbAriaLabel="Minimum face count"
+                maxThumbAriaLabel="Maximum face count"
+                onValueChange={(nextMin, nextMax) =>
+                  onFacesCountRangeChange(nextMin, nextMax === 10 ? null : nextMax)
+                }
+                disabled={false}
+              />
+              <p className="search-filter-section-label">Top certainty range</p>
+              <ConfidenceRangeSlider
+                minBound={0}
+                maxBound={100}
+                minLabel="Top certainty minimum"
+                maxLabel="Top certainty maximum"
+                minValue={facesFilter.certaintyMinPct}
+                maxValue={facesFilter.certaintyMaxPct}
+                onValueChange={onFacesCertaintyRangeChange}
+                disabled={isZeroFacesOnly}
+              />
+              <label className="search-filter-checkbox-row">
+                <input
+                  type="checkbox"
+                  checked={facesFilter.hasUnknownPerson}
+                  disabled={isZeroFacesOnly}
+                  onChange={(event) => onFacesUnknownPersonChange(event.target.checked)}
+                />
+                Has face assigned to unknown person
+              </label>
+              {isZeroFacesOnly ? (
+                <p className="search-faces-helper-text">
+                  Face certainty and unknown-person filters are disabled for exactly zero faces.
+                </p>
+              ) : null}
+            </div>
+            <div className="search-person-input-row">
+              <button type="button" onClick={() => setOpenFilterPanel(null)}>
+                Done faces filters
+              </button>
+            </div>
+          </div>
+        ) : null}
       </div>
 
       {dateRangeError ? (
@@ -500,4 +577,14 @@ function formatSuggestionThresholdDraft(percent: number): string {
 
 function hasSelectedPersonFilter(selectedPersonNames: string[], personDraft: string): boolean {
   return selectedPersonNames.length > 0 || personDraft.trim().length > 0;
+}
+
+function isFacesAttributeFilterActive(facesFilter: LibraryFacesFilterState): boolean {
+  return (
+    facesFilter.minCount > 0
+    || facesFilter.maxCount !== null
+    || facesFilter.certaintyMinPct > 0
+    || facesFilter.certaintyMaxPct < 100
+    || facesFilter.hasUnknownPerson
+  );
 }

--- a/apps/ui/src/pages/library/LibrarySearchForm.tsx
+++ b/apps/ui/src/pages/library/LibrarySearchForm.tsx
@@ -1,12 +1,11 @@
-import { useState, type FormEventHandler } from "react";
+import { useEffect, useState, type FormEventHandler } from "react";
 import { ConfidenceSingleSlider } from "../shared/ConfidenceSlider";
 import type { FacetCountEntry } from "../search/facetFilters";
-import { FacetFilterPanel } from "../search/FacetFilterPanel";
 import { LocationRadiusPicker } from "../search/LocationRadiusPicker";
 import type { LocationRadiusValue } from "../search/types";
 import type { PersonCertaintyMode, PersonRecord } from "./libraryRouteTypes";
 
-type OpenFilterPanel = "date" | "person" | "location" | "album" | "facets" | null;
+type OpenFilterPanel = "date" | "person" | "location" | "album" | "pathHints" | null;
 
 interface LibrarySearchFormProps {
   queryInput: string;
@@ -98,12 +97,53 @@ export function LibrarySearchForm({
   onClearAllPathHints
 }: LibrarySearchFormProps) {
   const [openFilterPanel, setOpenFilterPanel] = useState<OpenFilterPanel>(null);
+  const [dateSnapshot, setDateSnapshot] = useState<{ fromDate: string; toDate: string } | null>(null);
+  const [isDateAutoCloseArmed, setIsDateAutoCloseArmed] = useState(false);
+  const [locationSnapshot, setLocationSnapshot] = useState<{
+    latitudeDraft: string;
+    longitudeDraft: string;
+    radiusDraft: string;
+  } | null>(null);
   const suggestionThresholdPercent = normalizeSuggestionThresholdPercent(suggestionConfidenceMinDraft);
   const hasDateFilter = Boolean(fromDate || toDate);
   const hasPersonFilter = hasSelectedPersonFilter(selectedPersonNames, personDraft);
   const hasLocationFilter = Boolean(locationRadius || latitudeDraft || longitudeDraft || radiusDraft);
   const hasAlbumFilter = selectedAlbumIds.length > 0;
-  const hasFacetFilter = hasFacesFilter !== null || pathHintFilters.length > 0;
+  const hasPathHintFilter = pathHintFilters.length > 0;
+
+  useEffect(() => {
+    if (openFilterPanel !== "date") {
+      return;
+    }
+    if (!isDateAutoCloseArmed || !fromDate || !toDate || dateRangeError) {
+      return;
+    }
+    setOpenFilterPanel(null);
+  }, [dateRangeError, fromDate, isDateAutoCloseArmed, openFilterPanel, toDate]);
+
+  function handleFilterPanelClick(panel: Exclude<OpenFilterPanel, null>) {
+    const isOpening = openFilterPanel !== panel;
+    if (isOpening && panel === "date") {
+      setDateSnapshot({ fromDate, toDate });
+      setIsDateAutoCloseArmed(false);
+    }
+    if (isOpening && panel === "location") {
+      setLocationSnapshot({ latitudeDraft, longitudeDraft, radiusDraft });
+    }
+    setOpenFilterPanel(isOpening ? panel : null);
+  }
+
+  function handleHasFacesChipClick() {
+    if (hasFacesFilter === null) {
+      onToggleHasFacesFilter(true);
+      return;
+    }
+    if (hasFacesFilter === true) {
+      onToggleHasFacesFilter(false);
+      return;
+    }
+    onClearHasFacesFilter();
+  }
 
   return (
     <form className="search-query-form" onSubmit={onSubmit}>
@@ -124,9 +164,7 @@ export function LibrarySearchForm({
               type="button"
               className={hasDateFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
               aria-label="Date filter type"
-              onClick={() =>
-                setOpenFilterPanel((current) => (current === "date" ? null : "date"))
-              }
+              onClick={() => handleFilterPanelClick("date")}
             >
               Date
             </button>
@@ -134,9 +172,7 @@ export function LibrarySearchForm({
               type="button"
               className={hasPersonFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
               aria-label="Person filter type"
-              onClick={() =>
-                setOpenFilterPanel((current) => (current === "person" ? null : "person"))
-              }
+              onClick={() => handleFilterPanelClick("person")}
             >
               Person
             </button>
@@ -144,9 +180,7 @@ export function LibrarySearchForm({
               type="button"
               className={hasLocationFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
               aria-label="Location filter type"
-              onClick={() =>
-                setOpenFilterPanel((current) => (current === "location" ? null : "location"))
-              }
+              onClick={() => handleFilterPanelClick("location")}
             >
               Location
             </button>
@@ -154,21 +188,26 @@ export function LibrarySearchForm({
               type="button"
               className={hasAlbumFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
               aria-label="Album filter type"
-              onClick={() =>
-                setOpenFilterPanel((current) => (current === "album" ? null : "album"))
-              }
+              onClick={() => handleFilterPanelClick("album")}
             >
               Album
             </button>
             <button
               type="button"
-              className={hasFacetFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
-              aria-label="Facet filter type"
-              onClick={() =>
-                setOpenFilterPanel((current) => (current === "facets" ? null : "facets"))
-              }
+              className={hasPathHintFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
+              aria-label="Path hints filter type"
+              onClick={() => handleFilterPanelClick("pathHints")}
             >
-              Facets
+              Path hints
+            </button>
+            <button
+              type="button"
+              className={hasFacesFilter !== null ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
+              aria-label="Has faces filter type"
+              title={`With faces: ${facetHasFacesCounts.true}, Without faces: ${facetHasFacesCounts.false}`}
+              onClick={handleHasFacesChipClick}
+            >
+              Has faces
             </button>
           </span>
         </div>
@@ -181,7 +220,10 @@ export function LibrarySearchForm({
                 id="search-date-from"
                 type="date"
                 value={fromDate}
-                onChange={(event) => onFromDateChange(event.target.value)}
+                onChange={(event) => {
+                  setIsDateAutoCloseArmed(true);
+                  onFromDateChange(event.target.value);
+                }}
                 aria-describedby="search-date-validation"
               />
               <label htmlFor="search-date-to">To date</label>
@@ -189,9 +231,26 @@ export function LibrarySearchForm({
                 id="search-date-to"
                 type="date"
                 value={toDate}
-                onChange={(event) => onToDateChange(event.target.value)}
+                onChange={(event) => {
+                  setIsDateAutoCloseArmed(true);
+                  onToDateChange(event.target.value);
+                }}
                 aria-describedby="search-date-validation"
               />
+            </div>
+            <div className="search-person-input-row">
+              <button
+                type="button"
+                onClick={() => {
+                  if (dateSnapshot) {
+                    onFromDateChange(dateSnapshot.fromDate);
+                    onToDateChange(dateSnapshot.toDate);
+                  }
+                  setOpenFilterPanel(null);
+                }}
+              >
+                Cancel date filters
+              </button>
             </div>
           </div>
         ) : null}
@@ -238,6 +297,11 @@ export function LibrarySearchForm({
                 </div>
               ) : null}
             </div>
+            <div className="search-person-input-row">
+              <button type="button" onClick={() => setOpenFilterPanel(null)}>
+                Done person filters
+              </button>
+            </div>
           </div>
         ) : null}
 
@@ -276,25 +340,64 @@ export function LibrarySearchForm({
               </div>
               <LocationRadiusPicker value={locationRadius} onChange={onMapLocationChange} onMapError={onMapError} />
             </div>
+            <div className="search-person-input-row">
+              <button
+                type="button"
+                onClick={() => {
+                  if (!locationError) {
+                    setOpenFilterPanel(null);
+                  }
+                }}
+              >
+                Apply location filters
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  if (locationSnapshot) {
+                    onLatitudeDraftChange(locationSnapshot.latitudeDraft);
+                    onLongitudeDraftChange(locationSnapshot.longitudeDraft);
+                    onRadiusDraftChange(locationSnapshot.radiusDraft);
+                  }
+                  setOpenFilterPanel(null);
+                }}
+              >
+                Cancel location filters
+              </button>
+            </div>
           </div>
         ) : null}
 
         {openFilterPanel === "album" ? (
           <div className="search-filter-content">
-            <FacetFilterPanel
-              hasFacesFilter={hasFacesFilter}
-              selectedAlbumIds={selectedAlbumIds}
-              pathHintFilters={pathHintFilters}
-              albumOptions={albumFilterOptions}
-              hasFacesCounts={facetHasFacesCounts}
-              pathHintCounts={facetPathHintCounts}
-              onToggleHasFaces={onToggleHasFacesFilter}
-              onClearHasFaces={onClearHasFacesFilter}
-              onToggleAlbum={onToggleAlbumFilter}
-              onClearAllAlbums={onClearAllAlbumFilters}
-              onTogglePathHint={onTogglePathHintFilter}
-              onClearAllPathHints={onClearAllPathHints}
-            />
+            <div className="search-facet-panel" aria-label="Album filters">
+              <p className="search-filter-section-label">Albums</p>
+              <div className="search-facet-options">
+                {albumFilterOptions.length > 0 ? (
+                  albumFilterOptions.map((entry) => {
+                    const isActive = selectedAlbumIds.includes(entry.albumId);
+                    return (
+                      <button
+                        key={entry.albumId}
+                        type="button"
+                        className={`search-facet-option${isActive ? " search-facet-option-active" : ""}`}
+                        aria-pressed={isActive}
+                        onClick={() => onToggleAlbumFilter(entry.albumId)}
+                      >
+                        album: {entry.albumName}
+                      </button>
+                    );
+                  })
+                ) : (
+                  <p className="search-facet-empty">No editable albums yet.</p>
+                )}
+                {selectedAlbumIds.length > 0 ? (
+                  <button type="button" className="search-facet-clear" onClick={onClearAllAlbumFilters}>
+                    Clear albums
+                  </button>
+                ) : null}
+              </div>
+            </div>
             <div className="search-person-input-row">
               <button type="button" onClick={() => setOpenFilterPanel(null)}>
                 Done album filters
@@ -303,22 +406,41 @@ export function LibrarySearchForm({
           </div>
         ) : null}
 
-        {openFilterPanel === "facets" ? (
+        {openFilterPanel === "pathHints" ? (
           <div className="search-filter-content">
-            <FacetFilterPanel
-              hasFacesFilter={hasFacesFilter}
-              selectedAlbumIds={selectedAlbumIds}
-              pathHintFilters={pathHintFilters}
-              albumOptions={albumFilterOptions}
-              hasFacesCounts={facetHasFacesCounts}
-              pathHintCounts={facetPathHintCounts}
-              onToggleHasFaces={onToggleHasFacesFilter}
-              onClearHasFaces={onClearHasFacesFilter}
-              onToggleAlbum={onToggleAlbumFilter}
-              onClearAllAlbums={onClearAllAlbumFilters}
-              onTogglePathHint={onTogglePathHintFilter}
-              onClearAllPathHints={onClearAllPathHints}
-            />
+            <div className="search-facet-panel" aria-label="Path hint filters">
+              <p className="search-filter-section-label">Path hints</p>
+              <div className="search-facet-options">
+                {facetPathHintCounts.length > 0 ? (
+                  facetPathHintCounts.map((entry) => {
+                    const isActive = pathHintFilters.includes(entry.value);
+                    return (
+                      <button
+                        key={entry.value}
+                        type="button"
+                        className={`search-facet-option${isActive ? " search-facet-option-active" : ""}`}
+                        aria-pressed={isActive}
+                        onClick={() => onTogglePathHintFilter(entry.value)}
+                      >
+                        path: {entry.value} ({entry.count})
+                      </button>
+                    );
+                  })
+                ) : (
+                  <p className="search-facet-empty">Submit a search to load path-hint counts.</p>
+                )}
+                {pathHintFilters.length > 0 ? (
+                  <button type="button" className="search-facet-clear" onClick={onClearAllPathHints}>
+                    Clear path hints
+                  </button>
+                ) : null}
+              </div>
+            </div>
+            <div className="search-person-input-row">
+              <button type="button" onClick={() => setOpenFilterPanel(null)}>
+                Done path hint filters
+              </button>
+            </div>
           </div>
         ) : null}
       </div>

--- a/apps/ui/src/pages/library/LibrarySearchForm.tsx
+++ b/apps/ui/src/pages/library/LibrarySearchForm.tsx
@@ -6,6 +6,8 @@ import { LocationRadiusPicker } from "../search/LocationRadiusPicker";
 import type { LocationRadiusValue } from "../search/types";
 import type { PersonCertaintyMode, PersonRecord } from "./libraryRouteTypes";
 
+type OpenFilterPanel = "date" | "person" | "location" | "album" | "facets" | null;
+
 interface LibrarySearchFormProps {
   queryInput: string;
   fromDate: string;
@@ -95,7 +97,7 @@ export function LibrarySearchForm({
   onTogglePathHintFilter,
   onClearAllPathHints
 }: LibrarySearchFormProps) {
-  const [isFilterEditorOpen, setIsFilterEditorOpen] = useState(false);
+  const [openFilterPanel, setOpenFilterPanel] = useState<OpenFilterPanel>(null);
   const suggestionThresholdPercent = normalizeSuggestionThresholdPercent(suggestionConfidenceMinDraft);
   const hasDateFilter = Boolean(fromDate || toDate);
   const hasPersonFilter = hasSelectedPersonFilter(selectedPersonNames, personDraft);
@@ -115,41 +117,64 @@ export function LibrarySearchForm({
       </div>
 
       <div className="search-filter-disclosure">
-        <button
-          type="button"
-          className="search-filter-summary"
-          aria-label="Filter labels"
-          aria-expanded={isFilterEditorOpen}
-          aria-controls="library-filter-editor"
-          onClick={() => setIsFilterEditorOpen((current) => !current)}
-        >
+        <div className="search-filter-summary" aria-label="Filter labels">
           <span className="search-filter-summary-title">Filter labels</span>
           <span className="search-filter-summary-line">
-            <span className={hasDateFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}>
+            <button
+              type="button"
+              className={hasDateFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
+              aria-label="Date filter type"
+              onClick={() =>
+                setOpenFilterPanel((current) => (current === "date" ? null : "date"))
+              }
+            >
               Date
-            </span>
-            <span
+            </button>
+            <button
+              type="button"
               className={hasPersonFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
+              aria-label="Person filter type"
+              onClick={() =>
+                setOpenFilterPanel((current) => (current === "person" ? null : "person"))
+              }
             >
               Person
-            </span>
-            <span
+            </button>
+            <button
+              type="button"
               className={hasLocationFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
+              aria-label="Location filter type"
+              onClick={() =>
+                setOpenFilterPanel((current) => (current === "location" ? null : "location"))
+              }
             >
               Location
-            </span>
-            <span className={hasAlbumFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}>
+            </button>
+            <button
+              type="button"
+              className={hasAlbumFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
+              aria-label="Album filter type"
+              onClick={() =>
+                setOpenFilterPanel((current) => (current === "album" ? null : "album"))
+              }
+            >
               Album
-            </span>
-            <span className={hasFacetFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}>
+            </button>
+            <button
+              type="button"
+              className={hasFacetFilter ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
+              aria-label="Facet filter type"
+              onClick={() =>
+                setOpenFilterPanel((current) => (current === "facets" ? null : "facets"))
+              }
+            >
               Facets
-            </span>
+            </button>
           </span>
-          <span className="search-filter-summary-action">{isFilterEditorOpen ? "Hide" : "Edit"}</span>
-        </button>
+        </div>
 
-        {isFilterEditorOpen ? (
-          <div id="library-filter-editor" className="search-filter-content">
+        {openFilterPanel === "date" ? (
+          <div className="search-filter-content">
             <div className="search-date-row">
               <label htmlFor="search-date-from">From date</label>
               <input
@@ -168,7 +193,11 @@ export function LibrarySearchForm({
                 aria-describedby="search-date-validation"
               />
             </div>
+          </div>
+        ) : null}
 
+        {openFilterPanel === "person" ? (
+          <div className="search-filter-content">
             <div className="search-person-row">
               <label htmlFor="search-person-input">Person filter</label>
               <div className="search-person-input-row">
@@ -209,7 +238,11 @@ export function LibrarySearchForm({
                 </div>
               ) : null}
             </div>
+          </div>
+        ) : null}
 
+        {openFilterPanel === "location" ? (
+          <div className="search-filter-content">
             <div className="search-location-panel">
               <p className="search-filter-section-label">Location radius</p>
               <div className="search-location-row">
@@ -243,7 +276,35 @@ export function LibrarySearchForm({
               </div>
               <LocationRadiusPicker value={locationRadius} onChange={onMapLocationChange} onMapError={onMapError} />
             </div>
+          </div>
+        ) : null}
 
+        {openFilterPanel === "album" ? (
+          <div className="search-filter-content">
+            <FacetFilterPanel
+              hasFacesFilter={hasFacesFilter}
+              selectedAlbumIds={selectedAlbumIds}
+              pathHintFilters={pathHintFilters}
+              albumOptions={albumFilterOptions}
+              hasFacesCounts={facetHasFacesCounts}
+              pathHintCounts={facetPathHintCounts}
+              onToggleHasFaces={onToggleHasFacesFilter}
+              onClearHasFaces={onClearHasFacesFilter}
+              onToggleAlbum={onToggleAlbumFilter}
+              onClearAllAlbums={onClearAllAlbumFilters}
+              onTogglePathHint={onTogglePathHintFilter}
+              onClearAllPathHints={onClearAllPathHints}
+            />
+            <div className="search-person-input-row">
+              <button type="button" onClick={() => setOpenFilterPanel(null)}>
+                Done album filters
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {openFilterPanel === "facets" ? (
+          <div className="search-filter-content">
             <FacetFilterPanel
               hasFacesFilter={hasFacesFilter}
               selectedAlbumIds={selectedAlbumIds}

--- a/apps/ui/src/pages/library/libraryRouteApi.ts
+++ b/apps/ui/src/pages/library/libraryRouteApi.ts
@@ -6,6 +6,7 @@ import {
   type SearchPageLimit
 } from "./libraryPageSize";
 import type {
+  LibraryFacesFilterState,
   LibraryLocationRadius,
   PersonCertaintyMode,
   PersonRecord,
@@ -86,6 +87,7 @@ export async function fetchLibraryPage(
   locationRadius: LibraryLocationRadius | null,
   hasFaces: boolean | null,
   pathHints: string[],
+  facesFilter: LibraryFacesFilterState,
   sortDirection: SortDirection,
   offset: number,
   pageLimit: number,
@@ -100,7 +102,8 @@ export async function fetchLibraryPage(
     suggestionConfidenceMinDraft,
     locationRadius,
     hasFaces,
-    pathHints
+    pathHints,
+    facesFilter
   );
   const requestBody = {
     ...(query ? { q: query } : {}),

--- a/apps/ui/src/pages/library/libraryRouteSearchState.test.ts
+++ b/apps/ui/src/pages/library/libraryRouteSearchState.test.ts
@@ -205,4 +205,32 @@ describe("libraryRouteSearchState", () => {
     });
     expect(filters?.faces).toEqual({ min_count: 0, max_count: 0 });
   });
+
+  it("parses and serializes face boxes and album widgets toggles", () => {
+    const state = parseLibraryUrlState("?showFaces=1&showAlbumWidgets=1");
+    expect(state.areFaceBoxesVisible).toBe(true);
+    expect(state.areAlbumAssignmentWidgetsVisible).toBe(true);
+
+    const query = buildLibraryUrlQuery({
+      queryChips: [],
+      fromDate: "",
+      toDate: "",
+      selectedPersonNames: [],
+      selectedAlbumIds: [],
+      personCertaintyMode: "human_only",
+      suggestionConfidenceMinDraft: "0.8",
+      locationRadius: null,
+      hasFacesFilter: null,
+      pathHintFilters: [],
+      facesFilter: state.facesFilter,
+      areFaceBoxesVisible: true,
+      areAlbumAssignmentWidgetsVisible: true,
+      page: 1,
+      pageSize: 60,
+      sortDirection: "desc"
+    });
+
+    expect(query).toContain("showFaces=1");
+    expect(query).toContain("showAlbumWidgets=1");
+  });
 });

--- a/apps/ui/src/pages/library/libraryRouteSearchState.test.ts
+++ b/apps/ui/src/pages/library/libraryRouteSearchState.test.ts
@@ -131,4 +131,78 @@ describe("libraryRouteSearchState", () => {
       album_ids: ["album-1"]
     });
   });
+
+  it("parses and serializes faces filter params", () => {
+    const state = parseLibraryUrlState(
+      "?facesMin=2&facesMax=7&facesCertMin=60&facesCertMax=95&facesUnknown=1"
+    );
+    expect(state.facesFilter).toEqual({
+      minCount: 2,
+      maxCount: 7,
+      certaintyMinPct: 60,
+      certaintyMaxPct: 95,
+      hasUnknownPerson: true
+    });
+
+    const query = buildLibraryUrlQuery({
+      queryChips: [],
+      fromDate: "",
+      toDate: "",
+      selectedPersonNames: [],
+      selectedAlbumIds: [],
+      personCertaintyMode: "human_only",
+      suggestionConfidenceMinDraft: "0.8",
+      locationRadius: null,
+      hasFacesFilter: null,
+      pathHintFilters: [],
+      facesFilter: state.facesFilter,
+      page: 1,
+      pageSize: 60,
+      sortDirection: "desc"
+    });
+
+    expect(query).toContain("facesMin=2");
+    expect(query).toContain("facesMax=7");
+    expect(query).toContain("facesCertMin=60");
+    expect(query).toContain("facesCertMax=95");
+    expect(query).toContain("facesUnknown=1");
+  });
+
+  it("omits faces count defaults 0..infinity in URL and payload", () => {
+    const query = buildLibraryUrlQuery({
+      queryChips: [],
+      fromDate: "",
+      toDate: "",
+      selectedPersonNames: [],
+      selectedAlbumIds: [],
+      personCertaintyMode: "human_only",
+      suggestionConfidenceMinDraft: "0.8",
+      locationRadius: null,
+      hasFacesFilter: null,
+      pathHintFilters: [],
+      facesFilter: {
+        minCount: 0,
+        maxCount: null,
+        certaintyMinPct: 0,
+        certaintyMaxPct: 100,
+        hasUnknownPerson: false
+      },
+      page: 1,
+      pageSize: 60,
+      sortDirection: "desc"
+    });
+    expect(query).not.toContain("facesMin=");
+    expect(query).not.toContain("facesMax=");
+  });
+
+  it("omits face-attribute clauses when range is 0..0", () => {
+    const filters = buildSearchFilters("", "", [], [], "human_only", "0.8", null, null, [], {
+      minCount: 0,
+      maxCount: 0,
+      certaintyMinPct: 65,
+      certaintyMaxPct: 95,
+      hasUnknownPerson: true
+    });
+    expect(filters?.faces).toEqual({ min_count: 0, max_count: 0 });
+  });
 });

--- a/apps/ui/src/pages/library/libraryRouteSearchState.ts
+++ b/apps/ui/src/pages/library/libraryRouteSearchState.ts
@@ -261,6 +261,8 @@ export function parseLibraryUrlState(search: string): SearchUrlState {
   const pathHintFilters = normalizePathHintFilters(params.getAll("pathHint"));
   const hasFacesFilter = parseNullableBooleanParam(params.get("hasFaces"));
   const facesFilter = parseFacesFilterState(params);
+  const areFaceBoxesVisible = parseBooleanFlag(params.get("showFaces"));
+  const areAlbumAssignmentWidgetsVisible = parseBooleanFlag(params.get("showAlbumWidgets"));
 
   const latitudeCandidate = (params.get("lat") ?? "").trim();
   const longitudeCandidate = (params.get("lng") ?? "").trim();
@@ -299,7 +301,9 @@ export function parseLibraryUrlState(search: string): SearchUrlState {
     locationRadius,
     hasFacesFilter,
     pathHintFilters,
-    facesFilter
+    facesFilter,
+    areFaceBoxesVisible,
+    areAlbumAssignmentWidgetsVisible
   };
 }
 
@@ -315,6 +319,8 @@ export function buildLibraryUrlQuery(state: {
   hasFacesFilter: boolean | null;
   pathHintFilters: string[];
   facesFilter?: LibraryFacesFilterState;
+  areFaceBoxesVisible?: boolean;
+  areAlbumAssignmentWidgetsVisible?: boolean;
   sortDirection: SortDirection;
   page: number;
   pageSize: number;
@@ -375,6 +381,12 @@ export function buildLibraryUrlQuery(state: {
     if (facesFilter.hasUnknownPerson) {
       params.set("facesUnknown", "1");
     }
+  }
+  if (state.areFaceBoxesVisible) {
+    params.set("showFaces", "1");
+  }
+  if (state.areAlbumAssignmentWidgetsVisible) {
+    params.set("showAlbumWidgets", "1");
   }
   if (state.sortDirection !== DEFAULT_SORT_DIRECTION) {
     params.set("sort", state.sortDirection);

--- a/apps/ui/src/pages/library/libraryRouteSearchState.ts
+++ b/apps/ui/src/pages/library/libraryRouteSearchState.ts
@@ -9,6 +9,7 @@ import {
   parseNullableBooleanParam
 } from "./urlSerialization";
 import type {
+  LibraryFacesFilterState,
   LibraryLocationRadius,
   PersonCertaintyMode,
   SortDirection,
@@ -23,6 +24,15 @@ const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const DEFAULT_PERSON_CERTAINTY_MODE: PersonCertaintyMode = "human_only";
 const DEFAULT_SUGGESTION_CONFIDENCE_MIN = "0.8";
 const DEFAULT_SORT_DIRECTION: SortDirection = "desc";
+const MIN_FACES_BOUND = 0;
+const MAX_FACES_BOUND = 10;
+const DEFAULT_FACES_FILTER: LibraryFacesFilterState = {
+  minCount: 0,
+  maxCount: null,
+  certaintyMinPct: 0,
+  certaintyMaxPct: 100,
+  hasUnknownPerson: false
+};
 
 function isValidIsoDate(value: string): boolean {
   if (!DATE_PATTERN.test(value)) {
@@ -89,6 +99,105 @@ function parseSortDirection(raw: string | null): SortDirection {
   return DEFAULT_SORT_DIRECTION;
 }
 
+function parseIntegerInRange(
+  raw: string | null,
+  minValue: number,
+  maxValue: number
+): number | null {
+  if (raw === null) {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed < minValue || parsed > maxValue) {
+    return null;
+  }
+  return parsed;
+}
+
+function parseBooleanFlag(raw: string | null): boolean {
+  if (raw === null) {
+    return false;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+}
+
+function parseFacesFilterState(params: URLSearchParams): LibraryFacesFilterState {
+  const parsedMin = parseIntegerInRange(params.get("facesMin"), MIN_FACES_BOUND, MAX_FACES_BOUND);
+  const parsedMax = parseIntegerInRange(params.get("facesMax"), MIN_FACES_BOUND, MAX_FACES_BOUND);
+  const parsedCertaintyMin = parseIntegerInRange(params.get("facesCertMin"), 0, 100);
+  const parsedCertaintyMax = parseIntegerInRange(params.get("facesCertMax"), 0, 100);
+
+  const normalizedMinCount = parsedMin ?? DEFAULT_FACES_FILTER.minCount;
+  const normalizedMaxCount =
+    parsedMax === null || parsedMax >= MAX_FACES_BOUND ? null : parsedMax;
+  const minCount =
+    normalizedMaxCount !== null && normalizedMinCount > normalizedMaxCount
+      ? normalizedMaxCount
+      : normalizedMinCount;
+
+  const certaintyMinPct = parsedCertaintyMin ?? DEFAULT_FACES_FILTER.certaintyMinPct;
+  const certaintyMaxPct = parsedCertaintyMax ?? DEFAULT_FACES_FILTER.certaintyMaxPct;
+
+  return {
+    minCount,
+    maxCount: normalizedMaxCount,
+    certaintyMinPct: Math.min(certaintyMinPct, certaintyMaxPct),
+    certaintyMaxPct: Math.max(certaintyMinPct, certaintyMaxPct),
+    hasUnknownPerson: parseBooleanFlag(params.get("facesUnknown"))
+  };
+}
+
+function isZeroFacesOnly(facesFilter: LibraryFacesFilterState): boolean {
+  return facesFilter.minCount === 0 && facesFilter.maxCount === 0;
+}
+
+function normalizeFacesFilterForPayload(
+  facesFilter: LibraryFacesFilterState
+):
+  | {
+      min_count?: number;
+      max_count?: number;
+      top_certainty_min?: number;
+      top_certainty_max?: number;
+      has_unknown_person?: boolean;
+    }
+  | null {
+  const payload: {
+    min_count?: number;
+    max_count?: number;
+    top_certainty_min?: number;
+    top_certainty_max?: number;
+    has_unknown_person?: boolean;
+  } = {};
+
+  const includeZeroFacesRange = isZeroFacesOnly(facesFilter);
+  if (facesFilter.minCount > 0 || includeZeroFacesRange) {
+    payload.min_count = facesFilter.minCount;
+  }
+  if (facesFilter.maxCount !== null || includeZeroFacesRange) {
+    payload.max_count = facesFilter.maxCount ?? 0;
+  }
+
+  if (!includeZeroFacesRange) {
+    if (facesFilter.certaintyMinPct > 0) {
+      payload.top_certainty_min = facesFilter.certaintyMinPct / 100;
+    }
+    if (facesFilter.certaintyMaxPct < 100) {
+      payload.top_certainty_max = facesFilter.certaintyMaxPct / 100;
+    }
+    if (facesFilter.hasUnknownPerson) {
+      payload.has_unknown_person = true;
+    }
+  }
+
+  return Object.keys(payload).length > 0 ? payload : null;
+}
+
 function normalizeSuggestionConfidenceMin(
   raw: string,
   fallback = Number(DEFAULT_SUGGESTION_CONFIDENCE_MIN)
@@ -151,6 +260,7 @@ export function parseLibraryUrlState(search: string): SearchUrlState {
   const suggestionConfidenceMinDraft = parseSuggestionConfidenceMinDraft(params.get("suggestionMin"));
   const pathHintFilters = normalizePathHintFilters(params.getAll("pathHint"));
   const hasFacesFilter = parseNullableBooleanParam(params.get("hasFaces"));
+  const facesFilter = parseFacesFilterState(params);
 
   const latitudeCandidate = (params.get("lat") ?? "").trim();
   const longitudeCandidate = (params.get("lng") ?? "").trim();
@@ -188,7 +298,8 @@ export function parseLibraryUrlState(search: string): SearchUrlState {
     radiusDraft: locationDrafts.radiusDraft,
     locationRadius,
     hasFacesFilter,
-    pathHintFilters
+    pathHintFilters,
+    facesFilter
   };
 }
 
@@ -203,11 +314,13 @@ export function buildLibraryUrlQuery(state: {
   locationRadius: LibraryLocationRadius | null;
   hasFacesFilter: boolean | null;
   pathHintFilters: string[];
+  facesFilter?: LibraryFacesFilterState;
   sortDirection: SortDirection;
   page: number;
   pageSize: number;
 }): string {
   const params = new URLSearchParams();
+  const facesFilter = state.facesFilter ?? DEFAULT_FACES_FILTER;
 
   for (const chip of state.queryChips) {
     params.append("query", chip);
@@ -246,6 +359,23 @@ export function buildLibraryUrlQuery(state: {
   for (const pathHint of state.pathHintFilters) {
     params.append("pathHint", pathHint);
   }
+  if (facesFilter.minCount > 0) {
+    params.set("facesMin", String(facesFilter.minCount));
+  }
+  if (facesFilter.maxCount !== null) {
+    params.set("facesMax", String(facesFilter.maxCount));
+  }
+  if (!isZeroFacesOnly(facesFilter)) {
+    if (facesFilter.certaintyMinPct > 0) {
+      params.set("facesCertMin", String(facesFilter.certaintyMinPct));
+    }
+    if (facesFilter.certaintyMaxPct < 100) {
+      params.set("facesCertMax", String(facesFilter.certaintyMaxPct));
+    }
+    if (facesFilter.hasUnknownPerson) {
+      params.set("facesUnknown", "1");
+    }
+  }
   if (state.sortDirection !== DEFAULT_SORT_DIRECTION) {
     params.set("sort", state.sortDirection);
   }
@@ -276,7 +406,8 @@ export function buildSearchFilters(
   suggestionConfidenceMinDraft: string,
   locationRadius: LibraryLocationRadius | null,
   hasFaces: boolean | null,
-  pathHints: string[]
+  pathHints: string[],
+  facesFilter: LibraryFacesFilterState = DEFAULT_FACES_FILTER
 ): {
   date?: { from?: string; to?: string };
   person_names?: string[];
@@ -286,12 +417,20 @@ export function buildSearchFilters(
   location_radius?: LibraryLocationRadius;
   has_faces?: boolean;
   path_hints?: string[];
+  faces?: {
+    min_count?: number;
+    max_count?: number;
+    top_certainty_min?: number;
+    top_certainty_max?: number;
+    has_unknown_person?: boolean;
+  };
 } | null {
   const dateFilter = buildDateFilter(fromDate, toDate);
   const personNameFilter = selectedPersonNames.length > 0 ? selectedPersonNames : null;
   const albumIdFilter = selectedAlbumIds.length > 0 ? selectedAlbumIds : null;
   const locationFilter = locationRadius;
   const pathHintFilter = pathHints.length > 0 ? pathHints : null;
+  const facesPayload = normalizeFacesFilterForPayload(facesFilter);
 
   if (
     !dateFilter &&
@@ -299,7 +438,8 @@ export function buildSearchFilters(
     !albumIdFilter &&
     !locationFilter &&
     hasFaces === null &&
-    !pathHintFilter
+    !pathHintFilter &&
+    !facesPayload
   ) {
     return null;
   }
@@ -314,6 +454,7 @@ export function buildSearchFilters(
       : {}),
     ...(locationFilter ? { location_radius: locationFilter } : {}),
     ...(hasFaces === null ? {} : { has_faces: hasFaces }),
-    ...(pathHintFilter ? { path_hints: pathHintFilter } : {})
+    ...(pathHintFilter ? { path_hints: pathHintFilter } : {}),
+    ...(facesPayload ? { faces: facesPayload } : {})
   };
 }

--- a/apps/ui/src/pages/library/libraryRouteTypes.ts
+++ b/apps/ui/src/pages/library/libraryRouteTypes.ts
@@ -95,4 +95,6 @@ export type SearchUrlState = {
   hasFacesFilter: boolean | null;
   pathHintFilters: string[];
   facesFilter: LibraryFacesFilterState;
+  areFaceBoxesVisible: boolean;
+  areAlbumAssignmentWidgetsVisible: boolean;
 };

--- a/apps/ui/src/pages/library/libraryRouteTypes.ts
+++ b/apps/ui/src/pages/library/libraryRouteTypes.ts
@@ -70,6 +70,14 @@ export type LibraryLocationRadius = {
   radius_km: number;
 };
 
+export type LibraryFacesFilterState = {
+  minCount: number;
+  maxCount: number | null;
+  certaintyMinPct: number;
+  certaintyMaxPct: number;
+  hasUnknownPerson: boolean;
+};
+
 export type SearchUrlState = {
   queryChips: string[];
   fromDate: string;
@@ -86,4 +94,5 @@ export type SearchUrlState = {
   locationRadius: LibraryLocationRadius | null;
   hasFacesFilter: boolean | null;
   pathHintFilters: string[];
+  facesFilter: LibraryFacesFilterState;
 };

--- a/apps/ui/src/pages/library/useLibraryBulkActions.ts
+++ b/apps/ui/src/pages/library/useLibraryBulkActions.ts
@@ -9,7 +9,13 @@ import {
 } from "./libraryRouteApi";
 import { buildSearchFilters } from "./libraryRouteSearchState";
 import type { LibrarySelectionState } from "./librarySelection";
-import type { LibraryLocationRadius, LibraryPhoto, PersonCertaintyMode, SortDirection } from "./libraryRouteTypes";
+import type {
+  LibraryFacesFilterState,
+  LibraryLocationRadius,
+  LibraryPhoto,
+  PersonCertaintyMode,
+  SortDirection
+} from "./libraryRouteTypes";
 
 const ACTION_SCOPE_FETCH_LIMIT = 120;
 
@@ -26,6 +32,7 @@ interface UseLibraryBulkActionsArgs {
   locationRadiusFilter: LibraryLocationRadius | null;
   hasFacesFilter: boolean | null;
   pathHintFilters: string[];
+  facesFilter: LibraryFacesFilterState;
   sortDirection: SortDirection;
 }
 
@@ -42,6 +49,7 @@ export function useLibraryBulkActions({
   locationRadiusFilter,
   hasFacesFilter,
   pathHintFilters,
+  facesFilter,
   sortDirection,
 }: UseLibraryBulkActionsArgs) {
   const [notifications, setNotifications] = useState<NotificationEntry[]>([]);
@@ -113,6 +121,7 @@ export function useLibraryBulkActions({
         locationRadiusFilter,
         hasFacesFilter,
         pathHintFilters,
+        facesFilter,
         sortDirection,
         offset,
         ACTION_SCOPE_FETCH_LIMIT
@@ -186,7 +195,8 @@ export function useLibraryBulkActions({
           suggestionConfidenceMinDraft,
           locationRadiusFilter,
           hasFacesFilter,
-          pathHintFilters
+          pathHintFilters,
+          facesFilter
         ) ?? {};
         const created = await createAlbum(
           {

--- a/apps/ui/src/pages/library/useLibraryResults.ts
+++ b/apps/ui/src/pages/library/useLibraryResults.ts
@@ -7,6 +7,7 @@ import {
 import { parseHasFacesFacetCounts, toPathHintFacetCounts, type FacetCountEntry } from "../search/facetFilters";
 import { useRouteRequestState } from "./requestLifecycle";
 import type {
+  LibraryFacesFilterState,
   LibraryLocationRadius,
   LibraryPhoto,
   PersonCertaintyMode,
@@ -24,6 +25,7 @@ interface UseLibraryResultsArgs {
   locationRadiusFilter: LibraryLocationRadius | null;
   hasFacesFilter: boolean | null;
   pathHintFilters: string[];
+  facesFilter: LibraryFacesFilterState;
   sortDirection: SortDirection;
   requestedPage: number;
   pageSize: number;
@@ -43,6 +45,7 @@ export function useLibraryResults({
   locationRadiusFilter,
   hasFacesFilter,
   pathHintFilters,
+  facesFilter,
   sortDirection,
   requestedPage,
   pageSize,
@@ -90,6 +93,7 @@ export function useLibraryResults({
       locationRadiusFilter,
       hasFacesFilter,
       pathHintFilters,
+      facesFilter,
       sortDirection,
       requestOffset,
       pageSize,
@@ -127,6 +131,7 @@ export function useLibraryResults({
     locationError,
     locationRadiusFilter,
     pathHintFilters,
+    facesFilter,
     reloadToken,
     requestOffset,
     selectedAlbumIds,

--- a/apps/ui/src/pages/library/useLibraryUrlSync.ts
+++ b/apps/ui/src/pages/library/useLibraryUrlSync.ts
@@ -28,6 +28,8 @@ interface UseLibraryUrlSyncArgs {
   hasFacesFilter: boolean | null;
   pathHintFilters: string[];
   facesFilter: LibraryFacesFilterState;
+  areFaceBoxesVisible: boolean;
+  areAlbumAssignmentWidgetsVisible: boolean;
   sortDirection: SortDirection;
   requestedPage: number;
   pageSize: number;
@@ -52,6 +54,8 @@ export function useLibraryUrlSync({
   hasFacesFilter,
   pathHintFilters,
   facesFilter,
+  areFaceBoxesVisible,
+  areAlbumAssignmentWidgetsVisible,
   sortDirection,
   requestedPage,
   pageSize,
@@ -119,6 +123,8 @@ export function useLibraryUrlSync({
       hasFacesFilter,
       pathHintFilters,
       facesFilter,
+      areFaceBoxesVisible,
+      areAlbumAssignmentWidgetsVisible,
       sortDirection,
       page: requestedPage,
       pageSize,
@@ -144,6 +150,8 @@ export function useLibraryUrlSync({
     committedQuery,
     fromDate,
     hasFacesFilter,
+    areFaceBoxesVisible,
+    areAlbumAssignmentWidgetsVisible,
     location.pathname,
     location.search,
     locationRadiusFilter,

--- a/apps/ui/src/pages/library/useLibraryUrlSync.ts
+++ b/apps/ui/src/pages/library/useLibraryUrlSync.ts
@@ -4,6 +4,7 @@ import type { LibraryViewRouteState } from "../libraryRouteState";
 import { buildLibraryUrlQuery } from "./libraryRouteSearchState";
 import { saveLastLibraryUrl, saveLibraryViewState } from "./libraryRouteMemory";
 import type {
+  LibraryFacesFilterState,
   LibraryLocationRadius,
   PersonCertaintyMode,
   SearchUrlState,
@@ -26,6 +27,7 @@ interface UseLibraryUrlSyncArgs {
   locationRadiusFilter: LibraryLocationRadius | null;
   hasFacesFilter: boolean | null;
   pathHintFilters: string[];
+  facesFilter: LibraryFacesFilterState;
   sortDirection: SortDirection;
   requestedPage: number;
   pageSize: number;
@@ -49,6 +51,7 @@ export function useLibraryUrlSync({
   locationRadiusFilter,
   hasFacesFilter,
   pathHintFilters,
+  facesFilter,
   sortDirection,
   requestedPage,
   pageSize,
@@ -115,6 +118,7 @@ export function useLibraryUrlSync({
       locationRadius: locationRadiusFilter,
       hasFacesFilter,
       pathHintFilters,
+      facesFilter,
       sortDirection,
       page: requestedPage,
       pageSize,
@@ -145,6 +149,7 @@ export function useLibraryUrlSync({
     locationRadiusFilter,
     navigate,
     pathHintFilters,
+    facesFilter,
     pageSize,
     personCertaintyMode,
     requestedPage,

--- a/apps/ui/src/pages/search/LocationRadiusPicker.test.tsx
+++ b/apps/ui/src/pages/search/LocationRadiusPicker.test.tsx
@@ -142,8 +142,20 @@ vi.mock("leaflet", () => {
     },
     marker(position: { lat: number; lng: number }, options: LayerOptions) {
       const layer = createLayer(options);
-      const marker: MockMarker = {
-        ...layer,
+      let marker: MockMarker;
+      marker = {
+        options: layer.options,
+        addTo(map) {
+          layer.addTo(map);
+          return marker;
+        },
+        remove() {
+          layer.remove();
+        },
+        on(eventName, handler) {
+          layer.on(eventName, handler);
+          return marker;
+        },
         getLatLng() {
           return position;
         },

--- a/apps/ui/src/pages/search/LocationRadiusPicker.test.tsx
+++ b/apps/ui/src/pages/search/LocationRadiusPicker.test.tsx
@@ -142,6 +142,7 @@ vi.mock("leaflet", () => {
     },
     marker(position: { lat: number; lng: number }, options: LayerOptions) {
       const layer = createLayer(options);
+      let markerPosition = { ...position };
       let marker: MockMarker;
       marker = {
         options: layer.options,
@@ -157,12 +158,15 @@ vi.mock("leaflet", () => {
           return marker;
         },
         getLatLng() {
-          return position;
+          return markerPosition;
         },
         fire(eventName, event) {
+          if (event?.latlng) {
+            markerPosition = { ...event.latlng };
+          }
           layer.fire(eventName, {
-            latlng: event?.latlng ?? position,
-            target: event?.target
+            latlng: event?.latlng ?? markerPosition,
+            target: marker
           });
         }
       };
@@ -206,5 +210,30 @@ describe("LocationRadiusPicker", () => {
     marker?.fire("mousedown");
 
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("updates radius only when drag ends", async () => {
+    const onChange = vi.fn();
+    render(<LocationRadiusPicker value={locationValue} onChange={onChange} />);
+
+    const leaflet = await import("leaflet");
+    const mockedLeaflet = leaflet.default as unknown as { __mock: MockLeafletState };
+    const marker = mockedLeaflet.__mock.lastMarker;
+
+    expect(marker).not.toBeNull();
+    marker?.fire("drag", {
+      latlng: { lat: locationValue.latitude, lng: locationValue.longitude + 0.2 }
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    marker?.fire("dragend", {
+      latlng: { lat: locationValue.latitude, lng: locationValue.longitude + 0.2 }
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0]?.[0]).toMatchObject({
+      latitude: locationValue.latitude,
+      longitude: locationValue.longitude
+    });
+    expect(onChange.mock.calls[0]?.[0]?.radiusKm).toBeGreaterThan(0.1);
   });
 });

--- a/apps/ui/src/pages/search/LocationRadiusPicker.test.tsx
+++ b/apps/ui/src/pages/search/LocationRadiusPicker.test.tsx
@@ -1,0 +1,198 @@
+import { render } from "@testing-library/react";
+
+import { LocationRadiusPicker } from "./LocationRadiusPicker";
+import type { LocationRadiusValue } from "./types";
+
+type LeafletEventHandler = (event: { latlng: { lat: number; lng: number }; target?: unknown }) => void;
+
+type LayerOptions = {
+  bubblingMouseEvents?: boolean;
+};
+
+type MockMap = {
+  handlers: Map<string, LeafletEventHandler[]>;
+  setView: (center: [number, number], zoom: number) => MockMap;
+  on: (eventName: string, handler: LeafletEventHandler) => MockMap;
+  fire: (eventName: string, event: { latlng: { lat: number; lng: number } }) => void;
+  distance: (from: { lat: number; lng: number }, to: { lat: number; lng: number }) => number;
+  getZoom: () => number;
+  remove: () => void;
+};
+
+type MockMarker = {
+  options: LayerOptions;
+  addTo: (map: MockMap) => MockMarker;
+  remove: () => void;
+  on: (eventName: string, handler: LeafletEventHandler) => MockMarker;
+  fire: (eventName: string, event?: { latlng: { lat: number; lng: number }; target?: unknown }) => void;
+  getLatLng: () => { lat: number; lng: number };
+};
+
+type MockLeafletState = {
+  lastMap: MockMap | null;
+  lastMarker: MockMarker | null;
+  reset: () => void;
+};
+
+vi.mock("leaflet", () => {
+  let activeMap: MockMap | null = null;
+  let lastMarker: MockMarker | null = null;
+
+  function createMap(): MockMap {
+    const handlers = new Map<string, LeafletEventHandler[]>();
+    return {
+      handlers,
+      setView() {
+        return this;
+      },
+      on(eventName, handler) {
+        const eventHandlers = handlers.get(eventName) ?? [];
+        eventHandlers.push(handler);
+        handlers.set(eventName, eventHandlers);
+        return this;
+      },
+      fire(eventName, event) {
+        for (const handler of handlers.get(eventName) ?? []) {
+          handler(event);
+        }
+      },
+      distance(from, to) {
+        const dx = from.lat - to.lat;
+        const dy = from.lng - to.lng;
+        return Math.sqrt(dx * dx + dy * dy) * 1000;
+      },
+      getZoom() {
+        return 10;
+      },
+      remove() {
+        handlers.clear();
+      }
+    };
+  }
+
+  function createLayer(options: LayerOptions = {}) {
+    let mapForLayer: MockMap | null = null;
+    const handlers = new Map<string, LeafletEventHandler[]>();
+    return {
+      options,
+      addTo(map: MockMap) {
+        mapForLayer = map;
+        return this;
+      },
+      remove() {
+        handlers.clear();
+      },
+      on(eventName: string, handler: LeafletEventHandler) {
+        const eventHandlers = handlers.get(eventName) ?? [];
+        eventHandlers.push(handler);
+        handlers.set(eventName, eventHandlers);
+        return this;
+      },
+      fire(eventName: string, event: { latlng: { lat: number; lng: number }; target?: unknown }) {
+        for (const handler of handlers.get(eventName) ?? []) {
+          handler(event);
+        }
+        if (eventName === "mousedown" && mapForLayer && options.bubblingMouseEvents !== false) {
+          mapForLayer.fire("click", {
+            latlng: event.latlng
+          });
+        }
+      }
+    };
+  }
+
+  const mockState: MockLeafletState = {
+    get lastMap() {
+      return activeMap;
+    },
+    get lastMarker() {
+      return lastMarker;
+    },
+    reset() {
+      activeMap = null;
+      lastMarker = null;
+    }
+  };
+
+  const leaflet = {
+    map() {
+      activeMap = createMap();
+      return activeMap;
+    },
+    tileLayer() {
+      return {
+        on() {
+          return this;
+        },
+        addTo() {
+          return this;
+        }
+      };
+    },
+    circleMarker() {
+      return createLayer();
+    },
+    circle() {
+      return {
+        ...createLayer(),
+        setRadius() {
+          return this;
+        }
+      };
+    },
+    marker(position: { lat: number; lng: number }, options: LayerOptions) {
+      const layer = createLayer(options);
+      const marker: MockMarker = {
+        ...layer,
+        getLatLng() {
+          return position;
+        },
+        fire(eventName, event) {
+          layer.fire(eventName, {
+            latlng: event?.latlng ?? position,
+            target: event?.target
+          });
+        }
+      };
+      lastMarker = marker;
+      return marker;
+    },
+    divIcon() {
+      return {};
+    },
+    latLng(lat: number, lng: number) {
+      return { lat, lng };
+    },
+    __mock: mockState
+  };
+
+  return { default: leaflet };
+});
+
+describe("LocationRadiusPicker", () => {
+  const locationValue: LocationRadiusValue = {
+    latitude: 40.7128,
+    longitude: -74.006,
+    radiusKm: 5
+  };
+
+  beforeEach(async () => {
+    const leaflet = await import("leaflet");
+    const mockedLeaflet = leaflet.default as unknown as { __mock: MockLeafletState };
+    mockedLeaflet.__mock.reset();
+  });
+
+  it("does not trigger map click updates when pressing the radius handle", async () => {
+    const onChange = vi.fn();
+    render(<LocationRadiusPicker value={locationValue} onChange={onChange} />);
+
+    const leaflet = await import("leaflet");
+    const mockedLeaflet = leaflet.default as unknown as { __mock: MockLeafletState };
+    const marker = mockedLeaflet.__mock.lastMarker;
+
+    expect(marker).not.toBeNull();
+    marker?.fire("mousedown");
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/ui/src/pages/search/LocationRadiusPicker.tsx
+++ b/apps/ui/src/pages/search/LocationRadiusPicker.tsx
@@ -123,6 +123,12 @@ export function LocationRadiusPicker({ value, onChange, onMapError }: LocationRa
       const markerPosition = marker.getLatLng();
       const nextRadiusKm = Math.max(map.distance(center, markerPosition) / 1000, 0.1);
       radiusCircle.setRadius(nextRadiusKm * 1000);
+    });
+
+    radiusHandle.on("dragend", (event: L.LeafletEvent) => {
+      const marker = event.target as L.Marker;
+      const markerPosition = marker.getLatLng();
+      const nextRadiusKm = Math.max(map.distance(center, markerPosition) / 1000, 0.1);
       onChange({
         latitude: value.latitude,
         longitude: value.longitude,

--- a/apps/ui/src/pages/search/LocationRadiusPicker.tsx
+++ b/apps/ui/src/pages/search/LocationRadiusPicker.tsx
@@ -110,6 +110,7 @@ export function LocationRadiusPicker({ value, onChange, onMapError }: LocationRa
 
     const radiusHandle = L.marker(handle, {
       draggable: true,
+      bubblingMouseEvents: false,
       icon: L.divIcon({
         className: "search-location-radius-handle",
         iconSize: [14, 14]

--- a/apps/ui/src/pages/shared/ConfidenceSlider.tsx
+++ b/apps/ui/src/pages/shared/ConfidenceSlider.tsx
@@ -12,18 +12,35 @@ interface ConfidenceRangeSliderProps {
   maxValue: number;
   onValueChange: (minValue: number, maxValue: number) => void;
   disabled?: boolean;
+  minBound?: number;
+  maxBound?: number;
+  minLabel?: string;
+  maxLabel?: string;
+  minValueFormatter?: (value: number) => string;
+  maxValueFormatter?: (value: number) => string;
+  minThumbAriaLabel?: string;
+  maxThumbAriaLabel?: string;
+}
+
+function clampToBounds(value: number, minBound: number, maxBound: number): number {
+  if (!Number.isFinite(value)) {
+    return minBound;
+  }
+  return Math.max(minBound, Math.min(maxBound, Math.round(value)));
 }
 
 function clampPercent(value: number): number {
-  if (!Number.isFinite(value)) {
-    return 0;
-  }
-  return Math.max(0, Math.min(100, Math.round(value)));
+  return clampToBounds(value, 0, 100);
 }
 
-function normalizeRange(minValue: number, maxValue: number): [number, number] {
-  const normalizedMin = clampPercent(minValue);
-  const normalizedMax = clampPercent(maxValue);
+function normalizeRange(
+  minValue: number,
+  maxValue: number,
+  minBound: number,
+  maxBound: number
+): [number, number] {
+  const normalizedMin = clampToBounds(minValue, minBound, maxBound);
+  const normalizedMax = clampToBounds(maxValue, minBound, maxBound);
   if (normalizedMin <= normalizedMax) {
     return [normalizedMin, normalizedMax];
   }
@@ -104,8 +121,16 @@ export function ConfidenceRangeSlider({
   maxValue,
   onValueChange,
   disabled = false,
+  minBound = 0,
+  maxBound = 100,
+  minLabel = "Minimum certainty",
+  maxLabel = "Maximum certainty",
+  minValueFormatter = (value) => `${value}%`,
+  maxValueFormatter = (value) => `${value}%`,
+  minThumbAriaLabel = "Minimum suggestion certainty",
+  maxThumbAriaLabel = "Maximum suggestion certainty",
 }: ConfidenceRangeSliderProps) {
-  const [normalizedMin, normalizedMax] = normalizeRange(minValue, maxValue);
+  const [normalizedMin, normalizedMax] = normalizeRange(minValue, maxValue, minBound, maxBound);
   const [draftRange, setDraftRange] = useState<[number, number]>([normalizedMin, normalizedMax]);
   const [draftMin, draftMax] = draftRange;
 
@@ -115,22 +140,22 @@ export function ConfidenceRangeSlider({
 
   return (
     <div className="confidence-slider-wrapper">
-      <p>{`Minimum certainty: ${draftMin}%`}</p>
-      <p>{`Maximum certainty: ${draftMax}%`}</p>
+      <p>{`${minLabel}: ${minValueFormatter(draftMin)}`}</p>
+      <p>{`${maxLabel}: ${maxValueFormatter(draftMax)}`}</p>
       <Range
-        min={0}
-        max={100}
+        min={minBound}
+        max={maxBound}
         step={1}
         values={draftRange}
         disabled={disabled}
         onChange={(next) => {
           const [nextMin = draftMin, nextMax = draftMax] = next;
-          const [safeMin, safeMax] = normalizeRange(nextMin, nextMax);
+          const [safeMin, safeMax] = normalizeRange(nextMin, nextMax, minBound, maxBound);
           setDraftRange([safeMin, safeMax]);
         }}
         onFinalChange={(next) => {
           const [nextMin = draftMin, nextMax = draftMax] = next;
-          const [safeMin, safeMax] = normalizeRange(nextMin, nextMax);
+          const [safeMin, safeMax] = normalizeRange(nextMin, nextMax, minBound, maxBound);
           onValueChange(safeMin, safeMax);
         }}
         renderTrack={({ props, children }) => (
@@ -148,8 +173,8 @@ export function ConfidenceRangeSlider({
                 background: getTrackBackground({
                   values: draftRange,
                   colors: ["#dbeafe", "#3b82f6", "#dbeafe"],
-                  min: 0,
-                  max: 100,
+                  min: minBound,
+                  max: maxBound,
                 }),
               }}
             >
@@ -164,7 +189,7 @@ export function ConfidenceRangeSlider({
               key={key}
               {...thumbProps}
               className="confidence-slider-thumb"
-              aria-label={index === 0 ? "Minimum suggestion certainty" : "Maximum suggestion certainty"}
+              aria-label={index === 0 ? minThumbAriaLabel : maxThumbAriaLabel}
             />
           );
         }}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -1984,6 +1984,24 @@ body {
   font-size: 0.88rem;
 }
 
+.search-faces-panel {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.search-faces-helper-text {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.88rem;
+}
+
+.search-filter-checkbox-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #334155;
+}
+
 .search-location-row {
   display: grid;
   grid-template-columns: auto minmax(7rem, 1fr) auto minmax(8rem, 1fr) auto minmax(6rem, 1fr);

--- a/docs/superpowers/plans/2026-05-10-advanced-faces-filter-implementation.md
+++ b/docs/superpowers/plans/2026-05-10-advanced-faces-filter-implementation.md
@@ -1,0 +1,552 @@
+# Advanced Faces Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an advanced Library Faces filter with face-count range, top-certainty range, and unknown-person selection, with deterministic UI/URL/API behavior.
+
+**Architecture:** Keep UI interaction state in Library route UI components, URL/request serialization in `libraryRouteSearchState`, request transport in `libraryRouteApi/useLibraryResults`, schema validation in `search_request.py`, and SQL semantics in `photos_repo.py`. Implement face filtering through a new `filters.faces` object without breaking existing search behavior.
+
+**Tech Stack:** React, TypeScript, react-range, Vitest/Testing Library, FastAPI/Pydantic, SQLAlchemy, pytest.
+
+---
+
+## SRP Guardrails
+
+- `LibrarySearchForm.tsx` owns panel orchestration only (open/close/edit flow), not URL parsing.
+- Face-filter serialization/parsing lives in `libraryRouteSearchState.ts` only.
+- `libraryRouteApi.ts` only sends payloads; no filter business rules.
+- `search_request.py` only validates filter schema; no query semantics.
+- `photos_repo.py` only expresses query semantics.
+- Test files verify observable behavior at each layer and do not duplicate logic from production code.
+
+---
+
+### Task 1: Add API Schema Support For `filters.faces`
+
+**Files:**
+- Modify: `apps/api/app/schemas/search_request.py`
+- Test: `apps/api/tests/test_search_service.py`
+
+- [ ] **Step 1: Write failing schema validation tests for faces filter bounds**
+
+```python
+def test_faces_filter_validation_rejects_negative_counts():
+    with pytest.raises(ValidationError):
+        SearchFilters(faces={"min_count": -1})
+
+
+def test_faces_filter_validation_rejects_invalid_certainty_bounds():
+    with pytest.raises(ValidationError):
+        SearchFilters(faces={"top_certainty_min": 1.2})
+
+
+def test_faces_filter_validation_rejects_inverted_ranges():
+    with pytest.raises(ValidationError):
+        SearchFilters(faces={"min_count": 5, "max_count": 2})
+    with pytest.raises(ValidationError):
+        SearchFilters(faces={"top_certainty_min": 0.9, "top_certainty_max": 0.1})
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `uv run pytest apps/api/tests/test_search_service.py -k "faces_filter_validation"`
+Expected: FAIL because `SearchFilters` has no `faces` object yet.
+
+- [ ] **Step 3: Add `FaceFilters` schema model and wire into `SearchFilters`**
+
+```python
+class FaceFilters(BaseModel):
+    min_count: Optional[int] = Field(default=None, ge=0)
+    max_count: Optional[int] = Field(default=None, ge=0)
+    top_certainty_min: Optional[float] = None
+    top_certainty_max: Optional[float] = None
+    has_unknown_person: Optional[bool] = None
+
+    @field_validator("top_certainty_min", "top_certainty_max")
+    @classmethod
+    def validate_certainty(cls, value: Optional[float]) -> Optional[float]:
+        if value is None:
+            return None
+        if not math.isfinite(value):
+            raise ValueError("top certainty bounds must be finite")
+        if value < 0 or value > 1:
+            raise ValueError("top certainty bounds must be between 0 and 1")
+        return value
+
+    @model_validator(mode="after")
+    def validate_ranges(self) -> "FaceFilters":
+        if self.min_count is not None and self.max_count is not None and self.min_count > self.max_count:
+            raise ValueError("min_count must be <= max_count")
+        if (
+            self.top_certainty_min is not None
+            and self.top_certainty_max is not None
+            and self.top_certainty_min > self.top_certainty_max
+        ):
+            raise ValueError("top_certainty_min must be <= top_certainty_max")
+        return self
+```
+
+- [ ] **Step 4: Add field to `SearchFilters`**
+
+```python
+class SearchFilters(BaseModel):
+    date: Optional[DateFilter] = None
+    camera_make: Optional[List[str]] = None
+    extension: Optional[List[str]] = None
+    path_hints: Optional[List[str]] = None
+    album_ids: Optional[List[str]] = None
+    orientation: Optional[List[str]] = None
+    filesize_range: Optional[FilesizeRange] = None
+    has_faces: Optional[bool] = None
+    tags: Optional[List[str]] = None
+    people: Optional[List[str]] = None
+    person_names: Optional[List[str]] = None
+    person_certainty_mode: Optional[Literal["human_only", "include_suggestions"]] = None
+    suggestion_confidence_min: Optional[float] = None
+    location_radius: Optional[LocationRadiusFilter] = None
+    faces: Optional[FaceFilters] = None
+```
+
+- [ ] **Step 5: Re-run schema tests**
+
+Run: `uv run pytest apps/api/tests/test_search_service.py -k "faces_filter_validation"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 1**
+
+```bash
+git -C /mnt/d/Projects/photo-org add apps/api/app/schemas/search_request.py apps/api/tests/test_search_service.py
+git -C /mnt/d/Projects/photo-org commit -m "feat(api): add faces filter schema validation"
+```
+
+---
+
+### Task 2: Implement Repository Query Semantics For Faces Filter
+
+**Files:**
+- Modify: `apps/api/app/repositories/photos_repo.py`
+- Test: `apps/api/tests/test_search_service.py`
+
+- [ ] **Step 1: Write failing repository/service tests for face count range**
+
+```python
+def test_faces_filter_count_range_filters_results(tmp_path):
+    # seed photo-0 (0 active faces), photo-1 (1 active face), photo-2 (2 active faces)
+    # assert min_count=1 removes photo-0 and max_count=1 removes photo-2
+```
+
+- [ ] **Step 2: Write failing tests for certainty ANY-face semantics and unknown-person filter**
+
+```python
+def test_faces_filter_top_certainty_any_face_semantics(tmp_path):
+    # photo-a has two faces: one human_confirmed (100%), one top suggestion 0.2
+    # photo-b has one face with top suggestion 0.45
+    # filter range 0.9..1.0 should include photo-a and exclude photo-b
+
+
+def test_faces_filter_unknown_person_matches_at_least_one_unknown_assigned_face(tmp_path):
+    # photo-u has one face assigned to Unknown person, photo-k has only known assignments
+    # has_unknown_person=true should include photo-u and exclude photo-k
+```
+
+- [ ] **Step 3: Run targeted tests to verify failure**
+
+Run: `uv run pytest apps/api/tests/test_search_service.py -k "faces_filter_count_range or faces_filter_top_certainty or faces_filter_unknown_person"`
+Expected: FAIL before repo logic is added.
+
+- [ ] **Step 4: Add helper clauses in `PhotosRepository` for face filter semantics**
+
+```python
+def _active_faces_subquery(self):
+    return select(self.faces.c.photo_id, self.faces.c.face_id, self.faces.c.person_id).where(
+        self.faces.c.dismissed_ts.is_(None)
+    ).subquery()
+
+
+def _faces_count_clause(self, faces_filter):
+    active_face_count = (
+        select(func.count())
+        .select_from(self.faces)
+        .where(
+            self.faces.c.photo_id == self.photos.c.photo_id,
+            self.faces.c.dismissed_ts.is_(None),
+        )
+        .scalar_subquery()
+    )
+    clauses = []
+    if faces_filter.min_count is not None:
+        clauses.append(active_face_count >= faces_filter.min_count)
+    if faces_filter.max_count is not None:
+        clauses.append(active_face_count <= faces_filter.max_count)
+    return and_(*clauses) if clauses else None
+
+
+def _faces_top_certainty_clause(self, faces_filter):
+    # return EXISTS(correlated_face_query) where any active face for this photo has
+    # effective_top_certainty in [top_certainty_min, top_certainty_max]
+    # effective_top_certainty = 1.0 for human_confirmed assignment, else top suggestion confidence
+
+
+def _unknown_person_clause(self, faces_filter):
+    # return EXISTS(correlated_unknown_person_query) for at least one active face assigned to a person
+    # whose display_name == UNKNOWN_PERSON_DISPLAY_NAME
+```
+
+- [ ] **Step 5: Apply faces filter clauses inside `_apply_filters`**
+
+```python
+if filters.faces:
+    count_clause = self._faces_count_clause(filters.faces)
+    if count_clause is not None:
+        where_conditions.append(count_clause)
+    certainty_clause = self._faces_top_certainty_clause(filters.faces)
+    if certainty_clause is not None:
+        where_conditions.append(certainty_clause)
+    unknown_clause = self._unknown_person_clause(filters.faces)
+    if unknown_clause is not None:
+        where_conditions.append(unknown_clause)
+```
+
+- [ ] **Step 6: Re-run targeted tests**
+
+Run: `uv run pytest apps/api/tests/test_search_service.py -k "faces_filter_count_range or faces_filter_top_certainty or faces_filter_unknown_person"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 2**
+
+```bash
+git -C /mnt/d/Projects/photo-org add apps/api/app/repositories/photos_repo.py apps/api/tests/test_search_service.py
+git -C /mnt/d/Projects/photo-org commit -m "feat(api): implement advanced faces filter query clauses"
+```
+
+---
+
+### Task 3: Add UI State Types And URL/Request Serialization Rules
+
+**Files:**
+- Modify: `apps/ui/src/pages/library/libraryRouteTypes.ts`
+- Modify: `apps/ui/src/pages/library/libraryRouteSearchState.ts`
+- Test: `apps/ui/src/pages/library/libraryRouteSearchState.test.ts`
+
+- [ ] **Step 1: Write failing tests for parse/serialize of advanced faces filter**
+
+```ts
+it("parses and serializes faces filter params", () => {
+  const state = parseLibraryUrlState("?facesMin=2&facesMax=7&facesCertMin=60&facesCertMax=95&facesUnknown=1");
+  expect(state.facesFilter).toEqual({
+    minCount: 2,
+    maxCount: 7,
+    certaintyMinPct: 60,
+    certaintyMaxPct: 95,
+    hasUnknownPerson: true
+  });
+});
+
+it("omits faces count defaults 0..infinity in URL and payload", () => {
+  const query = buildLibraryUrlQuery({
+    queryChips: [],
+    fromDate: "",
+    toDate: "",
+    selectedPersonNames: [],
+    selectedAlbumIds: [],
+    personCertaintyMode: "human_only",
+    suggestionConfidenceMinDraft: "0.8",
+    locationRadius: null,
+    hasFacesFilter: null,
+    pathHintFilters: [],
+    sortDirection: "desc",
+    page: 1,
+    pageSize: 60,
+    facesFilter: { minCount: 0, maxCount: null, certaintyMinPct: 0, certaintyMaxPct: 100, hasUnknownPerson: false }
+  });
+  expect(query).not.toContain("facesMin=");
+  expect(query).not.toContain("facesMax=");
+});
+
+it("omits face-attribute clauses when range is 0..0", () => {
+  const filters = buildSearchFilters("", "", [], [], "human_only", "0.8", null, null, [], {
+    minCount: 0,
+    maxCount: 0,
+    certaintyMinPct: 65,
+    certaintyMaxPct: 95,
+    hasUnknownPerson: true
+  });
+  expect(filters?.faces).toEqual({ min_count: 0, max_count: 0 });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm --prefix apps/ui test -- src/pages/library/libraryRouteSearchState.test.ts`
+Expected: FAIL (missing facesFilter state/serialization).
+
+- [ ] **Step 3: Add `LibraryFacesFilterState` type and wire into `SearchUrlState`**
+
+```ts
+export type LibraryFacesFilterState = {
+  minCount: number;
+  maxCount: number | null; // null = unbounded
+  certaintyMinPct: number;
+  certaintyMaxPct: number;
+  hasUnknownPerson: boolean;
+};
+```
+
+- [ ] **Step 4: Implement parse/serialize helpers and request mapping**
+
+```ts
+function normalizeFacesFilterForPayload(state: LibraryFacesFilterState): {
+  min_count?: number;
+  max_count?: number;
+  top_certainty_min?: number;
+  top_certainty_max?: number;
+  has_unknown_person?: boolean;
+} | null
+```
+
+Rules:
+- omit min/max when `0..∞`
+- omit certainty/unknown when `0..0`
+- convert percent to decimal for request payload
+
+- [ ] **Step 5: Re-run state tests**
+
+Run: `npm --prefix apps/ui test -- src/pages/library/libraryRouteSearchState.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git -C /mnt/d/Projects/photo-org add apps/ui/src/pages/library/libraryRouteTypes.ts apps/ui/src/pages/library/libraryRouteSearchState.ts apps/ui/src/pages/library/libraryRouteSearchState.test.ts
+git -C /mnt/d/Projects/photo-org commit -m "feat(ui): add advanced faces filter state serialization"
+```
+
+---
+
+### Task 4: Wire Advanced Faces Filter Through Request Pipeline
+
+**Files:**
+- Modify: `apps/ui/src/pages/library/libraryRouteApi.ts`
+- Modify: `apps/ui/src/pages/library/useLibraryResults.ts`
+- Modify: `apps/ui/src/pages/LibraryRoutePage.tsx`
+- Test: `apps/ui/src/pages/LibraryRoutePage.test.tsx`
+
+- [ ] **Step 1: Write failing request-payload tests in `LibraryRoutePage.test.tsx`**
+
+```ts
+it("sends faces filter payload with count, certainty, and unknown fields", async () => {
+  // interact with faces controls
+  // assert latest /api/v1/search request body has filters.faces
+});
+
+it("suppresses certainty and unknown fields when face count is 0..0", async () => {
+  // set 0..0 and assert filters.faces excludes top_certainty_* and has_unknown_person
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm --prefix apps/ui test -- src/pages/LibraryRoutePage.test.tsx -t "faces filter payload"`
+Expected: FAIL (payload lacks `filters.faces`).
+
+- [ ] **Step 3: Add faces filter state to route state plumbing**
+
+```ts
+const [facesFilter, setFacesFilter] = useState<LibraryFacesFilterState>(parsedUrlState.facesFilter);
+```
+
+- [ ] **Step 4: Thread `facesFilter` through `useLibraryResults` and `fetchLibraryPage`**
+
+```ts
+fetchLibraryPage(
+  committedQuery,
+  fromDate,
+  toDate,
+  selectedPersonNames,
+  selectedAlbumIds,
+  personCertaintyMode,
+  suggestionConfidenceMinDraft,
+  locationRadiusFilter,
+  hasFacesFilter,
+  pathHintFilters,
+  facesFilter,
+  sortDirection,
+  requestOffset,
+  pageSize,
+  includeFaceInfo
+)
+```
+
+- [ ] **Step 5: Ensure request body includes `filters.faces` only when active**
+
+```ts
+const searchFilters = buildSearchFilters(
+  fromDate,
+  toDate,
+  selectedPersonNames,
+  selectedAlbumIds,
+  personCertaintyMode,
+  suggestionConfidenceMinDraft,
+  locationRadius,
+  hasFaces,
+  pathHints,
+  facesFilter
+);
+```
+
+- [ ] **Step 6: Re-run targeted route tests**
+
+Run: `npm --prefix apps/ui test -- src/pages/LibraryRoutePage.test.tsx -t "faces filter payload|suppresses certainty"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 4**
+
+```bash
+git -C /mnt/d/Projects/photo-org add apps/ui/src/pages/library/libraryRouteApi.ts apps/ui/src/pages/library/useLibraryResults.ts apps/ui/src/pages/LibraryRoutePage.tsx apps/ui/src/pages/LibraryRoutePage.test.tsx
+git -C /mnt/d/Projects/photo-org commit -m "feat(ui): wire advanced faces filter into library search requests"
+```
+
+---
+
+### Task 5: Build Faces UI Controls With Drag-Stable React-Range Sliders
+
+**Files:**
+- Modify: `apps/ui/src/pages/library/LibrarySearchForm.tsx`
+- Modify: `apps/ui/src/pages/shared/ConfidenceSlider.tsx`
+- Modify: `apps/ui/src/styles/app-shell.css`
+- Test: `apps/ui/src/pages/LibraryRoutePage.test.tsx`
+
+- [ ] **Step 1: Write failing UI tests for Faces panel controls**
+
+```ts
+it("renders faces range sliders and unknown checkbox in faces panel", async () => {
+  await user.click(screen.getByRole("button", { name: "Faces filter type" }));
+  expect(screen.getByText("Face count range")).toBeInTheDocument();
+  expect(screen.getByText("Top certainty range")).toBeInTheDocument();
+  expect(screen.getByRole("checkbox", { name: "Has face assigned to unknown person" })).toBeInTheDocument();
+});
+
+it("shows infinity label when max faces handle is 10", async () => {
+  await user.click(screen.getByRole("button", { name: "Faces filter type" }));
+  expect(screen.getByText(/At most faces: ∞/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `npm --prefix apps/ui test -- src/pages/LibraryRoutePage.test.tsx -t "faces panel controls|infinity label"`
+Expected: FAIL (controls not present yet).
+
+- [ ] **Step 3: Extend slider component support for custom bounds/labels**
+
+```ts
+interface ConfidenceRangeSliderProps {
+  minValue: number;
+  maxValue: number;
+  onValueChange: (minValue: number, maxValue: number) => void;
+  disabled?: boolean;
+  minBound?: number;
+  maxBound?: number;
+  minLabel?: string;
+  maxLabel?: string;
+  maxValueFormatter?: (value: number) => string;
+}
+```
+
+Keep `onChange` draft state + `onFinalChange` commit behavior to retain smooth dragging.
+
+- [ ] **Step 4: Implement Faces panel in `LibrarySearchForm.tsx`**
+
+```tsx
+<button aria-label="Faces filter type">Faces</button>
+<ConfidenceRangeSlider
+  minBound={0}
+  maxBound={10}
+  minLabel="At least faces"
+  maxLabel="At most faces"
+  maxValueFormatter={(value) => (value === 10 ? "∞" : String(value))}
+  minValue={facesFilter.minCount}
+  maxValue={facesFilter.maxCount ?? 10}
+  onValueChange={onFacesCountRangeChange}
+/>
+<ConfidenceRangeSlider
+  minBound={0}
+  maxBound={100}
+  minLabel="Top certainty minimum"
+  maxLabel="Top certainty maximum"
+  minValue={facesFilter.certaintyMinPct}
+  maxValue={facesFilter.certaintyMaxPct}
+  disabled={isZeroFacesOnly}
+  onValueChange={onFacesCertaintyRangeChange}
+/>
+<label className="search-filter-checkbox-row">
+  <input
+    type="checkbox"
+    checked={facesFilter.hasUnknownPerson}
+    disabled={isZeroFacesOnly}
+    onChange={(event) => onFacesUnknownToggle(event.target.checked)}
+  />
+  Has face assigned to unknown person
+</label>
+```
+
+- [ ] **Step 5: Add/adjust styles for Faces panel rows and helper text**
+
+```css
+.search-faces-panel {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.search-faces-helper-text {
+  margin: 0;
+  color: #64748b;
+  font-size: 0.88rem;
+}
+
+.search-filter-checkbox-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: #334155;
+}
+```
+
+- [ ] **Step 6: Re-run targeted UI tests**
+
+Run: `npm --prefix apps/ui test -- src/pages/LibraryRoutePage.test.tsx -t "faces panel controls|infinity label|faces filter payload"`
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 5**
+
+```bash
+git -C /mnt/d/Projects/photo-org add apps/ui/src/pages/library/LibrarySearchForm.tsx apps/ui/src/pages/shared/ConfidenceSlider.tsx apps/ui/src/styles/app-shell.css apps/ui/src/pages/LibraryRoutePage.test.tsx
+git -C /mnt/d/Projects/photo-org commit -m "feat(ui): add advanced faces filter panel with range sliders"
+```
+
+---
+
+### Task 6: Full Verification Pass
+
+**Files:**
+- Verify only; no planned file creation.
+
+- [ ] **Step 1: Run UI tests for touched files**
+
+Run: `npm --prefix apps/ui test -- src/pages/LibraryRoutePage.test.tsx src/pages/library/libraryRouteSearchState.test.ts src/pages/search/LocationRadiusPicker.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 2: Run API tests for search filter behavior**
+
+Run: `uv run pytest apps/api/tests/test_search_service.py -k "faces_filter or location_radius or page_spec"`
+Expected: PASS.
+
+- [ ] **Step 3: Run UI build check**
+
+Run: `npm --prefix apps/ui run build`
+Expected: PASS (or known unrelated failure documented before merge).
+
+- [ ] **Step 4: Confirm working tree and summarize residual risks**
+
+Run: `git -C /mnt/d/Projects/photo-org status --short`
+Expected: empty output.

--- a/docs/superpowers/plans/2026-05-10-library-filter-chip-popups-implementation.md
+++ b/docs/superpowers/plans/2026-05-10-library-filter-chip-popups-implementation.md
@@ -1,0 +1,536 @@
+# Library Filter Chip Popups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Library route's all-at-once filter editor with per-filter chip popups that open one at a time, keep live updates where required, and add Done/Apply/Cancel behavior by filter type.
+
+**Architecture:** Keep filter source-of-truth in `LibraryRoutePage` and implement popup/session behavior in `LibrarySearchForm`. Keep active filter removal chips unchanged. Move has-faces interaction to a direct cycling chip and keep album/path-hint controls in their own popup sections.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library, existing app-shell CSS.
+
+---
+
+## SRP Guardrails (Apply To Every Task)
+
+- Keep container orchestration in `LibrarySearchForm.tsx` and avoid leaking panel-session logic into unrelated files.
+- Keep reusable facet-option rendering concerns in `FacetFilterPanel.tsx`; do not re-embed duplicate album/path-hint control logic in multiple places.
+- Keep presentation-only styling in `app-shell.css`; no behavior encoded in CSS class naming or selector hacks.
+- Keep tests in `LibraryRoutePage.test.tsx` focused on user-observable behavior, not implementation internals.
+- Before each task commit, confirm each touched file still has one clear responsibility and remove any helper/function that crosses responsibilities.
+
+---
+
+### Task 1: Add One-Panel Filter Chip Controller In `LibrarySearchForm`
+
+**Files:**
+- Modify: `apps/ui/src/pages/library/LibrarySearchForm.tsx`
+- Test: `apps/ui/src/pages/LibraryRoutePage.test.tsx`
+
+- [ ] **Step 1: Write failing tests for panel switching and per-chip entry points**
+
+```tsx
+it("opens one filter panel at a time from filter chips", async () => {
+  const user = userEvent.setup();
+  renderLibraryAt("/library");
+  await screen.findByRole("heading", { name: "Library", level: 1 });
+
+  await user.click(screen.getByRole("button", { name: "Person filter type" }));
+  expect(screen.getByLabelText("Person filter")).toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: "Album filter type" }));
+  expect(screen.queryByLabelText("Person filter")).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Done album filters" })).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run targeted test command and verify failure**
+
+Run: `npm --prefix apps/ui test -- --runInBand src/pages/LibraryRoutePage.test.tsx -t "opens one filter panel at a time from filter chips"`
+
+Expected: FAIL with missing `Person filter type`/`Album filter type` controls.
+
+- [ ] **Step 3: Replace disclosure state with `openPanel` state and chip row**
+
+```tsx
+type OpenPanel = "date" | "person" | "location" | "album" | "pathHints" | null;
+
+const [openPanel, setOpenPanel] = useState<OpenPanel>(null);
+
+function handleTogglePanel(panel: Exclude<OpenPanel, null>) {
+  setOpenPanel((current) => (current === panel ? null : panel));
+}
+
+<div className="search-filter-entry-row" aria-label="Filter labels">
+  <button type="button" aria-label="Date filter type" onClick={() => handleTogglePanel("date")}>Date</button>
+  <button type="button" aria-label="Person filter type" onClick={() => handleTogglePanel("person")}>Person</button>
+  <button type="button" aria-label="Location filter type" onClick={() => handleTogglePanel("location")}>Location</button>
+  <button type="button" aria-label="Album filter type" onClick={() => handleTogglePanel("album")}>Album</button>
+  <button type="button" aria-label="Path hints filter type" onClick={() => handleTogglePanel("pathHints")}>Path hints</button>
+  <button type="button" aria-label="Has faces filter type">Has faces</button>
+</div>
+
+{openPanel === "person" ? (
+  <div className="search-filter-panel" aria-label="Person filters panel">
+    <div className="search-person-row">
+      <label htmlFor="search-person-input">Person filter</label>
+      <div className="search-person-input-row">
+        <input id="search-person-input" type="text" value={personDraft} onChange={(event) => onPersonDraftChange(event.target.value)} />
+        <button type="button" onClick={onAddPersonFilter}>Add person filter</button>
+      </div>
+    </div>
+  </div>
+) : null}
+{openPanel === "album" ? (
+  <div className="search-filter-panel" aria-label="Album filters panel">
+    <FacetFilterPanel
+      selectedAlbumIds={selectedAlbumIds}
+      pathHintFilters={pathHintFilters}
+      albumOptions={albumFilterOptions}
+      pathHintCounts={facetPathHintCounts}
+      onToggleAlbum={onToggleAlbumFilter}
+      onClearAllAlbums={onClearAllAlbumFilters}
+      onTogglePathHint={onTogglePathHintFilter}
+      onClearAllPathHints={onClearAllPathHints}
+    />
+  </div>
+) : null}
+```
+
+- [ ] **Step 4: Keep existing filter sections, but render each under its own conditional panel**
+
+```tsx
+{openPanel === "date" ? (
+  <div className="search-filter-panel" aria-label="Date filters panel">
+    <div className="search-date-row">
+      <label htmlFor="search-date-from">From date</label>
+      <input id="search-date-from" type="date" value={fromDate} onChange={(event) => onFromDateChange(event.target.value)} />
+      <label htmlFor="search-date-to">To date</label>
+      <input id="search-date-to" type="date" value={toDate} onChange={(event) => onToDateChange(event.target.value)} />
+    </div>
+  </div>
+) : null}
+
+{openPanel === "person" ? (
+  <div className="search-filter-panel" aria-label="Person filters panel">
+    <div className="search-person-row">
+      <label htmlFor="search-person-input">Person filter</label>
+      <div className="search-person-input-row">
+        <input id="search-person-input" type="text" value={personDraft} onChange={(event) => onPersonDraftChange(event.target.value)} />
+        <button type="button" onClick={onAddPersonFilter}>Add person filter</button>
+      </div>
+    </div>
+  </div>
+) : null}
+```
+
+- [ ] **Step 5: Re-run focused panel-switching test**
+
+Run: `npm --prefix apps/ui test -- --runInBand src/pages/LibraryRoutePage.test.tsx -t "opens one filter panel at a time from filter chips"`
+
+Expected: PASS.
+
+- [ ] **Step 6: SRP checkpoint for Task 1**
+
+Confirm:
+- `LibrarySearchForm.tsx` only coordinates chip/panel state and delegates filter mutations through existing callbacks.
+- No new duplicated filter rendering logic appears across panel sections.
+- Tests assert interaction behavior only.
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git -C /mnt/d/Projects/photo-org add apps/ui/src/pages/library/LibrarySearchForm.tsx apps/ui/src/pages/LibraryRoutePage.test.tsx
+git -C /mnt/d/Projects/photo-org commit -m "feat: add per-filter chip entry panels in library search form"
+```
+
+### Task 2: Implement Button Semantics (Done/Apply/Cancel) and Revert Snapshots
+
+**Files:**
+- Modify: `apps/ui/src/pages/library/LibrarySearchForm.tsx`
+- Test: `apps/ui/src/pages/LibraryRoutePage.test.tsx`
+
+- [ ] **Step 1: Write failing tests for Date cancel revert**
+
+```tsx
+it("reverts date edits on cancel", async () => {
+  const user = userEvent.setup();
+  renderLibraryAt("/library?from=2024-01-01&to=2024-01-31");
+  await screen.findByRole("heading", { name: "Library", level: 1 });
+
+  await user.click(screen.getByRole("button", { name: "Date filter type" }));
+  await user.clear(screen.getByLabelText("From date"));
+  await user.type(screen.getByLabelText("From date"), "2024-02-01");
+  await user.click(screen.getByRole("button", { name: "Cancel date filters" }));
+
+  await user.click(screen.getByRole("button", { name: "Date filter type" }));
+  expect(screen.getByLabelText("From date")).toHaveValue("2024-01-01");
+});
+```
+
+- [ ] **Step 2: Write failing tests for Location apply/cancel behavior**
+
+```tsx
+it("applies valid location and closes panel on apply", async () => {
+  const user = userEvent.setup();
+  renderLibraryAt("/library");
+  await screen.findByRole("heading", { name: "Library", level: 1 });
+
+  await user.click(screen.getByRole("button", { name: "Location filter type" }));
+  await user.type(screen.getByLabelText("Latitude"), "40.7");
+  await user.type(screen.getByLabelText("Longitude"), "-74.0");
+  await user.type(screen.getByLabelText("Radius (km)"), "3");
+  await user.click(screen.getByRole("button", { name: "Apply location filters" }));
+
+  expect(screen.queryByLabelText("Location filters panel")).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 3: Write failing test for automatic Date panel close after both dates are set**
+
+```tsx
+it("auto-closes date panel when both dates are chosen", async () => {
+  const user = userEvent.setup();
+  renderLibraryAt("/library");
+  await screen.findByRole("heading", { name: "Library", level: 1 });
+
+  await user.click(screen.getByRole("button", { name: "Date filter type" }));
+  await user.type(screen.getByLabelText("From date"), "2024-01-01");
+  await user.type(screen.getByLabelText("To date"), "2024-01-31");
+
+  expect(screen.queryByLabelText("Date filters panel")).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 4: Add snapshot state and open-time capture for date/location**
+
+```tsx
+const [dateSnapshot, setDateSnapshot] = useState<{ fromDate: string; toDate: string } | null>(null);
+const [locationSnapshot, setLocationSnapshot] = useState<{
+  latitudeDraft: string;
+  longitudeDraft: string;
+  radiusDraft: string;
+} | null>(null);
+
+function openPanel(panel: Exclude<OpenPanel, null>) {
+  if (panel === "date") {
+    setDateSnapshot({ fromDate, toDate });
+  }
+  if (panel === "location") {
+    setLocationSnapshot({ latitudeDraft, longitudeDraft, radiusDraft });
+  }
+  setOpenPanel(panel);
+}
+```
+
+- [ ] **Step 5: Add Date auto-close effect for complete valid range**
+
+```tsx
+useEffect(() => {
+  if (openPanel !== "date") {
+    return;
+  }
+  if (!fromDate || !toDate) {
+    return;
+  }
+  if (dateRangeError) {
+    return;
+  }
+  setOpenPanel(null);
+}, [openPanel, fromDate, toDate, dateRangeError]);
+```
+
+- [ ] **Step 6: Add Date cancel and Location apply/cancel action rows**
+
+```tsx
+{openPanel === "date" ? (
+  <div className="search-filter-panel-actions">
+    <button
+      type="button"
+      onClick={() => {
+        if (dateSnapshot) {
+          onFromDateChange(dateSnapshot.fromDate);
+          onToDateChange(dateSnapshot.toDate);
+        }
+        setOpenPanel(null);
+      }}
+    >
+      Cancel date filters
+    </button>
+  </div>
+) : null}
+
+{openPanel === "location" ? (
+  <div className="search-filter-panel-actions">
+    <button
+      type="button"
+      onClick={() => {
+        if (!locationError) {
+          setOpenPanel(null);
+        }
+      }}
+    >
+      Apply location filters
+    </button>
+    <button
+      type="button"
+      onClick={() => {
+        if (locationSnapshot) {
+          onLatitudeDraftChange(locationSnapshot.latitudeDraft);
+          onLongitudeDraftChange(locationSnapshot.longitudeDraft);
+          onRadiusDraftChange(locationSnapshot.radiusDraft);
+        }
+        setOpenPanel(null);
+      }}
+    >
+      Cancel location filters
+    </button>
+  </div>
+) : null}
+```
+
+- [ ] **Step 7: Add Done buttons for Person/Album/Path hints panels**
+
+```tsx
+<button type="button" onClick={() => setOpenPanel(null)}>
+  Done person filters
+</button>
+
+<button type="button" onClick={() => setOpenPanel(null)}>
+  Done album filters
+</button>
+
+<button type="button" onClick={() => setOpenPanel(null)}>
+  Done path hint filters
+</button>
+```
+
+- [ ] **Step 8: Run targeted tests for cancel/apply/auto-close/done flows**
+
+Run: `npm --prefix apps/ui test -- --runInBand src/pages/LibraryRoutePage.test.tsx -t "reverts date edits on cancel|applies valid location and closes panel on apply|auto-closes date panel when both dates are chosen|person panel stays open"`
+
+Expected: PASS.
+
+- [ ] **Step 9: SRP checkpoint for Task 2**
+
+Confirm:
+- Snapshot/revert logic stays in `LibrarySearchForm.tsx` and is scoped to Date/Location only.
+- `LibraryRoutePage.tsx` ownership of filter source-of-truth is unchanged.
+- Tests remain behavior-level.
+
+- [ ] **Step 10: Commit Task 2**
+
+```bash
+git -C /mnt/d/Projects/photo-org add apps/ui/src/pages/library/LibrarySearchForm.tsx apps/ui/src/pages/LibraryRoutePage.test.tsx
+git -C /mnt/d/Projects/photo-org commit -m "feat: add filter panel done apply cancel semantics"
+```
+
+### Task 3: Extract Has-Faces Cycle Chip and Split Facet UI Responsibilities
+
+**Files:**
+- Modify: `apps/ui/src/pages/library/LibrarySearchForm.tsx`
+- Modify: `apps/ui/src/pages/search/FacetFilterPanel.tsx`
+- Test: `apps/ui/src/pages/LibraryRoutePage.test.tsx`
+
+- [ ] **Step 1: Write failing test for has-faces chip cycle**
+
+```tsx
+it("cycles has-faces chip any with without any", async () => {
+  const user = userEvent.setup();
+  renderLibraryAt("/library");
+  await screen.findByRole("heading", { name: "Library", level: 1 });
+
+  const chip = screen.getByRole("button", { name: "Has faces filter type" });
+  await user.click(chip); // any -> with
+  expect(screen.getByText("has faces: yes")).toBeInTheDocument();
+  await user.click(chip); // with -> without
+  expect(screen.getByText("has faces: no")).toBeInTheDocument();
+  await user.click(chip); // without -> any
+  expect(screen.queryByText(/has faces:/i)).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Implement cycle helper and connect to has-faces chip click**
+
+```tsx
+function resolveNextHasFacesFilter(current: boolean | null): boolean | null {
+  if (current === null) return true;
+  if (current === true) return false;
+  return null;
+}
+
+<button
+  type="button"
+  aria-label="Has faces filter type"
+  className={hasFacesFilter !== null ? "search-filter-chip search-filter-chip-active" : "search-filter-chip"}
+  onClick={() => {
+    const nextValue = resolveNextHasFacesFilter(hasFacesFilter);
+    if (nextValue === null) {
+      onClearHasFacesFilter();
+      return;
+    }
+    onToggleHasFacesFilter(nextValue);
+  }}
+>
+  Has faces
+</button>
+```
+
+- [ ] **Step 3: Remove has-faces controls from facet panel and use only album/path hints popup sections**
+
+```tsx
+// FacetFilterPanel props no longer include hasFaces* fields.
+type FacetFilterPanelProps = {
+  selectedAlbumIds: string[];
+  pathHintFilters: string[];
+  albumOptions: Array<{ albumId: string; albumName: string }>;
+  pathHintCounts: FacetCountEntry[];
+  onToggleAlbum: (albumId: string) => void;
+  onClearAllAlbums: () => void;
+  onTogglePathHint: (pathHint: string) => void;
+  onClearAllPathHints: () => void;
+};
+```
+
+- [ ] **Step 4: Run has-faces and facet regression tests**
+
+Run: `npm --prefix apps/ui test -- --runInBand src/pages/LibraryRoutePage.test.tsx -t "cycles has-faces chip|shows album filter controls and chips with album names"`
+
+Expected: PASS.
+
+- [ ] **Step 5: SRP checkpoint for Task 3**
+
+Confirm:
+- `Has faces` interaction exists in one place only (chip entry control path).
+- `FacetFilterPanel.tsx` responsibility is reduced to album/path-hint option sections.
+- No cross-file responsibility duplication.
+
+- [ ] **Step 6: Commit Task 3**
+
+```bash
+git -C /mnt/d/Projects/photo-org add apps/ui/src/pages/library/LibrarySearchForm.tsx apps/ui/src/pages/search/FacetFilterPanel.tsx apps/ui/src/pages/LibraryRoutePage.test.tsx
+git -C /mnt/d/Projects/photo-org commit -m "feat: add has-faces chip cycle and split facet panels"
+```
+
+### Task 4: Style The New Chip Entry Row And Inline Panels For Mobile/Desktop
+
+**Files:**
+- Modify: `apps/ui/src/styles/app-shell.css`
+- Test: `apps/ui/src/pages/LibraryRoutePage.test.tsx`
+
+- [ ] **Step 1: Add failing assertion that new panel action controls are visible**
+
+```tsx
+it("shows panel action controls per filter type", async () => {
+  const user = userEvent.setup();
+  renderLibraryAt("/library");
+  await screen.findByRole("heading", { name: "Library", level: 1 });
+
+  await user.click(screen.getByRole("button", { name: "Path hints filter type" }));
+  expect(screen.getByRole("button", { name: "Done path hint filters" })).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Add CSS for new entry row and panel actions without touching active chip row**
+
+```css
+.search-filter-entry-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0.45rem 0.55rem;
+}
+
+.search-filter-entry-chip {
+  border: 1px solid #cbd5e1;
+  background: #ffffff;
+  color: #334155;
+  border-radius: 999px;
+  padding: 0.2rem 0.55rem;
+  font: inherit;
+}
+
+.search-filter-panel {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0 0.55rem 0.55rem;
+}
+
+.search-filter-panel-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  justify-content: flex-end;
+}
+
+@media (max-width: 700px) {
+  .search-filter-panel-actions {
+    justify-content: stretch;
+  }
+
+  .search-filter-panel-actions button {
+    flex: 1 1 auto;
+  }
+}
+```
+
+- [ ] **Step 3: Apply new class names in `LibrarySearchForm.tsx`**
+
+```tsx
+<button
+  type="button"
+  className={isActive ? "search-filter-entry-chip search-filter-chip-active" : "search-filter-entry-chip"}
+  aria-label="Person filter type"
+  onClick={() => handleTogglePanel("person")}
+>
+  Person
+</button>
+```
+
+- [ ] **Step 4: Run full library route test file**
+
+Run: `npm --prefix apps/ui test -- --runInBand src/pages/LibraryRoutePage.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: SRP checkpoint for Task 4**
+
+Confirm:
+- `app-shell.css` additions are limited to layout/styling for entry chips and panel action rows.
+- No behavior assumptions or feature branching encoded in style selectors.
+
+- [ ] **Step 6: Commit Task 4**
+
+```bash
+git -C /mnt/d/Projects/photo-org add apps/ui/src/styles/app-shell.css apps/ui/src/pages/library/LibrarySearchForm.tsx apps/ui/src/pages/LibraryRoutePage.test.tsx
+git -C /mnt/d/Projects/photo-org commit -m "style: add inline per-filter panel layout for library filters"
+```
+
+### Task 5: Final Verification Before PR
+
+**Files:**
+- Verify only; no file edits expected.
+
+- [ ] **Step 1: Run focused UI tests for touched filter-related files**
+
+Run: `npm --prefix apps/ui test -- --runInBand src/pages/LibraryRoutePage.test.tsx src/pages/search/LocationRadiusPicker.test.tsx`
+
+Expected: PASS with all tests green.
+
+- [ ] **Step 2: Run lint check for UI package**
+
+Run: `npm --prefix apps/ui run lint`
+
+Expected: PASS with no errors.
+
+- [ ] **Step 3: Confirm clean working tree**
+
+Run: `git -C /mnt/d/Projects/photo-org status --short`
+
+Expected: empty output.
+
+- [ ] **Step 4: Create integration commit if verification-only adjustments were needed**
+
+```bash
+git -C /mnt/d/Projects/photo-org add -A
+git -C /mnt/d/Projects/photo-org commit -m "test: finalize library filter chip popup UX coverage"
+```

--- a/docs/superpowers/specs/2026-05-10-library-advanced-faces-filter-design.md
+++ b/docs/superpowers/specs/2026-05-10-library-advanced-faces-filter-design.md
@@ -1,0 +1,194 @@
+# Library Advanced Faces Filter Design
+
+Date: 2026-05-10
+
+## Summary
+
+Add a richer Faces filter to Library search that replaces dependence on simple `has_faces` semantics for face-centric workflows. The new filter supports:
+
+- face-count range (`at least` / `at most`)
+- top-certainty range over faces in each photo
+- a checkbox for photos containing at least one face assigned to Unknown person
+
+The filter must support slider-based interaction and preserve clean drag behavior consistent with Suggestions page controls.
+
+## Goals
+
+- Provide face-count range filtering using a dual-handle slider.
+- Provide top-certainty range filtering using a dual-handle slider.
+- Support unknown-person face filtering with explicit checkbox behavior.
+- Ensure face-specific subfilters are inactive when zero-face-only filtering is selected.
+- Keep query semantics deterministic and testable across UI, URL state, and backend query evaluation.
+
+## Non-Goals
+
+- Redesign non-face filter controls.
+- Replace search pagination or sorting architecture.
+- Introduce a separate search endpoint for face filters.
+- Remove legacy `has_faces` backend support in this slice (compatibility can remain during migration).
+
+## User-Facing Behavior
+
+## Faces Filter Panel
+
+The panel exposes:
+
+1. Face count range slider (`0..10`, dual handle)
+2. Top certainty range slider (`0..100`, dual handle)
+3. `Has face assigned to unknown person` checkbox
+
+### Face count slider semantics
+
+- Left handle: minimum face count.
+- Right handle: maximum face count.
+- Right handle at `10` is displayed as `∞` and means unbounded max.
+- Active face-count includes active non-dismissed faces only.
+
+Examples:
+
+- `0..0`: photos with zero faces only
+- `2..5`: photos with 2 to 5 faces
+- `1..∞`: photos with at least one face
+
+### Top certainty slider semantics
+
+- Dual handle on `0..100`.
+- Applied with ANY-face semantics per photo:
+  - a photo passes if at least one face in that photo has effective top certainty within range.
+
+Effective top certainty per face:
+
+- `100%` if face is human-confirmed assignment
+- otherwise top machine suggestion confidence for that face
+
+### Unknown person checkbox
+
+- When checked, include photos where at least one active face is assigned to the system Unknown person identity.
+- This is **at least one face**, not all faces.
+
+### Zero-face-only disable rule
+
+When count range is exactly `0..0`, face-attribute subfilters are inactive:
+
+- top-certainty range is disabled/ignored
+- unknown-person checkbox is disabled/ignored
+- any other face-attribute-specific options in this panel are disabled/ignored
+
+Helper text:
+
+`Face-specific options are unavailable when only zero-face photos are selected.`
+
+## Interaction Model
+
+- Panel is accessed from the existing filter-chip entry pattern.
+- Changes update live while editing.
+- `Done` closes panel; no `Cancel` in this phase.
+- Sliders must use drag behavior consistent with existing Suggestions confidence controls (smooth handle drag without noisy intermediate behavior regressions).
+
+## Data Contract
+
+Add a dedicated `faces` object under `SearchFilters`.
+
+Proposed structure:
+
+```json
+{
+  "filters": {
+    "faces": {
+      "min_count": 2,
+      "max_count": null,
+      "top_certainty_min": 0.65,
+      "top_certainty_max": 1.0,
+      "has_unknown_person": true
+    }
+  }
+}
+```
+
+Fields:
+
+- `min_count: int | null`
+- `max_count: int | null` (`null` = unbounded)
+- `top_certainty_min: float | null` (`0..1`)
+- `top_certainty_max: float | null` (`0..1`)
+- `has_unknown_person: bool | null`
+
+`null` means the clause is omitted from query filtering, not zero.
+
+## Serialization Rules (UI/URL/Request)
+
+Defaults in UI can display `0..∞`, but serialization omits no-op defaults:
+
+- if count range is default `0..∞`, omit both `min_count` and `max_count`
+- if count range is `0..0`, omit `top_certainty_*` and `has_unknown_person`
+- if certainty range is default `0..100` and active, it may still be omitted as no-op
+
+URL-state parsing/serialization should round-trip deterministically.
+
+## Backend Query Semantics
+
+The new `faces` filter clauses compose with existing filters using `AND`.
+
+### Face count
+
+- apply `face_count >= min_count` when set
+- apply `face_count <= max_count` when set
+- count is over non-dismissed faces tied to the photo
+
+### Top certainty range
+
+- derive per-face effective certainty:
+  - human-confirmed assigned face => `1.0`
+  - otherwise top suggestion confidence for that face (if present)
+- photo passes if any face certainty in photo is within `[top_certainty_min, top_certainty_max]`
+
+### Unknown person
+
+- pass when a photo has at least one active face assigned to the system Unknown person identity.
+- resolve unknown identity robustly via canonical display name / known identity lookup, not hardcoded IDs.
+
+## SRP-Oriented File Responsibilities
+
+- `LibrarySearchForm.tsx`: panel UI and local interaction/session behavior only
+- `libraryRouteSearchState.ts`: parse/serialize URL/query-state shape only
+- `useLibraryResults.ts` (or request builder path): mapping UI state to request payload only
+- `search_request.py`: request schema/validation only
+- `photos_repo.py`: SQL/query filtering semantics only
+
+Avoid duplicating certainty/count/unknown logic in multiple layers.
+
+## Testing Strategy
+
+### UI tests (`LibraryRoutePage.test.tsx`)
+
+- face count slider changes emit expected filter payload
+- `10` max is displayed as `∞` and treated as unbounded
+- certainty range slider updates payload with decimal bounds
+- unknown-person checkbox updates payload
+- `0..0` disables/ignores face-attribute subfilters
+- slider drag interactions remain stable
+
+### URL state tests (`libraryRouteSearchState.test.ts`)
+
+- parse/serialize roundtrip for face filter params
+- omit no-op defaults (`0..∞`)
+- enforce omission of face-attribute filters when `0..0`
+
+### API/schema/repository tests
+
+- schema validation for count/certainty bounds and min<=max
+- repository filtering:
+  - count range filtering
+  - certainty ANY-face semantics
+  - unknown-person inclusion behavior
+  - conjunction with existing filters
+
+## Risks and Mitigations
+
+- Risk: uncertain unknown-person identity lookup in query layer.
+  - Mitigation: centralize unknown-person resolution and test against assignment workflow behavior.
+- Risk: slider UX regressions (jitter/noisy updates).
+  - Mitigation: reuse existing Suggestions slider interaction pattern and add focused UI tests.
+- Risk: duplicated logic across UI/query serialization/repository.
+  - Mitigation: enforce SRP boundaries and keep each layer focused on one responsibility.
+

--- a/docs/superpowers/specs/2026-05-10-library-filter-chip-popups-design.md
+++ b/docs/superpowers/specs/2026-05-10-library-filter-chip-popups-design.md
@@ -1,0 +1,155 @@
+# Library Filter Chip Popups Design
+
+Date: 2026-05-10
+
+## Summary
+
+Improve Library filter-selection UX by replacing the single "Filter labels" disclosure editor with per-filter chip entry points. Each filter type opens independently, only one filter editor can be open at a time, and active filter chips under the form remain unchanged for quick removal.
+
+## Goals
+
+- Use filter-type chips as the entry point for editing each filter.
+- Avoid showing all filter controls at once.
+- Keep live updates for multi-instance filters.
+- Support explicit close/confirm semantics per filter type.
+- Keep active-filter removal chips unchanged.
+- Keep behavior mobile-friendly with inline, non-floating editors.
+
+## Non-Goals
+
+- No backend API or search payload schema changes.
+- No change to the existing active-filter chip row semantics.
+- No new filter families beyond current Date/Person/Location/Album/Path hints/Has faces.
+
+## Interaction Model
+
+The filter entry row becomes six chips:
+
+1. Date
+2. Person
+3. Location
+4. Album
+5. Path hints
+6. Has faces
+
+Chip behavior:
+
+- Clicking a closed chip opens its editor panel inline below the chip row.
+- Clicking the currently open chip closes its panel.
+- Opening one panel closes any other currently open panel.
+- Chip active state reflects whether that filter currently has applied values.
+
+## Per-Filter Behavior
+
+### Date
+
+- Opens Date panel.
+- Action buttons: `Cancel` only.
+- `Cancel` reverts `fromDate` and `toDate` to the snapshot captured when Date panel opened, then closes.
+
+### Person
+
+- Opens Person panel.
+- Action buttons: `Done` only.
+- Live updates remain enabled while adding/removing multiple people.
+- Panel closes only when `Done` is clicked (or another chip is opened).
+
+### Location
+
+- Opens Location panel.
+- Action buttons: `Apply` and `Cancel`.
+- `Apply` validates current location fields; if valid, close panel; if invalid, keep panel open and show validation.
+- `Cancel` reverts location fields to the snapshot captured when Location panel opened, then closes.
+
+### Album
+
+- Opens Album panel.
+- Action buttons: `Done` only.
+- Live multi-select updates remain enabled.
+
+### Path hints
+
+- Opens Path-hints panel.
+- Action buttons: `Done` only.
+- Live multi-select updates remain enabled.
+
+### Has faces
+
+- No popup panel.
+- Chip click cycles live through:
+  - `Any` (no filter)
+  - `With faces`
+  - `Without faces`
+  - back to `Any`
+
+## State Model
+
+Existing filter state remains owned by `LibraryRoutePage`. `LibrarySearchForm` gets lightweight panel-session state:
+
+- `openPanel: "date" | "person" | "location" | "album" | "pathHints" | null`
+- `dateSnapshot` captured on Date panel open
+- `locationSnapshot` captured on Location panel open
+
+Lifecycle:
+
+1. Opening Date or Location captures a snapshot for cancel-revert.
+2. `Cancel` restores snapshot for Date/Location and closes.
+3. `Done` for Person/Album/Path hints closes without rollback.
+4. `Apply` for Location closes only on valid input.
+5. Has-faces chip updates directly without panel state.
+
+## Component-Level Changes
+
+### `apps/ui/src/pages/library/LibrarySearchForm.tsx`
+
+- Replace current single disclosure toggle ("Filter labels" + Edit/Hide) with chip entry row.
+- Render panel content by `openPanel`, one at a time.
+- Add per-panel action controls:
+  - Date: `Cancel`
+  - Person: `Done`
+  - Location: `Apply`, `Cancel`
+  - Album: `Done`
+  - Path hints: `Done`
+- Move has-faces interaction from panel buttons to direct chip cycling behavior.
+- Preserve existing handlers and live-update flow for person, album, and path hints.
+
+### `apps/ui/src/pages/search/FacetFilterPanel.tsx`
+
+- Refactor responsibilities so `Has faces` controls are removed from this panel path.
+- Reuse or split album/path-hints controls as needed by `LibrarySearchForm` without changing data semantics.
+
+### `apps/ui/src/styles/app-shell.css`
+
+- Add styles for filter entry chips that act as selectors/openers.
+- Add inline editor panel styling suitable for desktop and mobile.
+- Add panel action-row styling for `Done`, `Apply`, `Cancel`.
+- Keep active-filter chip row styles unchanged.
+
+## Accessibility
+
+- Entry chips remain keyboard operable (`button` semantics).
+- Only one panel visible at a time to reduce focus ambiguity.
+- Panel actions have explicit labels (`Done`, `Apply`, `Cancel`).
+- Existing validation messaging remains attached to relevant fields.
+
+## Testing Plan
+
+Update `apps/ui/src/pages/LibraryRoutePage.test.tsx` with:
+
+1. Opening one filter panel closes the previously open panel.
+2. Person panel stays open across multiple additions until `Done`.
+3. Date `Cancel` restores the snapshot state.
+4. Location `Cancel` restores the snapshot state.
+5. Location `Apply` closes on valid location and stays open on invalid location.
+6. Has-faces chip cycles `Any -> With -> Without -> Any`.
+7. Active-filter removal chips still remove filters correctly (regression guard).
+
+## Risks and Mitigations
+
+- Risk: confusion between entry chips and active-filter chips.
+  - Mitigation: preserve visual distinction and labels; keep active-filter row untouched.
+- Risk: state edge cases when switching panels mid-edit.
+  - Mitigation: snapshot only Date/Location, close previous panel deterministically.
+- Risk: regression in facet controls due to has-faces extraction.
+  - Mitigation: add explicit tests around has-faces cycle and path-hints panel behavior.
+


### PR DESCRIPTION
## Summary
- persist Library URL state for `showFaces` and `showAlbumWidgets` so both toggles survive reload/navigation
- wire toggle parsing/serialization through library route state sync and album saved-filter query generation
- fix location radius handle interaction by keeping live circle redraw on drag but committing state on `dragend`
- add regression tests for toggle URL restore and radius drag commit behavior
- harden an existing pagination assertion to avoid timing flakiness after route transitions

## Testing
- `npm --prefix apps/ui test -- src/pages/library/libraryRouteSearchState.test.ts src/pages/LibraryRoutePage.test.tsx src/pages/search/LocationRadiusPicker.test.tsx`
- `npm --prefix apps/ui test -- src/pages/search/LocationRadiusPicker.test.tsx`
- `npm --prefix apps/ui test -- src/pages/LibraryRoutePage.test.tsx`