### PR TITLE
Clear face embeddings when dismissing false positives

### DIFF
--- a/apps/api/app/services/face_assignment.py
+++ b/apps/api/app/services/face_assignment.py
@@ -235,6 +235,7 @@ def dismiss_false_positive_face(
         )
         .values(
             dismissed_ts=dismissed_ts,
+            embedding=None,
             dismissal_provenance={
                 "workflow": "face-labeling",
                 "surface": "api",

--- a/apps/api/tests/test_face_assignment_api.py
+++ b/apps/api/tests/test_face_assignment_api.py
@@ -99,6 +99,7 @@ def test_face_assignment_api_assigns_unlabeled_face_to_existing_person(tmp_path,
                 face_id="face-1",
                 photo_id="photo-1",
                 person_id=None,
+                embedding=[0.4, 0.9],
             )
         )
 
@@ -249,6 +250,7 @@ def test_face_dismissal_api_marks_unassigned_face_as_dismissed_and_clears_sugges
             select(
                 faces.c.dismissed_ts,
                 faces.c.dismissal_provenance,
+                faces.c.embedding,
             ).where(faces.c.face_id == "face-1")
         ).mappings().one()
         persisted_suggestions = connection.execute(
@@ -261,6 +263,7 @@ def test_face_dismissal_api_marks_unassigned_face_as_dismissed_and_clears_sugges
         "surface": "api",
         "action": "dismiss_false_positive",
     }
+    assert face_row["embedding"] is None
     assert persisted_suggestions == []
 
 

--- a/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
+++ b/apps/ui/src/pages/SuggestionsRoutePage.test.tsx
@@ -300,7 +300,8 @@ describe("SuggestionsRoutePage", () => {
     expect(screen.getByLabelText("Enable album interactions")).toBeChecked();
     expect(screen.getByRole("region", { name: "Album actions" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Open face 1 actions" }));
+    const openFaceActionsButton = await screen.findByRole("button", { name: "Open face 1 actions" });
+    await user.click(openFaceActionsButton);
     expect(await screen.findByRole("dialog", { name: "Face assignment" })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Close face assignment modal" }));


### PR DESCRIPTION
## Summary
- clear `faces.embedding` when dismissing an unassigned face as a false positive
- keep dismissal provenance behavior and suggestion cleanup unchanged
- extend dismissal API coverage to assert embeddings are removed on dismissal

## Testing
- `uv run pytest apps/api/tests/test_face_assignment_api.py -k "dismissal"`