### PR TITLE
Fix album content face-box toggle and replace remove button with destructive badge

### DIFF
--- a/apps/ui/src/pages/AlbumsRoutePage.test.tsx
+++ b/apps/ui/src/pages/AlbumsRoutePage.test.tsx
@@ -101,6 +101,156 @@ describe("AlbumsRoutePage", () => {
     ).toBeInTheDocument();
   });
 
+  it("toggles album face boxes and preloads detail faces for visible photos", async () => {
+    const user = userEvent.setup();
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/v1/people") {
+        return {
+          ok: true,
+          json: async () => []
+        } as Response;
+      }
+
+      if (url === "/api/v1/albums") {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              album_id: "album-1",
+              name: "Weekend",
+              owner_user_id: "demo-user",
+              kind: "editable",
+              created_ts: "2026-05-08T12:00:00Z",
+              updated_ts: "2026-05-08T12:00:00Z",
+              item_count: 1,
+              saved_filter: null
+            }
+          ]
+        } as Response;
+      }
+
+      if (url === "/api/v1/albums/album-1?page=1&page_size=24") {
+        return {
+          ok: true,
+          json: async () => ({
+            album_id: "album-1",
+            name: "Weekend",
+            owner_user_id: "demo-user",
+            kind: "editable",
+            created_ts: "2026-05-08T12:00:00Z",
+            updated_ts: "2026-05-08T12:00:00Z",
+            item_count: 1,
+            items_total: 1,
+            items: [
+              {
+                photo_id: "photo-1",
+                path: "/library/photo-1.jpg",
+                ext: "jpg",
+                shot_ts: null,
+                filesize: 1024,
+                thumbnail: {
+                  mime_type: "image/jpeg",
+                  width: 120,
+                  height: 80,
+                  data_base64: "dGh1bWI="
+                }
+              }
+            ],
+            page: 1,
+            page_size: 24,
+            total_pages: 1,
+            saved_filter: null
+          })
+        } as Response;
+      }
+
+      if (url === "/api/v1/photos/photo-1") {
+        return {
+          ok: true,
+          json: async () => ({
+            photo_id: "photo-1",
+            path: "/library/photo-1.jpg",
+            ext: "jpg",
+            camera_make: null,
+            orientation: null,
+            shot_ts: null,
+            filesize: 1024,
+            tags: [],
+            people: [],
+            faces: [
+              {
+                face_id: "face-1",
+                person_id: null,
+                bbox_x: 10,
+                bbox_y: 12,
+                bbox_w: 18,
+                bbox_h: 20,
+                bbox_space_width: 120,
+                bbox_space_height: 80,
+                label_source: null,
+                confidence: null,
+                model_version: null,
+                provenance: null,
+                label_recorded_ts: null
+              }
+            ],
+            thumbnail: {
+              mime_type: "image/jpeg",
+              width: 120,
+              height: 80,
+              data_base64: "dGh1bWI="
+            },
+            original: {
+              is_available: true,
+              availability_state: "available",
+              last_failure_reason: null
+            },
+            metadata: {
+              sha256: "sha",
+              phash: null,
+              shot_ts_source: null,
+              camera_model: null,
+              software: null,
+              gps_latitude: null,
+              gps_longitude: null,
+              gps_altitude: null,
+              exif_attributes: null,
+              created_ts: "2026-05-08T12:00:00Z",
+              updated_ts: "2026-05-08T12:00:00Z",
+              modified_ts: null,
+              deleted_ts: null,
+              faces_count: 1,
+              faces_detected_ts: null
+            }
+          })
+        } as Response;
+      }
+
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    renderAlbumsRoute();
+
+    expect(await screen.findByRole("heading", { name: "Albums", level: 1 })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show content Weekend" }));
+
+    const faceBoxesToggle = screen.getByLabelText("Show face boxes on all photos");
+    expect(faceBoxesToggle).not.toBeChecked();
+    expect(faceBoxesToggle.closest("label")).toHaveClass("albums-detail-face-boxes-toggle");
+    expect(screen.queryByRole("button", { name: "Open face 1 actions" })).not.toBeInTheDocument();
+
+    await user.click(faceBoxesToggle);
+
+    expect(await screen.findByRole("button", { name: "Open face 1 actions" })).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Show face boxes on all photos"));
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Open face 1 actions" })).not.toBeInTheDocument();
+    });
+  });
+
   it("creates new albums and removes photo membership for editable albums", async () => {
     const user = userEvent.setup();
 

--- a/apps/ui/src/pages/AlbumsRoutePage.tsx
+++ b/apps/ui/src/pages/AlbumsRoutePage.tsx
@@ -157,6 +157,63 @@ export function AlbumsRoutePage() {
     return activeFaceSummary.faces.find((face) => face.faceId === activeFaceAssignment.faceId) ?? null;
   }, [activeFaceSummary, photoInspectorState.activeFaceAssignment]);
 
+  useEffect(() => {
+    if (!photoInspectorState.areFaceBoxesVisible || !detail || detail.items.length === 0) {
+      return;
+    }
+
+    let canceled = false;
+    const missingPhotoIds = detail.items
+      .map((item) => item.photo_id)
+      .filter((photoId) => !photoDetailById[photoId]);
+
+    if (missingPhotoIds.length === 0) {
+      return;
+    }
+
+    void Promise.all(
+      missingPhotoIds.map(async (photoId) => {
+        try {
+          const payload = await fetchPhotoDetail(photoId);
+          if (canceled) {
+            return;
+          }
+          setPhotoDetailById((current) => (
+            current[photoId]
+              ? current
+              : {
+                  ...current,
+                  [photoId]: payload
+                }
+          ));
+        } catch {
+          // Ignore prefetch failures; face overlays can still load when a card is inspected.
+        }
+      })
+    );
+
+    return () => {
+      canceled = true;
+    };
+  }, [detail, photoDetailById, photoInspectorState.areFaceBoxesVisible]);
+
+  const detailPhotoSummaryById = useMemo(() => {
+    const summaries = new Map<string, ReturnType<typeof adaptPhotoDetail>>();
+    if (!detail) {
+      return summaries;
+    }
+
+    for (const item of detail.items) {
+      const detailPayload = photoDetailById[item.photo_id];
+      if (!detailPayload) {
+        continue;
+      }
+      summaries.set(item.photo_id, adaptPhotoDetail(detailPayload));
+    }
+
+    return summaries;
+  }, [detail, photoDetailById]);
+
   function handleOpenAlbum(album: AlbumRecord) {
     const query = buildLibraryQueryForAlbum(album);
     navigate(`/library${query ? `?${query}` : ""}`);
@@ -188,6 +245,7 @@ export function AlbumsRoutePage() {
         albums={sortedAlbums}
         selectedAlbumId={selectedAlbumId}
         detail={detail}
+        detailPhotoSummaryById={detailPhotoSummaryById}
         selectedPhotoIds={selectionState.selectedPhotoIds}
         faceBoxesVisible={photoInspectorState.areFaceBoxesVisible}
         activeMetadataPhotoId={photoInspectorState.activeMetadataPhotoId}

--- a/apps/ui/src/pages/albums/AlbumDetailInline.tsx
+++ b/apps/ui/src/pages/albums/AlbumDetailInline.tsx
@@ -5,6 +5,7 @@ import { formatDisplayPath } from "../suggestions/formatting";
 
 interface AlbumDetailInlineProps {
   detail: AlbumDetail | null;
+  photoSummaryById: Map<string, PhotoSummary>;
   selectedPhotoIds: Set<string>;
   faceBoxesVisible: boolean;
   activeMetadataPhotoId: string | null;
@@ -47,6 +48,7 @@ function adaptAlbumItem(detail: AlbumDetail, item: AlbumDetail["items"][number])
 
 export function AlbumDetailInline({
   detail,
+  photoSummaryById,
   selectedPhotoIds,
   faceBoxesVisible,
   activeMetadataPhotoId,
@@ -72,44 +74,65 @@ export function AlbumDetailInline({
             <p className="albums-empty">No photos in this album.</p>
           ) : (
             <>
-            <label>
-              <input
-                type="checkbox"
-                checked={faceBoxesVisible}
-                onChange={(event) => onFaceBoxesVisibleChange(event.currentTarget.checked)}
-              />
-              Show face boxes on all photos
-            </label>
-            <ul className="albums-detail-grid" aria-label="Album photo thumbnails">
-              {detail.items.map((item) => (
-                <li key={item.photo_id}>
-                  <PhotoSurface
-                    photo={adaptAlbumItem(detail, item)}
-                    selected={selectedPhotoIds.has(item.photo_id)}
-                    faceBoxesVisible={faceBoxesVisible}
-                    activeMetadata={activeMetadataPhotoId === item.photo_id}
-                    detailTo={`/library/${item.photo_id}`}
-                    selectionLabel={`Select photo ${item.photo_id}`}
-                    detailLabel={`Open details for ${item.path}`}
-                    metadataLabel={`Show metadata for ${item.photo_id}`}
-                    onToggleSelected={onTogglePhotoSelected}
-                    onOpenMetadata={onOpenMetadata}
-                    onOpenFace={onOpenFace}
-                  />
-                  {detail.kind === "editable" ? (
-                    <button type="button" onClick={() => onRemovePhoto(item.photo_id)}>
-                      Remove photo {item.photo_id}
-                    </button>
-                  ) : null}
-                </li>
-              ))}
-            </ul>
+              <label className="albums-detail-face-boxes-toggle">
+                <input
+                  type="checkbox"
+                  checked={faceBoxesVisible}
+                  onChange={(event) => onFaceBoxesVisibleChange(event.currentTarget.checked)}
+                />
+                Show face boxes on all photos
+              </label>
+              <ul className="albums-detail-grid" aria-label="Album photo thumbnails">
+                {detail.items.map((item) => {
+                  const hydratedSummary = photoSummaryById.get(item.photo_id);
+                  const cardSummary = hydratedSummary
+                    ? {
+                        ...hydratedSummary,
+                        title: formatDisplayPath(item.path),
+                        albumMembership: {
+                          albumIds: [detail.album_id],
+                          currentAlbumId: detail.album_id
+                        }
+                      }
+                    : adaptAlbumItem(detail, item);
+
+                  return (
+                    <li key={item.photo_id}>
+                      <PhotoSurface
+                        photo={cardSummary}
+                        selected={selectedPhotoIds.has(item.photo_id)}
+                        faceBoxesVisible={faceBoxesVisible}
+                        activeMetadata={activeMetadataPhotoId === item.photo_id}
+                        detailTo={`/library/${item.photo_id}`}
+                        selectionLabel={`Select photo ${item.photo_id}`}
+                        detailLabel={`Open details for ${item.path}`}
+                        metadataLabel={`Show metadata for ${item.photo_id}`}
+                        onToggleSelected={onTogglePhotoSelected}
+                        onOpenMetadata={onOpenMetadata}
+                        onOpenFace={onOpenFace}
+                      />
+                      {detail.kind === "editable" ? (
+                        <button
+                          type="button"
+                          className="albums-detail-remove-photo-badge"
+                          aria-label={`Remove photo ${item.photo_id}`}
+                          title={`Remove photo ${item.photo_id}`}
+                          onClick={() => onRemovePhoto(item.photo_id)}
+                        >
+                          <span aria-hidden="true">×</span>
+                        </button>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ul>
             </>
           )}
           {detail.total_pages > 1 ? (
             <div className="albums-detail-pagination" aria-label="Album content pagination">
               <button
                 type="button"
+                className="albums-button"
                 onClick={() => {
                   if (detail.page > 1) {
                     onSelectPage(detail.album_id, detail.page - 1);
@@ -124,6 +147,7 @@ export function AlbumDetailInline({
               </p>
               <button
                 type="button"
+                className="albums-button"
                 onClick={() => {
                   if (detail.page < detail.total_pages) {
                     onSelectPage(detail.album_id, detail.page + 1);

--- a/apps/ui/src/pages/albums/AlbumsGrid.tsx
+++ b/apps/ui/src/pages/albums/AlbumsGrid.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from "react";
 import type { AlbumDetail, AlbumRecord } from "../library/libraryRouteApi";
+import type { PhotoSummary } from "../photo-interactions/photoInteractionTypes";
 import { serializeSavedFilter } from "./albumLibraryQuery";
 import type { AlbumRowDraft } from "./useAlbumsRouteState";
 import { AlbumDetailInline } from "./AlbumDetailInline";
@@ -9,6 +10,7 @@ interface AlbumsGridProps {
   albums: AlbumRecord[];
   selectedAlbumId: string | null;
   detail: AlbumDetail | null;
+  detailPhotoSummaryById: Map<string, PhotoSummary>;
   selectedPhotoIds: Set<string>;
   faceBoxesVisible: boolean;
   activeMetadataPhotoId: string | null;
@@ -41,6 +43,7 @@ export function AlbumsGrid({
   albums,
   selectedAlbumId,
   detail,
+  detailPhotoSummaryById,
   selectedPhotoIds,
   faceBoxesVisible,
   activeMetadataPhotoId,
@@ -157,6 +160,7 @@ export function AlbumsGrid({
                     <td colSpan={4}>
                       <AlbumDetailInline
                         detail={detail}
+                        photoSummaryById={detailPhotoSummaryById}
                         selectedPhotoIds={selectedPhotoIds}
                         faceBoxesVisible={faceBoxesVisible}
                         activeMetadataPhotoId={activeMetadataPhotoId}

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -798,7 +798,7 @@ body {
 }
 
 .albums-grid button,
-.albums-detail button {
+.albums-detail .albums-button {
   border: 1px solid #bfdbfe;
   background: #eff6ff;
   color: #1d4ed8;
@@ -916,6 +916,18 @@ body {
   font-size: 0.82rem;
 }
 
+.albums-detail-face-boxes-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #1e293b;
+  font-size: 0.84rem;
+}
+
+.albums-detail-face-boxes-toggle input {
+  margin: 0;
+}
+
 .albums-detail-grid {
   list-style: none;
   margin: 0;
@@ -926,6 +938,7 @@ body {
 }
 
 .albums-detail-grid li {
+  position: relative;
   border: 1px solid #e2e8f0;
   border-radius: 0.5rem;
   background: #f8fafc;
@@ -933,6 +946,35 @@ body {
   display: grid;
   gap: 0.4rem;
   align-content: start;
+}
+
+.albums-detail-remove-photo-badge {
+  position: absolute;
+  top: 0.68rem;
+  right: 0.68rem;
+  z-index: 5;
+  width: 1.4rem;
+  height: 1.4rem;
+  border: 1px solid #ef4444;
+  border-radius: 999px;
+  background: rgb(254 226 226 / 94%);
+  color: #b91c1c;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font: inherit;
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+}
+
+.albums-detail-remove-photo-badge:hover,
+.albums-detail-remove-photo-badge:focus-visible {
+  background: #fee2e2;
+  color: #991b1b;
+  border-color: #dc2626;
+  box-shadow: 0 0 0 2px rgb(248 113 113 / 28%);
 }
 
 .albums-detail-thumb {


### PR DESCRIPTION
## Summary
- make album content face-box toggling effective by hydrating card face data from photo detail when enabled
- align the `Show face boxes on all photos` checkbox with dedicated toggle styling
- replace the `Remove photo <id>` button with a top-right destructive red badge icon on each editable album photo card
- keep album detail/grid responsibilities separated by passing hydrated summaries via `AlbumsGrid` into `AlbumDetailInline`

## Testing
- `npm --prefix apps/ui test -- --run src/pages/AlbumsRoutePage.test.tsx src/pages/photo-interactions/PhotoSurface.test.tsx`
- `npm --prefix apps/ui test`
- `npm --prefix apps/ui test -- --run src/pages/AlbumsRoutePage.test.tsx`