### PR TITLE
feat: improve album export UX, polling throughput, and HTTPS proxy setup

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,7 @@
+localhost, 127.0.0.1 {
+  tls internal
+
+  @api path /api/*
+  reverse_proxy @api db-service:8000
+  reverse_proxy ui:5173
+}

--- a/apps/api/app/processing/ingest_common.py
+++ b/apps/api/app/processing/ingest_common.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
@@ -18,6 +19,11 @@ class IngestResult:
 
 
 def iter_photo_files(root: Path) -> Iterable[Path]:
-    for path in sorted(root.rglob("*")):
-        if path.is_file() and path.suffix.lower() in SUPPORTED_EXTENSIONS:
-            yield path
+    for current_root, dirnames, filenames in os.walk(root):
+        dirnames.sort()
+        filenames.sort()
+        root_path = Path(current_root)
+        for filename in filenames:
+            path = root_path / filename
+            if path.suffix.lower() in SUPPORTED_EXTENSIONS:
+                yield path

--- a/apps/api/app/routers/exports.py
+++ b/apps/api/app/routers/exports.py
@@ -37,7 +37,7 @@ def _safe_archive_name(photo_id: str, resolved_path: Path) -> str:
     name = resolved_path.name.strip()
     if not name:
         name = f"{photo_id}.bin"
-    return f"{photo_id}_{name}"
+    return f"{photo_id}-{name}"
 
 
 @router.post(

--- a/apps/api/app/routers/ingest_queue.py
+++ b/apps/api/app/routers/ingest_queue.py
@@ -65,6 +65,10 @@ class TriggerStorageSourcePollingRequest(BaseModel):
         le=1000,
         description="Maximum queue items to process per internal drain pass.",
     )
+    drain_queue: bool = Field(
+        default=True,
+        description="When false, only scan and enqueue candidates without draining queued ingest work.",
+    )
 
 
 class TriggerStorageSourcePollingResponse(BaseModel):
@@ -272,7 +276,10 @@ def poll_storage_sources_endpoint(
     ),
     _: None = Depends(require_worker_role),
 ) -> TriggerStorageSourcePollingResponse:
-    result = trigger_storage_source_polling(queue_process_limit=body.queue_process_limit)
+    result = trigger_storage_source_polling(
+        queue_process_limit=body.queue_process_limit,
+        drain_queue=body.drain_queue,
+    )
     return TriggerStorageSourcePollingResponse(
         scanned=result.scanned,
         enqueued=result.enqueued,

--- a/apps/api/app/routers/photos.py
+++ b/apps/api/app/routers/photos.py
@@ -94,6 +94,7 @@ def _transcode_image_to_jpeg(path: Path) -> bytes:
 def get_photo_original(
     photo_id: str,
     request: Request,
+    download: bool = False,
     db: Session = Depends(get_db),
 ) -> Response:
     repo = PhotosRepository(db)
@@ -103,6 +104,14 @@ def get_photo_original(
 
     mime_type, _ = mimetypes.guess_type(str(resolved))
     content_type = mime_type or "application/octet-stream"
+    if download:
+        return FileResponse(
+            path=resolved,
+            media_type=content_type,
+            filename=resolved.name,
+            content_disposition_type="attachment",
+        )
+
     if _needs_browser_transcode(resolved, mime_type):
         try:
             jpeg_bytes = _transcode_image_to_jpeg(resolved)

--- a/apps/api/app/services/file_reconciliation.py
+++ b/apps/api/app/services/file_reconciliation.py
@@ -8,6 +8,8 @@ from sqlalchemy.engine import Connection
 
 from app.storage import photo_files, photos, storage_sources, watched_folders
 
+LAST_SEEN_REFRESH_INTERVAL = timedelta(minutes=5)
+
 
 def _watched_folder_id_for_scan_path(scan_path: str) -> str:
     return str(uuid5(NAMESPACE_URL, f"watched-folder:{scan_path}"))
@@ -151,10 +153,25 @@ def activate_observed_file(
 ) -> str:
     photo_file_id = str(uuid5(NAMESPACE_URL, f"photo-file:{watched_folder_id}:{relative_path}"))
     row = connection.execute(
-        select(photo_files.c.photo_file_id).where(
+        select(
+            photo_files.c.photo_file_id,
+            photo_files.c.photo_id,
+            photo_files.c.watched_folder_id,
+            photo_files.c.relative_path,
+            photo_files.c.filename,
+            photo_files.c.extension,
+            photo_files.c.filesize,
+            photo_files.c.created_ts,
+            photo_files.c.modified_ts,
+            photo_files.c.last_seen_ts,
+            photo_files.c.missing_ts,
+            photo_files.c.deleted_ts,
+            photo_files.c.lifecycle_state,
+            photo_files.c.absence_reason,
+        ).where(
             photo_files.c.photo_file_id == photo_file_id
         )
-    ).first()
+    ).mappings().one_or_none()
     values = {
         "photo_id": photo_id,
         "watched_folder_id": watched_folder_id,
@@ -179,12 +196,47 @@ def activate_observed_file(
             )
         )
     else:
-        connection.execute(
-            update(photo_files)
-            .where(photo_files.c.photo_file_id == photo_file_id)
-            .values(**values)
+        should_refresh_last_seen = _should_refresh_last_seen(
+            row["last_seen_ts"],
+            now=now,
         )
+        needs_update = (
+            row["photo_id"] != photo_id
+            or row["watched_folder_id"] != watched_folder_id
+            or row["relative_path"] != relative_path
+            or row["filename"] != filename
+            or row["extension"] != extension
+            or row["filesize"] != filesize
+            or not _timestamps_equal(row["created_ts"], created_ts)
+            or not _timestamps_equal(row["modified_ts"], modified_ts)
+            or row["missing_ts"] is not None
+            or row["deleted_ts"] is not None
+            or row["lifecycle_state"] != "active"
+            or row["absence_reason"] is not None
+            or should_refresh_last_seen
+        )
+        if needs_update:
+            update_values = dict(values)
+            if not should_refresh_last_seen:
+                update_values.pop("last_seen_ts")
+            connection.execute(
+                update(photo_files)
+                .where(photo_files.c.photo_file_id == photo_file_id)
+                .values(**update_values)
+            )
     return photo_id
+
+
+def _should_refresh_last_seen(last_seen_ts: datetime | None, *, now: datetime) -> bool:
+    if last_seen_ts is None:
+        return True
+    return normalize_timestamp(last_seen_ts) + LAST_SEEN_REFRESH_INTERVAL <= now
+
+
+def _timestamps_equal(left: datetime | None, right: datetime | None) -> bool:
+    if left is None or right is None:
+        return left is right
+    return normalize_timestamp(left) == normalize_timestamp(right)
 
 
 def reconcile_watched_folder(

--- a/apps/api/app/services/storage_source_polling.py
+++ b/apps/api/app/services/storage_source_polling.py
@@ -40,6 +40,7 @@ def trigger_storage_source_polling(
     *,
     database_url: str | Path | None = None,
     queue_process_limit: int = 100,
+    drain_queue: bool = True,
 ) -> TriggerStorageSourcePollingResult:
     initial_photo_count = _count_photos(database_url)
     poll_result = poll_registered_storage_sources(database_url=database_url)
@@ -47,16 +48,17 @@ def trigger_storage_source_polling(
     queue_processed = 0
     queue_failed = 0
     queue_retryable_errors = 0
-    while True:
-        queue_result = process_pending_ingest_queue(
-            database_url=database_url,
-            limit=queue_process_limit,
-        )
-        queue_processed += queue_result.processed
-        queue_failed += queue_result.failed
-        queue_retryable_errors += queue_result.retryable_errors
-        if queue_result.processed == 0:
-            break
+    if drain_queue:
+        while True:
+            queue_result = process_pending_ingest_queue(
+                database_url=database_url,
+                limit=queue_process_limit,
+            )
+            queue_processed += queue_result.processed
+            queue_failed += queue_result.failed
+            queue_retryable_errors += queue_result.retryable_errors
+            if queue_result.processed == 0:
+                break
 
     inserted = max(0, _count_photos(database_url) - initial_photo_count)
     return TriggerStorageSourcePollingResult(

--- a/apps/api/tests/test_albums_and_exports_api.py
+++ b/apps/api/tests/test_albums_and_exports_api.py
@@ -240,12 +240,16 @@ def test_photo_export_returns_zip_with_selected_files(tmp_path, monkeypatch):
     source_root.mkdir(parents=True, exist_ok=True)
     folder_a = source_root / "a"
     folder_b = source_root / "b"
+    folder_c = source_root / "c"
     folder_a.mkdir(parents=True, exist_ok=True)
     folder_b.mkdir(parents=True, exist_ok=True)
+    folder_c.mkdir(parents=True, exist_ok=True)
     file_a = folder_a / "trip-a.jpg"
     file_b = folder_b / "trip-b.jpg"
+    file_c = folder_c / "portrait.heic"
     file_a.write_bytes(b"trip-a-bytes")
     file_b.write_bytes(b"trip-b-bytes")
+    file_c.write_bytes(b"heic-original-binary-payload")
 
     client = _client(tmp_path, monkeypatch, "exports-api.db")
 
@@ -253,22 +257,24 @@ def test_photo_export_returns_zip_with_selected_files(tmp_path, monkeypatch):
     with engine.begin() as connection:
         _seed_photo(connection, photo_id="photo-a", relative_path="trip-a.jpg", scan_path=str(folder_a))
         _seed_photo(connection, photo_id="photo-b", relative_path="trip-b.jpg", scan_path=str(folder_b))
+        _seed_photo(connection, photo_id="photo-c", relative_path="portrait.heic", scan_path=str(folder_c))
 
     response = client.post(
         "/api/v1/exports/photos",
-        json={"photo_ids": ["photo-a", "photo-missing", "photo-b"]},
+        json={"photo_ids": ["photo-a", "photo-missing", "photo-c", "photo-b"]},
     )
 
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/zip"
-    assert response.headers["x-photo-org-exported-count"] == "2"
+    assert response.headers["x-photo-org-exported-count"] == "3"
     assert response.headers["x-photo-org-skipped-count"] == "1"
 
     archive = ZipFile(BytesIO(response.content))
     names = sorted(archive.namelist())
-    assert names == ["photo-a_trip-a.jpg", "photo-b_trip-b.jpg"]
-    assert archive.read("photo-a_trip-a.jpg") == b"trip-a-bytes"
-    assert archive.read("photo-b_trip-b.jpg") == b"trip-b-bytes"
+    assert names == ["photo-a-trip-a.jpg", "photo-b-trip-b.jpg", "photo-c-portrait.heic"]
+    assert archive.read("photo-a-trip-a.jpg") == b"trip-a-bytes"
+    assert archive.read("photo-b-trip-b.jpg") == b"trip-b-bytes"
+    assert archive.read("photo-c-portrait.heic") == b"heic-original-binary-payload"
 
 
 def test_photo_export_rejects_empty_photo_ids(tmp_path, monkeypatch):

--- a/apps/api/tests/test_ingest.py
+++ b/apps/api/tests/test_ingest.py
@@ -1713,6 +1713,86 @@ def test_reappearing_file_clears_parent_photo_deleted_timestamp(tmp_path):
     assert load_photo_deleted_ts(database_url, "photo-1") is None
 
 
+def test_activate_observed_file_throttles_last_seen_refresh_for_unchanged_rows(tmp_path):
+    database_url = f"sqlite:///{tmp_path / 'photo-last-seen-throttle.db'}"
+    upgrade_database(database_url)
+    initial_now = datetime(2026, 3, 24, tzinfo=UTC)
+    within_refresh_window = initial_now + timedelta(minutes=1)
+    beyond_refresh_window = initial_now + timedelta(minutes=6)
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                path="/test-root/family-events/birthday-park/birthday_park_001.jpg",
+                sha256="a" * 64,
+                phash=None,
+                filesize=100,
+                ext="jpg",
+                created_ts=initial_now,
+                modified_ts=initial_now,
+                shot_ts=None,
+                shot_ts_source=None,
+                camera_make=None,
+                camera_model=None,
+                software=None,
+                orientation=None,
+                gps_latitude=None,
+                gps_longitude=None,
+                gps_altitude=None,
+                updated_ts=initial_now,
+                deleted_ts=None,
+                faces_count=0,
+                faces_detected_ts=None,
+            )
+        )
+        activate_observed_file(
+            connection,
+            watched_folder_id="watched-folder-1",
+            photo_id="photo-1",
+            relative_path="family-events/birthday-park/birthday_park_001.jpg",
+            filename="birthday_park_001.jpg",
+            extension="jpg",
+            filesize=100,
+            created_ts=initial_now,
+            modified_ts=initial_now,
+            now=initial_now,
+        )
+        activate_observed_file(
+            connection,
+            watched_folder_id="watched-folder-1",
+            photo_id="photo-1",
+            relative_path="family-events/birthday-park/birthday_park_001.jpg",
+            filename="birthday_park_001.jpg",
+            extension="jpg",
+            filesize=100,
+            created_ts=initial_now,
+            modified_ts=initial_now,
+            now=within_refresh_window,
+        )
+
+    unchanged_row = load_photo_file_rows(database_url, "photo-1")[0]
+    assert unchanged_row["last_seen_ts"] == initial_now
+
+    with engine.begin() as connection:
+        activate_observed_file(
+            connection,
+            watched_folder_id="watched-folder-1",
+            photo_id="photo-1",
+            relative_path="family-events/birthday-park/birthday_park_001.jpg",
+            filename="birthday_park_001.jpg",
+            extension="jpg",
+            filesize=100,
+            created_ts=initial_now,
+            modified_ts=initial_now,
+            now=beyond_refresh_window,
+        )
+
+    refreshed_row = load_photo_file_rows(database_url, "photo-1")[0]
+    assert refreshed_row["last_seen_ts"] == beyond_refresh_window
+
+
 def load_photo_count(database_url: str) -> int:
     engine = create_engine(database_url, future=True)
     with engine.connect() as connection:

--- a/apps/api/tests/test_ingest_common.py
+++ b/apps/api/tests/test_ingest_common.py
@@ -1,0 +1,24 @@
+from app.processing.ingest_common import iter_photo_files
+
+
+def test_iter_photo_files_streams_supported_files_in_stable_directory_order(tmp_path):
+    root = tmp_path / "root"
+    nested = root / "b" / "nested"
+    sibling = root / "a"
+    nested.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+
+    (root / "ignore.txt").write_text("ignore")
+    (sibling / "img-02.jpg").write_text("jpg")
+    (sibling / "img-01.jpeg").write_text("jpeg")
+    (nested / "img-03.heic").write_text("heic")
+    (nested / "img-04.png").write_text("png")
+
+    observed = [path.relative_to(root).as_posix() for path in iter_photo_files(root)]
+
+    assert observed == [
+        "a/img-01.jpeg",
+        "a/img-02.jpg",
+        "b/nested/img-03.heic",
+        "b/nested/img-04.png",
+    ]

--- a/apps/api/tests/test_ingest_queue_api.py
+++ b/apps/api/tests/test_ingest_queue_api.py
@@ -312,7 +312,7 @@ def test_poll_storage_sources_endpoint_forwards_queue_process_limit(
     client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    captured: dict[str, int] = {}
+    captured: dict[str, object] = {}
 
     class Result:
         scanned = 10
@@ -325,8 +325,13 @@ def test_poll_storage_sources_endpoint_forwards_queue_process_limit(
         poll_errors = ("marker mismatch",)
         error_count = 4
 
-    def fake_trigger_storage_source_polling(*, queue_process_limit: int = 100):
+    def fake_trigger_storage_source_polling(
+        *,
+        queue_process_limit: int = 100,
+        drain_queue: bool = True,
+    ):
         captured["queue_process_limit"] = queue_process_limit
+        captured["drain_queue"] = drain_queue
         return Result()
 
     monkeypatch.setattr(
@@ -337,11 +342,11 @@ def test_poll_storage_sources_endpoint_forwards_queue_process_limit(
     response = client.post(
         "/api/v1/internal/storage-sources/poll",
         headers={"X-Worker-Role": "ingest-processor"},
-        json={"queue_process_limit": 333},
+        json={"queue_process_limit": 333, "drain_queue": False},
     )
 
     assert response.status_code == 200
-    assert captured == {"queue_process_limit": 333}
+    assert captured == {"queue_process_limit": 333, "drain_queue": False}
     assert response.json() == {
         "scanned": 10,
         "enqueued": 7,

--- a/apps/api/tests/test_photo_detail_api.py
+++ b/apps/api/tests/test_photo_detail_api.py
@@ -849,3 +849,104 @@ def test_photo_original_api_transcodes_heic_for_browser_preview(tmp_path, monkey
     assert response.headers["content-type"].startswith("image/jpeg")
     assert response.headers["content-disposition"].startswith("inline;")
     assert len(response.content) > 0
+
+
+def test_photo_original_api_download_mode_returns_raw_heic_bytes(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'photo-original-api-heic-download.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    _get_session_factory.cache_clear()
+
+    def _fail_if_transcode_called(_path):
+        raise AssertionError("HEIC transcode must not be used in download mode")
+
+    monkeypatch.setattr("app.routers.photos._transcode_image_to_jpeg", _fail_if_transcode_called)
+
+    source_root = tmp_path / "storage-source"
+    watched_root = source_root / "trips"
+    watched_root.mkdir(parents=True, exist_ok=True)
+    photo_path = watched_root / "photo-1.heic"
+    photo_bytes = b"heic-original-download-bytes"
+    photo_path.write_bytes(photo_bytes)
+    (source_root / ".photo-org-source.json").write_text(
+        json.dumps({"storage_source_id": "source-1", "marker_version": 1})
+    )
+
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 3, 28, 19, 30, tzinfo=UTC)
+    with engine.begin() as connection:
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                sha256="sha-1",
+                created_ts=now,
+                updated_ts=now,
+                path="/storage-sources/source-1/trips/photo-1.heic",
+                filesize=len(photo_bytes),
+                ext="heic",
+                faces_count=0,
+            )
+        )
+        connection.execute(
+            insert(storage_sources).values(
+                storage_source_id="source-1",
+                display_name="Family share",
+                marker_filename=".photo-org-source.json",
+                marker_version=1,
+                availability_state="active",
+                last_failure_reason=None,
+                last_validated_ts=now,
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        connection.execute(
+            insert(storage_source_aliases).values(
+                storage_source_alias_id="alias-1",
+                storage_source_id="source-1",
+                alias_path=str(source_root),
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        connection.execute(
+            insert(watched_folders).values(
+                watched_folder_id="wf-1",
+                scan_path=str(watched_root),
+                storage_source_id="source-1",
+                relative_path="trips",
+                display_name="Trips",
+                is_enabled=1,
+                availability_state="active",
+                last_failure_reason=None,
+                last_successful_scan_ts=now,
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        connection.execute(
+            insert(photo_files).values(
+                photo_file_id="pf-1",
+                photo_id="photo-1",
+                watched_folder_id="wf-1",
+                relative_path="photo-1.heic",
+                filename="photo-1.heic",
+                extension="heic",
+                filesize=len(photo_bytes),
+                created_ts=now,
+                modified_ts=now,
+                first_seen_ts=now,
+                last_seen_ts=now,
+                missing_ts=None,
+                deleted_ts=None,
+                lifecycle_state="active",
+                absence_reason=None,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.get("/api/v1/photos/photo-1/original?download=true")
+
+    assert response.status_code == 200
+    assert response.content == photo_bytes
+    assert response.headers["content-disposition"].startswith("attachment;")

--- a/apps/api/tests/test_storage_source_polling_service.py
+++ b/apps/api/tests/test_storage_source_polling_service.py
@@ -51,3 +51,55 @@ def test_trigger_storage_source_polling_runs_poll_then_drains_queue(monkeypatch)
     assert result.queue_retryable_errors == 1
     assert result.poll_errors == ("marker mismatch",)
     assert result.error_count == 3
+
+
+def test_trigger_storage_source_polling_can_skip_queue_draining(monkeypatch):
+    queue_calls = 0
+    photo_counts = iter([11, 11])
+
+    monkeypatch.setattr(
+        polling_service,
+        "poll_registered_storage_sources",
+        lambda **_: type(
+            "PollResult",
+            (),
+            {
+                "scanned": 4,
+                "enqueued": 4,
+                "updated": 0,
+                "errors": [],
+            },
+        )(),
+    )
+
+    def fake_process_pending_ingest_queue(**_kwargs):
+        nonlocal queue_calls
+        queue_calls += 1
+        return type("QueueResult", (), {"processed": 0, "failed": 0, "retryable_errors": 0})()
+
+    monkeypatch.setattr(
+        polling_service,
+        "process_pending_ingest_queue",
+        fake_process_pending_ingest_queue,
+    )
+    monkeypatch.setattr(
+        polling_service,
+        "_count_photos",
+        lambda database_url=None: next(photo_counts),
+    )
+
+    result = polling_service.trigger_storage_source_polling(
+        queue_process_limit=77,
+        drain_queue=False,
+    )
+
+    assert queue_calls == 0
+    assert result.scanned == 4
+    assert result.enqueued == 4
+    assert result.inserted == 0
+    assert result.updated == 0
+    assert result.queue_processed == 0
+    assert result.queue_failed == 0
+    assert result.queue_retryable_errors == 0
+    assert result.poll_errors == ()
+    assert result.error_count == 0

--- a/apps/ui/src/pages/AlbumsRoutePage.test.tsx
+++ b/apps/ui/src/pages/AlbumsRoutePage.test.tsx
@@ -99,6 +99,7 @@ describe("AlbumsRoutePage", () => {
     expect(
       await screen.findByRole("img", { name: /preview of \/library\/photo-1.jpg/i })
     ).toBeInTheDocument();
+    expect(screen.getByRole("list", { name: "Album photo thumbnails" })).toHaveClass("browse-grid");
   });
 
   it("toggles album face boxes and preloads detail faces for visible photos", async () => {
@@ -531,5 +532,244 @@ describe("AlbumsRoutePage", () => {
 
     expect(screen.getByRole("checkbox", { name: /select photo/i })).toBeChecked();
     expect(screen.getByRole("complementary", { name: /metadata/i })).toBeInTheDocument();
+  });
+
+  it("exports album photos into a selected folder one file at a time", async () => {
+    const user = userEvent.setup();
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    let releaseFirstWrite: (() => void) | null = null;
+    const firstWritePending = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    const writeSpy = vi.fn(async () => {});
+    const closeSpy = vi.fn(async () => {});
+    writeSpy.mockImplementationOnce(async () => {
+      await firstWritePending;
+    });
+    const createWritableSpy = vi.fn(async () => ({
+      write: writeSpy,
+      close: closeSpy
+    }));
+    const getFileHandleSpy = vi.fn(async () => ({
+      createWritable: createWritableSpy
+    }));
+    const showDirectoryPickerSpy = vi.fn(async () => ({
+      name: "AlbumExports",
+      getFileHandle: getFileHandleSpy
+    }));
+    Object.defineProperty(window, "showDirectoryPicker", {
+      writable: true,
+      value: showDirectoryPickerSpy
+    });
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/v1/albums") {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              album_id: "album-1",
+              name: "Weekend",
+              owner_user_id: "demo-user",
+              kind: "editable",
+              created_ts: "2026-05-08T12:00:00Z",
+              updated_ts: "2026-05-08T12:00:00Z",
+              item_count: 2,
+              saved_filter: null
+            }
+          ]
+        } as Response;
+      }
+      if (url === "/api/v1/albums/album-1?page=1&page_size=24") {
+        return {
+          ok: true,
+          json: async () => ({
+            album_id: "album-1",
+            name: "Weekend",
+            owner_user_id: "demo-user",
+            kind: "editable",
+            created_ts: "2026-05-08T12:00:00Z",
+            updated_ts: "2026-05-08T12:00:00Z",
+            item_count: 2,
+            items_total: 2,
+            items: [
+              {
+                photo_id: "photo-1",
+                path: "/library/photo-1.jpg",
+                ext: "jpg",
+                shot_ts: null,
+                filesize: 1024,
+                thumbnail: null
+              },
+              {
+                photo_id: "photo-2",
+                path: "/library/photo-2.jpg",
+                ext: "jpg",
+                shot_ts: null,
+                filesize: 2048,
+                thumbnail: null
+              }
+            ],
+            page: 1,
+            page_size: 24,
+            total_pages: 1,
+            saved_filter: null
+          })
+        } as Response;
+      }
+      if (url === "/api/v1/photos/photo-1/original?download=true") {
+        return new Response(new Blob([new Uint8Array([1, 2, 3])], { type: "image/jpeg" }), {
+          status: 200,
+          headers: {
+            "Content-Type": "image/jpeg",
+            "Content-Disposition": 'attachment; filename="photo-1-trip-a.jpg"'
+          }
+        });
+      }
+      if (url === "/api/v1/photos/photo-2/original?download=true") {
+        return new Response(new Blob([new Uint8Array([4, 5, 6])], { type: "image/heic" }), {
+          status: 200,
+          headers: {
+            "Content-Type": "image/heic",
+            "Content-Disposition": 'attachment; filename="photo-2-portrait.heic"'
+          }
+        });
+      }
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    renderAlbumsRoute();
+    expect(await screen.findByRole("heading", { name: "Albums", level: 1 })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Export album Weekend" }));
+
+    expect(
+      screen.getByRole("progressbar", { name: "Export progress for Weekend" })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Exporting 0 of 2 photos to "AlbumExports".')).toBeInTheDocument();
+
+    releaseFirstWrite?.();
+
+    await waitFor(() => {
+      expect(showDirectoryPickerSpy).toHaveBeenCalledTimes(1);
+      expect(getFileHandleSpy).toHaveBeenCalledWith("photo-1-trip-a.jpg", { create: true });
+      expect(getFileHandleSpy).toHaveBeenCalledWith("photo-2-portrait.heic", { create: true });
+    });
+    expect(writeSpy).toHaveBeenCalledTimes(2);
+    expect(closeSpy).toHaveBeenCalledTimes(2);
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Export complete: 2 photos saved to "AlbumExports". Open that folder in your file manager to access the photos.'
+    );
+  });
+
+  it("falls back to zip export when folder picker is unavailable", async () => {
+    const user = userEvent.setup();
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    Object.defineProperty(window, "showDirectoryPicker", {
+      writable: true,
+      value: undefined
+    });
+    if (!("createObjectURL" in URL)) {
+      Object.defineProperty(URL, "createObjectURL", {
+        writable: true,
+        value: vi.fn()
+      });
+      Object.defineProperty(URL, "revokeObjectURL", {
+        writable: true,
+        value: vi.fn()
+      });
+    }
+    const createObjectUrlSpy = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:album-export-fallback");
+    const revokeObjectUrlSpy = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/v1/albums") {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              album_id: "album-1",
+              name: "Weekend",
+              owner_user_id: "demo-user",
+              kind: "editable",
+              created_ts: "2026-05-08T12:00:00Z",
+              updated_ts: "2026-05-08T12:00:00Z",
+              item_count: 2,
+              saved_filter: null
+            }
+          ]
+        } as Response;
+      }
+      if (url === "/api/v1/albums/album-1?page=1&page_size=24") {
+        return {
+          ok: true,
+          json: async () => ({
+            album_id: "album-1",
+            name: "Weekend",
+            owner_user_id: "demo-user",
+            kind: "editable",
+            created_ts: "2026-05-08T12:00:00Z",
+            updated_ts: "2026-05-08T12:00:00Z",
+            item_count: 2,
+            items_total: 2,
+            items: [
+              {
+                photo_id: "photo-1",
+                path: "/library/photo-1.jpg",
+                ext: "jpg",
+                shot_ts: null,
+                filesize: 1024,
+                thumbnail: null
+              },
+              {
+                photo_id: "photo-2",
+                path: "/library/photo-2.jpg",
+                ext: "jpg",
+                shot_ts: null,
+                filesize: 2048,
+                thumbnail: null
+              }
+            ],
+            page: 1,
+            page_size: 24,
+            total_pages: 1,
+            saved_filter: null
+          })
+        } as Response;
+      }
+      if (url === "/api/v1/exports/photos") {
+        const parsedBody = JSON.parse((init?.body as string | undefined) ?? "{}") as {
+          photo_ids?: string[];
+        };
+        expect(parsedBody.photo_ids).toEqual(["photo-1", "photo-2"]);
+        return new Response(new Blob([new Uint8Array([7, 8, 9])], { type: "application/zip" }), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/zip",
+            "Content-Disposition": 'attachment; filename="album-export.zip"',
+            "X-Photo-Org-Exported-Count": "2",
+            "X-Photo-Org-Skipped-Count": "0"
+          }
+        });
+      }
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    renderAlbumsRoute();
+    expect(await screen.findByRole("heading", { name: "Albums", level: 1 })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Export album Weekend" }));
+
+    await waitFor(() => {
+      expect(createObjectUrlSpy).toHaveBeenCalled();
+    });
+    expect(clickSpy).toHaveBeenCalled();
+    expect(revokeObjectUrlSpy).toHaveBeenCalledWith("blob:album-export-fallback");
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Folder picker is unavailable in this browser. Downloaded "album-export.zip" as a ZIP file. Open your Downloads folder to access it.'
+    );
   });
 });

--- a/apps/ui/src/pages/AlbumsRoutePage.tsx
+++ b/apps/ui/src/pages/AlbumsRoutePage.tsx
@@ -46,12 +46,16 @@ export function AlbumsRoutePage() {
     rowDrafts,
     savingAlbumId,
     deletingAlbumId,
+    exportingAlbumId,
+    exportProgress,
+    canExport,
     handleCreateAlbum,
     handleSaveRow,
     handleDeleteRow,
     handleSelectRow,
     handleHideRow,
     handleRemovePhoto,
+    handleExportAlbum,
     handleUpdateCreateName,
     handleUpdateCreateType,
     handleUpdateCreateSavedFilterJsonDraft,
@@ -256,6 +260,9 @@ export function AlbumsRoutePage() {
         rowDrafts={rowDrafts}
         savingAlbumId={savingAlbumId}
         deletingAlbumId={deletingAlbumId}
+        exportingAlbumId={exportingAlbumId}
+        exportProgress={exportProgress}
+        canExport={canExport}
         onCreateNameChange={handleUpdateCreateName}
         onCreateTypeChange={handleUpdateCreateType}
         onCreateSavedFilterJsonDraftChange={handleUpdateCreateSavedFilterJsonDraft}
@@ -264,6 +271,7 @@ export function AlbumsRoutePage() {
         onToggleDetail={handleToggleDetail}
         onSave={(album) => void handleSaveRow(album)}
         onDelete={(album) => void handleDeleteRow(album)}
+        onExport={(album) => void handleExportAlbum(album)}
         onRemovePhoto={(photoId) => void handleRemovePhoto(photoId)}
         onSelectPage={(albumId, page) => void handleSelectRow(albumId, page)}
         onRowNameChange={handleUpdateRowName}

--- a/apps/ui/src/pages/albums/AlbumDetailInline.tsx
+++ b/apps/ui/src/pages/albums/AlbumDetailInline.tsx
@@ -82,7 +82,7 @@ export function AlbumDetailInline({
                 />
                 Show face boxes on all photos
               </label>
-              <ul className="albums-detail-grid" aria-label="Album photo thumbnails">
+              <ul className="browse-grid albums-detail-grid" aria-label="Album photo thumbnails">
                 {detail.items.map((item) => {
                   const hydratedSummary = photoSummaryById.get(item.photo_id);
                   const cardSummary = hydratedSummary

--- a/apps/ui/src/pages/albums/AlbumsGrid.tsx
+++ b/apps/ui/src/pages/albums/AlbumsGrid.tsx
@@ -2,7 +2,7 @@ import { Fragment } from "react";
 import type { AlbumDetail, AlbumRecord } from "../library/libraryRouteApi";
 import type { PhotoSummary } from "../photo-interactions/photoInteractionTypes";
 import { serializeSavedFilter } from "./albumLibraryQuery";
-import type { AlbumRowDraft } from "./useAlbumsRouteState";
+import type { AlbumExportProgress, AlbumRowDraft } from "./useAlbumsRouteState";
 import { AlbumDetailInline } from "./AlbumDetailInline";
 import { AlbumsCreateRow } from "./AlbumsCreateRow";
 
@@ -21,6 +21,9 @@ interface AlbumsGridProps {
   rowDrafts: Record<string, AlbumRowDraft>;
   savingAlbumId: string | null;
   deletingAlbumId: string | null;
+  exportingAlbumId: string | null;
+  exportProgress: AlbumExportProgress | null;
+  canExport: boolean;
   onCreateNameChange: (value: string) => void;
   onCreateTypeChange: (value: "editable" | "saved_filter") => void;
   onCreateSavedFilterJsonDraftChange: (value: string) => void;
@@ -29,6 +32,7 @@ interface AlbumsGridProps {
   onToggleDetail: (album: AlbumRecord) => void;
   onSave: (album: AlbumRecord) => void;
   onDelete: (album: AlbumRecord) => void;
+  onExport: (album: AlbumRecord) => void;
   onRemovePhoto: (photoId: string) => void;
   onSelectPage: (albumId: string, page: number) => void;
   onRowNameChange: (albumId: string, value: string) => void;
@@ -54,6 +58,9 @@ export function AlbumsGrid({
   rowDrafts,
   savingAlbumId,
   deletingAlbumId,
+  exportingAlbumId,
+  exportProgress,
+  canExport,
   onCreateNameChange,
   onCreateTypeChange,
   onCreateSavedFilterJsonDraftChange,
@@ -62,6 +69,7 @@ export function AlbumsGrid({
   onToggleDetail,
   onSave,
   onDelete,
+  onExport,
   onRemovePhoto,
   onSelectPage,
   onRowNameChange,
@@ -101,6 +109,11 @@ export function AlbumsGrid({
             };
             const isSaving = savingAlbumId === album.album_id;
             const isDeleting = deletingAlbumId === album.album_id;
+            const isExporting = exportingAlbumId === album.album_id;
+            const rowExportProgress =
+              exportProgress && exportProgress.albumId === album.album_id
+                ? exportProgress
+                : null;
 
             return (
               <Fragment key={album.album_id}>
@@ -152,7 +165,28 @@ export function AlbumsGrid({
                       <button type="button" onClick={() => onDelete(album)} disabled={isSaving || isDeleting}>
                         {isDeleting ? "Deleting…" : "Delete"}
                       </button>
+                      {canExport ? (
+                        <button
+                          type="button"
+                          onClick={() => onExport(album)}
+                          disabled={isSaving || isDeleting || isExporting}
+                        >
+                          {isExporting ? "Exporting…" : `Export album ${album.name}`}
+                        </button>
+                      ) : null}
                     </div>
+                    {rowExportProgress ? (
+                      <div className="albums-export-progress" role="status" aria-live="polite">
+                        <progress
+                          aria-label={`Export progress for ${rowExportProgress.albumName}`}
+                          max={rowExportProgress.totalCount}
+                          value={rowExportProgress.completedCount}
+                        />
+                        <p>
+                          Exporting {rowExportProgress.completedCount} of {rowExportProgress.totalCount} photos to "{rowExportProgress.folderLabel}".
+                        </p>
+                      </div>
+                    ) : null}
                   </td>
                 </tr>
                 {selectedAlbumId === album.album_id ? (

--- a/apps/ui/src/pages/albums/useAlbumsRouteState.ts
+++ b/apps/ui/src/pages/albums/useAlbumsRouteState.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import {
   createAlbum,
   deleteAlbum,
+  exportPhotos,
   fetchAlbumDetail,
   fetchAlbums,
   removePhotoFromAlbum,
@@ -20,8 +21,90 @@ export interface AlbumRowDraft {
 const DEFAULT_CREATE_SAVED_FILTER_JSON_DRAFT = '{"person_names":[]}';
 export const DETAIL_PAGE_SIZE = 24;
 
+interface FileSystemWritableFileStreamLike {
+  write(data: Blob): Promise<void>;
+  close(): Promise<void>;
+}
+
+interface FileSystemFileHandleLike {
+  createWritable(): Promise<FileSystemWritableFileStreamLike>;
+}
+
+interface FileSystemDirectoryHandleLike {
+  name?: string;
+  getFileHandle(name: string, options: { create: boolean }): Promise<FileSystemFileHandleLike>;
+}
+
+type DirectoryPickerWindow = Window & {
+  showDirectoryPicker?: () => Promise<FileSystemDirectoryHandleLike>;
+};
+
+export interface AlbumExportProgress {
+  albumId: string;
+  albumName: string;
+  folderLabel: string;
+  completedCount: number;
+  totalCount: number;
+}
+
+function sanitizeExportFilename(filename: string, fallback: string): string {
+  const cleaned = filename.trim().replace(/[\\/:*?"<>|]/g, "_");
+  return cleaned.length > 0 ? cleaned : fallback;
+}
+
+function parseAttachmentFilename(contentDisposition: string | null, fallback: string): string {
+  if (!contentDisposition) {
+    return fallback;
+  }
+  const match = contentDisposition.match(/filename=\"([^\"]+)\"/i);
+  if (!match || !match[1]) {
+    return fallback;
+  }
+  return sanitizeExportFilename(match[1], fallback);
+}
+
+async function fetchOriginalPhotoBlob(photoId: string): Promise<{ filename: string; blob: Blob }> {
+  const response = await fetch(
+    `/api/v1/photos/${encodeURIComponent(photoId)}/original?download=true`
+  );
+  if (!response.ok) {
+    throw new Error(`Download request failed for ${photoId} (${response.status}).`);
+  }
+
+  const fallbackName = `${photoId}.bin`;
+  return {
+    filename: parseAttachmentFilename(response.headers.get("Content-Disposition"), fallbackName),
+    blob: await response.blob(),
+  };
+}
+
+function isDirectoryPickerAvailable(): boolean {
+  return typeof (window as DirectoryPickerWindow).showDirectoryPicker === "function";
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  if (
+    typeof URL.createObjectURL !== "function" ||
+    typeof URL.revokeObjectURL !== "function"
+  ) {
+    throw new Error("Download is unavailable in this browser.");
+  }
+
+  const objectUrl = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = objectUrl;
+  link.download = filename;
+  link.rel = "noopener";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(objectUrl);
+}
+
 export function useAlbumsRouteState() {
-  const sessionUserId = resolveInitialSessionIdentity()?.userId ?? null;
+  const sessionIdentity = resolveInitialSessionIdentity();
+  const sessionUserId = sessionIdentity?.userId ?? null;
+  const canExport = sessionIdentity?.capabilities.export ?? false;
 
   const [albums, setAlbums] = useState<AlbumRecord[]>([]);
   const [selectedAlbumId, setSelectedAlbumId] = useState<string | null>(null);
@@ -40,6 +123,24 @@ export function useAlbumsRouteState() {
   const [rowDrafts, setRowDrafts] = useState<Record<string, AlbumRowDraft>>({});
   const [savingAlbumId, setSavingAlbumId] = useState<string | null>(null);
   const [deletingAlbumId, setDeletingAlbumId] = useState<string | null>(null);
+  const [exportingAlbumId, setExportingAlbumId] = useState<string | null>(null);
+  const [exportProgress, setExportProgress] = useState<AlbumExportProgress | null>(null);
+
+  async function resolveExportDirectoryHandle(): Promise<FileSystemDirectoryHandleLike> {
+    const pickerWindow = window as DirectoryPickerWindow;
+    if (typeof pickerWindow.showDirectoryPicker !== "function") {
+      throw new Error("Folder export is unavailable in this browser.");
+    }
+    try {
+      return await pickerWindow.showDirectoryPicker();
+    } catch (caughtError) {
+      const pickerError = caughtError as { name?: string } | undefined;
+      if (pickerError?.name === "AbortError") {
+        throw new Error("Folder selection was canceled.");
+      }
+      throw caughtError instanceof Error ? caughtError : new Error("Could not choose an export folder.");
+    }
+  }
 
   function syncRowDrafts(payload: AlbumRecord[]) {
     setRowDrafts((current) => {
@@ -281,7 +382,99 @@ export function useAlbumsRouteState() {
     }
   }
 
+  async function resolveAlbumPhotoIds(albumId: string): Promise<string[]> {
+    const photoIds: string[] = [];
+    const seen = new Set<string>();
+    let page = 1;
+    let totalPages = 1;
+
+    while (page <= totalPages) {
+      const albumDetail = await fetchAlbumDetail(albumId, {
+        page,
+        pageSize: DETAIL_PAGE_SIZE
+      });
+      totalPages = Math.max(albumDetail.total_pages, 1);
+      for (const item of albumDetail.items) {
+        if (seen.has(item.photo_id)) {
+          continue;
+        }
+        seen.add(item.photo_id);
+        photoIds.push(item.photo_id);
+      }
+      page += 1;
+    }
+
+    return photoIds;
+  }
+
+  async function handleExportAlbum(album: AlbumRecord) {
+    if (!canExport) {
+      setError("You do not have permission for this action.");
+      return;
+    }
+
+    setError(null);
+    try {
+      setExportingAlbumId(album.album_id);
+      const photoIds = await resolveAlbumPhotoIds(album.album_id);
+      if (photoIds.length === 0) {
+        setError(`Album "${album.name}" has no photos to export.`);
+        return;
+      }
+
+      if (isDirectoryPickerAvailable()) {
+        const directory = await resolveExportDirectoryHandle();
+        const folderLabel = directory.name?.trim() ? directory.name.trim() : "selected folder";
+        setExportProgress({
+          albumId: album.album_id,
+          albumName: album.name,
+          folderLabel,
+          completedCount: 0,
+          totalCount: photoIds.length,
+        });
+
+        let completedCount = 0;
+        for (const photoId of photoIds) {
+          const { filename, blob } = await fetchOriginalPhotoBlob(photoId);
+          const fileHandle = await directory.getFileHandle(filename, { create: true });
+          const writable = await fileHandle.createWritable();
+          await writable.write(blob);
+          await writable.close();
+          completedCount += 1;
+          setExportProgress((current) =>
+            current && current.albumId === album.album_id
+              ? {
+                  ...current,
+                  completedCount,
+                }
+              : current
+          );
+        }
+        if (typeof window.alert === "function") {
+          window.alert(
+            `Export complete: ${photoIds.length} photos saved to "${folderLabel}". Open that folder in your file manager to access the photos.`
+          );
+        }
+        return;
+      }
+
+      const exportResult = await exportPhotos(photoIds);
+      downloadBlob(exportResult.blob, exportResult.filename);
+      if (typeof window.alert === "function") {
+        window.alert(
+          `Folder picker is unavailable in this browser. Downloaded "${exportResult.filename}" as a ZIP file. Open your Downloads folder to access it.`
+        );
+      }
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : "Could not export album.");
+    } finally {
+      setExportingAlbumId(null);
+      setExportProgress(null);
+    }
+  }
+
   return {
+    canExport,
     sortedAlbums,
     selectedAlbumId,
     detail,
@@ -294,12 +487,15 @@ export function useAlbumsRouteState() {
     rowDrafts,
     savingAlbumId,
     deletingAlbumId,
+    exportingAlbumId,
+    exportProgress,
     handleCreateAlbum,
     handleSaveRow,
     handleDeleteRow,
     handleSelectRow,
     handleHideRow,
     handleRemovePhoto,
+    handleExportAlbum,
     handleUpdateCreateName,
     handleUpdateCreateType,
     handleUpdateCreateSavedFilterJsonDraft,

--- a/apps/ui/src/styles/app-shell.css
+++ b/apps/ui/src/styles/app-shell.css
@@ -893,6 +893,24 @@ body {
   gap: 0.35rem;
 }
 
+.albums-export-progress {
+  margin-top: 0.45rem;
+  display: grid;
+  gap: 0.25rem;
+  max-width: 18rem;
+}
+
+.albums-export-progress progress {
+  width: 100%;
+  height: 0.62rem;
+}
+
+.albums-export-progress p {
+  margin: 0;
+  font-size: 0.78rem;
+  color: #334155;
+}
+
 .albums-grid-expanded-row td {
   background: #f8fafc;
 }
@@ -932,20 +950,10 @@ body {
   list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  gap: 0.55rem;
-  grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
 }
 
 .albums-detail-grid li {
   position: relative;
-  border: 1px solid #e2e8f0;
-  border-radius: 0.5rem;
-  background: #f8fafc;
-  padding: 0.42rem;
-  display: grid;
-  gap: 0.4rem;
-  align-content: start;
 }
 
 .albums-detail-remove-photo-badge {
@@ -993,14 +1001,6 @@ body {
   min-height: 7rem;
   color: #475569;
   font-size: 0.8rem;
-}
-
-.albums-detail-grid p {
-  margin: 0;
-  color: #1e293b;
-  font-size: 0.78rem;
-  line-height: 1.3;
-  word-break: break-all;
 }
 
 .albums-detail-pagination {

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,7 +26,7 @@ services:
       dockerfile: apps/api/Dockerfile
     environment:
       DATABASE_URL: ${PHOTO_ORG_DB_SERVICE_DATABASE_URL:-postgresql+psycopg://photoorg:photoorg@postgres:5432/photoorg}
-      PHOTO_ORG_API_CORS_ALLOWED_ORIGINS: ${PHOTO_ORG_API_CORS_ALLOWED_ORIGINS:-http://127.0.0.1:5173,http://localhost:5173}
+      PHOTO_ORG_API_CORS_ALLOWED_ORIGINS: ${PHOTO_ORG_API_CORS_ALLOWED_ORIGINS:-http://127.0.0.1:5173,http://localhost:5173,https://127.0.0.1,https://localhost}
       FACE_DETECT_SCALE_FACTOR: ${FACE_DETECT_SCALE_FACTOR:-1.1}
       FACE_DETECT_MIN_NEIGHBORS: ${FACE_DETECT_MIN_NEIGHBORS:-5}
       FACE_DETECT_MIN_SIZE: ${FACE_DETECT_MIN_SIZE:-60x60}
@@ -72,5 +72,22 @@ services:
     ports:
       - "${PHOTO_ORG_UI_HOST_PORT:-5173}:5173"
 
+  caddy:
+    image: caddy:2-alpine
+    depends_on:
+      db-service:
+        condition: service_healthy
+      ui:
+        condition: service_started
+    ports:
+      - "${PHOTO_ORG_HTTP_HOST_PORT:-80}:80"
+      - "${PHOTO_ORG_HTTPS_HOST_PORT:-443}:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
 volumes:
   postgres_data:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
## Summary
- unify album export behavior around per-file downloads and UI export progress feedback
- align album card interaction styling with library cards and ensure album export wiring is active
- optimize storage source polling for large watched folders by streaming file discovery, reducing redundant file-state writes, and adding an optional queue-drain toggle
- add HTTPS reverse proxy support via Caddy in compose, including local Caddy config file

## Validation
- `uv run pytest apps/api/tests/test_storage_source_polling_service.py apps/api/tests/test_ingest_queue_api.py apps/api/tests/test_ingest_common.py apps/api/tests/test_ingest.py`
