### PR TITLE
feat: add Cloudflare DB-backed RBAC

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -8,4 +8,5 @@ PHOTO_ORG_DB_SERVICE_DATABASE_URL=postgresql+psycopg://photoorg:photoorg@postgre
 PHOTO_ORG_COMPOSE_DATABASE_URL=postgresql+psycopg://photoorg:photoorg@localhost:5432/photoorg
 PHOTO_ORG_UI_API_BASE_URL=http://127.0.0.1:8000
 PHOTO_ORG_UI_PROXY_TARGET=http://db-service:8000
-PHOTO_ORG_API_CORS_ALLOWED_ORIGINS=http://127.0.0.1:5173,http://localhost:5173
+PHOTO_ORG_UI_ALLOWED_HOSTS=photo.noead.com
+PHOTO_ORG_API_CORS_ALLOWED_ORIGINS=http://127.0.0.1:5173,http://localhost:5173,https://photo.noead.com

--- a/.env.compose.example
+++ b/.env.compose.example
@@ -9,4 +9,5 @@ PHOTO_ORG_COMPOSE_DATABASE_URL=postgresql+psycopg://photoorg:photoorg@localhost:
 PHOTO_ORG_UI_API_BASE_URL=http://127.0.0.1:8000
 PHOTO_ORG_UI_PROXY_TARGET=http://db-service:8000
 PHOTO_ORG_UI_ALLOWED_HOSTS=photo.noead.com
+PHOTO_ORG_AUTH_MODE=legacy_headers
 PHOTO_ORG_API_CORS_ALLOWED_ORIGINS=http://127.0.0.1:5173,http://localhost:5173,https://photo.noead.com

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,8 @@
-localhost, 127.0.0.1 {
-  tls internal
+{
+  auto_https off
+}
 
+:80 {
   @api path /api/*
   reverse_proxy @api db-service:8000
   reverse_proxy ui:5173

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,11 @@ endif
 ifndef PHOTO_ORG_UI_API_BASE_URL
 PHOTO_ORG_UI_API_BASE_URL := http://127.0.0.1:$(PHOTO_ORG_API_HOST_PORT)
 endif
+ifndef PHOTO_ORG_UI_ALLOWED_HOSTS
+PHOTO_ORG_UI_ALLOWED_HOSTS := photo.noead.com
+endif
 ifndef PHOTO_ORG_API_CORS_ALLOWED_ORIGINS
-PHOTO_ORG_API_CORS_ALLOWED_ORIGINS := http://127.0.0.1:$(PHOTO_ORG_UI_HOST_PORT),http://localhost:$(PHOTO_ORG_UI_HOST_PORT)
+PHOTO_ORG_API_CORS_ALLOWED_ORIGINS := http://127.0.0.1:$(PHOTO_ORG_UI_HOST_PORT),http://localhost:$(PHOTO_ORG_UI_HOST_PORT),https://photo.noead.com
 endif
 -include $(PHOTO_ORG_ENV_REGISTRY_FILE)
 COMPOSE_ENV_FILE_ARG := $(if $(PHOTO_ORG_ENV_FILE),--env-file $(PHOTO_ORG_ENV_FILE),)
@@ -59,6 +62,7 @@ export PHOTO_ORG_UI_HOST_PORT
 export PHOTO_ORG_DB_SERVICE_DATABASE_URL
 export PHOTO_ORG_COMPOSE_DATABASE_URL
 export PHOTO_ORG_UI_API_BASE_URL
+export PHOTO_ORG_UI_ALLOWED_HOSTS
 export PHOTO_ORG_API_CORS_ALLOWED_ORIGINS
 
 .PHONY: help sync lint test test-all ui-test ui-test-coverage ui-build test-e2e check pre-push migrate env-create compose-up compose-migrate compose-down compose-down-volumes compose-smoke compose-e2e-smoke print-compose-db-url print-compose-api-base-url print-compose-ui-base-url seed-corpus-check seed-corpus-load ensure-environment
@@ -134,6 +138,7 @@ env-create:
 		"PHOTO_ORG_DB_SERVICE_DATABASE_URL := $(PHOTO_ORG_DB_SERVICE_DATABASE_URL)" \
 		"PHOTO_ORG_COMPOSE_DATABASE_URL := $(PHOTO_ORG_COMPOSE_DATABASE_URL)" \
 		"PHOTO_ORG_UI_API_BASE_URL := $(PHOTO_ORG_UI_API_BASE_URL)" \
+		"PHOTO_ORG_UI_ALLOWED_HOSTS := $(PHOTO_ORG_UI_ALLOWED_HOSTS)" \
 		"PHOTO_ORG_API_CORS_ALLOWED_ORIGINS := $(PHOTO_ORG_API_CORS_ALLOWED_ORIGINS)" \
 		> "$$candidate"; \
 	if [ -f "$(PHOTO_ORG_ENV_REGISTRY_FILE)" ]; then \

--- a/apps/api/alembic/versions/20260525_000001_add_users_and_rbac_tables.py
+++ b/apps/api/alembic/versions/20260525_000001_add_users_and_rbac_tables.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20260525_000001"
+down_revision = "20260508_000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("user_id", sa.String(length=36), primary_key=True),
+        sa.Column("auth_provider", sa.String(), nullable=False),
+        sa.Column("auth_subject", sa.String(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("display_name", sa.String(), nullable=True),
+        sa.Column(
+            "created_ts",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_ts",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.UniqueConstraint("auth_subject", name="uq_users_auth_subject"),
+        sa.UniqueConstraint("email", name="uq_users_email"),
+    )
+    op.create_index("idx_users_email", "users", ["email"], unique=False)
+
+    op.create_table(
+        "user_role_assignments",
+        sa.Column(
+            "user_id",
+            sa.String(length=36),
+            sa.ForeignKey("users.user_id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("role", sa.String(), primary_key=True),
+        sa.Column(
+            "created_ts",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_ts",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.CheckConstraint(
+            "role IN ('viewer', 'contributor', 'admin')",
+            name="ck_user_role_assignments_role",
+        ),
+    )
+    op.create_index(
+        "idx_user_role_assignments_role",
+        "user_role_assignments",
+        ["role"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_user_role_assignments_role",
+        table_name="user_role_assignments",
+    )
+    op.drop_table("user_role_assignments")
+    op.drop_index("idx_users_email", table_name="users")
+    op.drop_table("users")

--- a/apps/api/app/auth.py
+++ b/apps/api/app/auth.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from fastapi import HTTPException, status
+from sqlalchemy import insert, select
+from sqlalchemy.orm import Session
+
+from app.storage import user_role_assignments, users
+
+
+CF_ACCESS_AUTHENTICATED_USER_EMAIL_HEADER = "Cf-Access-Authenticated-User-Email"
+AUTH_MODE_CLOUDFLARE_ACCESS = "cloudflare_access"
+
+
+@dataclass(frozen=True)
+class CloudflareAccessIdentity:
+    email: str
+
+
+@dataclass(frozen=True)
+class AppUser:
+    user_id: str
+    email: str
+    display_name: str | None
+    roles: frozenset[str]
+
+
+def normalize_email(value: str | None) -> str | None:
+    candidate = (value or "").strip().lower()
+    return candidate if candidate else None
+
+
+def resolve_cloudflare_access_identity(email_header: str | None) -> CloudflareAccessIdentity:
+    email = normalize_email(email_header)
+    if email is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Authenticated user required",
+        )
+    return CloudflareAccessIdentity(email=email)
+
+
+def get_or_create_cloudflare_user(
+    db: Session,
+    *,
+    email: str,
+    subject: str | None = None,
+) -> AppUser:
+    normalized_email = normalize_email(email)
+    if normalized_email is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Authenticated user required",
+        )
+    auth_subject = (subject or normalized_email).strip().lower()
+
+    row = db.execute(
+        select(users).where(users.c.auth_subject == auth_subject)
+    ).mappings().one_or_none()
+    if row is None:
+        now = datetime.now(tz=UTC)
+        user_id = str(uuid4())
+        db.execute(
+            insert(users).values(
+                user_id=user_id,
+                auth_provider=AUTH_MODE_CLOUDFLARE_ACCESS,
+                auth_subject=auth_subject,
+                email=normalized_email,
+                display_name=None,
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        db.commit()
+        row = db.execute(
+            select(users).where(users.c.user_id == user_id)
+        ).mappings().one()
+
+    assigned_roles = frozenset(
+        db.execute(
+            select(user_role_assignments.c.role).where(
+                user_role_assignments.c.user_id == row["user_id"]
+            )
+        ).scalars().all()
+    )
+
+    return AppUser(
+        user_id=row["user_id"],
+        email=row["email"],
+        display_name=row["display_name"],
+        roles=assigned_roles,
+    )

--- a/apps/api/app/dependencies.py
+++ b/apps/api/app/dependencies.py
@@ -110,6 +110,7 @@ def require_face_validation_role(
 
 def require_authenticated_user(
     db: Session = Depends(get_db),
+    user_id: str | None = Header(default=None, alias=USER_ID_HEADER),
     cloudflare_access_email: str | None = Header(
         default=None, alias=CF_ACCESS_AUTHENTICATED_USER_EMAIL_HEADER
     ),
@@ -117,9 +118,13 @@ def require_authenticated_user(
     if get_auth_mode() == AUTH_MODE_CLOUDFLARE_ACCESS:
         resolved_identity = resolve_cloudflare_access_identity(cloudflare_access_email)
         return get_or_create_cloudflare_user(db, email=resolved_identity.email)
-    raise HTTPException(
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-        detail="Legacy auth mode not supported in this plan.",
+
+    candidate = (user_id or "").strip() or "demo-user"
+    return AppUser(
+        user_id=candidate,
+        email="",
+        display_name=None,
+        roles=frozenset(),
     )
 
 

--- a/apps/api/app/dependencies.py
+++ b/apps/api/app/dependencies.py
@@ -2,12 +2,21 @@ import os
 from functools import lru_cache
 from typing import Iterator
 
-from fastapi import Header, HTTPException, status
+from fastapi import Depends, Header, HTTPException, status
 from sqlalchemy.orm import Session
 
+from app.auth import (
+    AUTH_MODE_CLOUDFLARE_ACCESS,
+    CF_ACCESS_AUTHENTICATED_USER_EMAIL_HEADER,
+    AppUser,
+    get_or_create_cloudflare_user,
+    resolve_cloudflare_access_identity,
+)
 from app.db.session import create_session_factory
 
 
+AUTH_MODE_ENV = "PHOTO_ORG_AUTH_MODE"
+AUTH_MODE_LEGACY_HEADERS = "legacy_headers"
 WORKER_ROLE_HEADER = "X-Worker-Role"
 INGEST_PROCESSOR_ROLE = "ingest-processor"
 FACE_VALIDATION_ROLE_HEADER = "X-Face-Validation-Role"
@@ -19,6 +28,7 @@ FACE_VALIDATION_ROLES = frozenset(
         FACE_VALIDATION_ROLE_ADMIN,
     }
 )
+USER_ID_HEADER = "X-Photo-Org-User-Id"
 
 
 @lru_cache(maxsize=None)
@@ -32,6 +42,13 @@ def get_db() -> Iterator[Session]:
         yield db
     finally:
         db.close()
+
+
+def get_auth_mode() -> str:
+    raw_mode = (os.getenv(AUTH_MODE_ENV) or AUTH_MODE_LEGACY_HEADERS).strip().lower()
+    if raw_mode in {AUTH_MODE_LEGACY_HEADERS, AUTH_MODE_CLOUDFLARE_ACCESS}:
+        return raw_mode
+    return AUTH_MODE_LEGACY_HEADERS
 
 
 def require_worker_role(
@@ -53,3 +70,24 @@ def require_face_validation_role(
             detail="Face validation role required",
         )
     return face_validation_role
+
+
+def require_authenticated_user(
+    db: Session = Depends(get_db),
+    cloudflare_access_email: str | None = Header(
+        default=None, alias=CF_ACCESS_AUTHENTICATED_USER_EMAIL_HEADER
+    ),
+) -> AppUser:
+    if get_auth_mode() == AUTH_MODE_CLOUDFLARE_ACCESS:
+        resolved_identity = resolve_cloudflare_access_identity(cloudflare_access_email)
+        return get_or_create_cloudflare_user(db, email=resolved_identity.email)
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="Legacy auth mode not supported in this plan.",
+    )
+
+
+def require_authenticated_user_id(
+    user: AppUser = Depends(require_authenticated_user),
+) -> str:
+    return user.user_id

--- a/apps/api/app/dependencies.py
+++ b/apps/api/app/dependencies.py
@@ -29,6 +29,11 @@ FACE_VALIDATION_ROLES = frozenset(
     }
 )
 USER_ID_HEADER = "X-Photo-Org-User-Id"
+ROLE_RANK = {
+    "viewer": 1,
+    "contributor": 2,
+    "admin": 3,
+}
 
 
 @lru_cache(maxsize=None)
@@ -61,9 +66,40 @@ def require_worker_role(
         )
 
 
+def require_role(required_role: str):
+    def dependency(user: AppUser = Depends(require_authenticated_user)) -> AppUser:
+        user_rank = max((ROLE_RANK.get(role, 0) for role in user.roles), default=0)
+        required_rank = ROLE_RANK[required_role]
+        if user_rank < required_rank:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Face validation role required"
+                if required_role == "contributor"
+                else "Admin role required",
+            )
+        return user
+
+    return dependency
+
+
 def require_face_validation_role(
     face_validation_role: str | None = Header(default=None, alias=FACE_VALIDATION_ROLE_HEADER),
+    db: Session = Depends(get_db),
+    cloudflare_access_email: str | None = Header(
+        default=None, alias=CF_ACCESS_AUTHENTICATED_USER_EMAIL_HEADER
+    ),
 ) -> str:
+    if get_auth_mode() == AUTH_MODE_CLOUDFLARE_ACCESS:
+        resolved_identity = resolve_cloudflare_access_identity(cloudflare_access_email)
+        user = get_or_create_cloudflare_user(db, email=resolved_identity.email)
+        user_rank = max((ROLE_RANK.get(role, 0) for role in user.roles), default=0)
+        if user_rank < ROLE_RANK["contributor"]:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Face validation role required",
+            )
+        return FACE_VALIDATION_ROLE_CONTRIBUTOR
+
     if face_validation_role not in FACE_VALIDATION_ROLES:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/apps/api/app/routers/albums.py
+++ b/apps/api/app/routers/albums.py
@@ -11,7 +11,8 @@ from pydantic import BaseModel, Field, StringConstraints
 from sqlalchemy import and_, func, insert, select, update, delete
 from sqlalchemy.orm import Session
 
-from app.dependencies import get_db
+from app.auth import AppUser
+from app.dependencies import get_db, require_authenticated_user
 from app.repositories.photos_repo import PhotosRepository
 from app.schemas.search_response import ThumbnailHit
 from app.schemas.search_request import SearchFilters, SortSpec, PageSpec
@@ -215,7 +216,10 @@ def create_album_endpoint(
     description="Return albums ordered by last update timestamp.",
     response_model=list[AlbumResponse],
 )
-def list_albums_endpoint(db: Session = Depends(get_db)) -> list[AlbumResponse]:
+def list_albums_endpoint(
+    db: Session = Depends(get_db),
+    _: AppUser = Depends(require_authenticated_user),
+) -> list[AlbumResponse]:
     rows = (
         db.execute(
             select(albums)

--- a/apps/api/app/routers/albums.py
+++ b/apps/api/app/routers/albums.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime
 from typing import Annotated, Any, Literal
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from pydantic import BaseModel, Field, StringConstraints
 from sqlalchemy import and_, func, insert, select, update, delete
 from sqlalchemy.orm import Session
@@ -75,11 +75,6 @@ class AddAlbumItemsResponse(BaseModel):
     missing_photo_ids: list[str]
 
 
-def _resolve_user_id(header_value: str | None) -> str:
-    candidate = (header_value or "").strip()
-    return candidate if candidate else "demo-user"
-
-
 def _normalize_photo_ids(photo_ids: list[str]) -> list[str]:
     deduped: list[str] = []
     seen: set[str] = set()
@@ -104,10 +99,16 @@ def _album_name_exists(db: Session, *, owner_user_id: str, name: str, exclude_al
     return db.execute(stmt).scalar_one_or_none() is not None
 
 
-def _get_album_row(db: Session, *, album_id: str) -> dict[str, Any]:
-    row = db.execute(
-        select(albums).where(albums.c.album_id == album_id)
-    ).mappings().one_or_none()
+def _get_album_row(
+    db: Session,
+    *,
+    album_id: str,
+    owner_user_id: str | None = None,
+) -> dict[str, Any]:
+    stmt = select(albums).where(albums.c.album_id == album_id)
+    if owner_user_id is not None:
+        stmt = stmt.where(albums.c.owner_user_id == owner_user_id)
+    row = db.execute(stmt).mappings().one_or_none()
     if row is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Album not found")
     return dict(row)
@@ -173,10 +174,9 @@ def _build_album_response(db: Session, album_row: dict[str, Any]) -> AlbumRespon
 def create_album_endpoint(
     body: CreateAlbumRequest,
     db: Session = Depends(get_db),
-    user_id_header: str | None = Header(default=None, alias="X-Photo-Org-User-Id"),
+    user: AppUser = Depends(require_authenticated_user),
 ) -> AlbumResponse:
-    user_id = _resolve_user_id(user_id_header)
-    if _album_name_exists(db, owner_user_id=user_id, name=body.name):
+    if _album_name_exists(db, owner_user_id=user.user_id, name=body.name):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="Album name already exists. Choose a different name.",
@@ -188,7 +188,7 @@ def create_album_endpoint(
         insert(albums).values(
             album_id=album_id,
             name=body.name,
-            owner_user_id=user_id,
+            owner_user_id=user.user_id,
             kind=body.kind,
             created_ts=now,
             updated_ts=now,
@@ -206,7 +206,7 @@ def create_album_endpoint(
         )
 
     db.commit()
-    created = _get_album_row(db, album_id=album_id)
+    created = _get_album_row(db, album_id=album_id, owner_user_id=user.user_id)
     return _build_album_response(db, created)
 
 
@@ -218,11 +218,12 @@ def create_album_endpoint(
 )
 def list_albums_endpoint(
     db: Session = Depends(get_db),
-    _: AppUser = Depends(require_authenticated_user),
+    user: AppUser = Depends(require_authenticated_user),
 ) -> list[AlbumResponse]:
     rows = (
         db.execute(
             select(albums)
+            .where(albums.c.owner_user_id == user.user_id)
             .order_by(albums.c.updated_ts.desc(), albums.c.album_id.asc())
         )
         .mappings()
@@ -242,8 +243,9 @@ def get_album_detail_endpoint(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=24, ge=1, le=120),
     db: Session = Depends(get_db),
+    user: AppUser = Depends(require_authenticated_user),
 ) -> AlbumDetailResponse:
-    album_row = _get_album_row(db, album_id=album_id)
+    album_row = _get_album_row(db, album_id=album_id, owner_user_id=user.user_id)
     album_payload = _build_album_response(db, album_row)
     offset = (page - 1) * page_size
 
@@ -361,16 +363,15 @@ def update_album_endpoint(
     album_id: str,
     body: UpdateAlbumRequest,
     db: Session = Depends(get_db),
-    user_id_header: str | None = Header(default=None, alias="X-Photo-Org-User-Id"),
+    user: AppUser = Depends(require_authenticated_user),
 ) -> AlbumResponse:
-    album_row = _get_album_row(db, album_id=album_id)
+    album_row = _get_album_row(db, album_id=album_id, owner_user_id=user.user_id)
     now = datetime.now(tz=UTC)
     next_name = body.name if body.name is not None else album_row["name"]
-    owner_user_id = _resolve_user_id(user_id_header)
 
     if _album_name_exists(
         db,
-        owner_user_id=owner_user_id,
+        owner_user_id=user.user_id,
         name=next_name,
         exclude_album_id=album_id,
     ):
@@ -394,7 +395,7 @@ def update_album_endpoint(
         )
 
     db.commit()
-    updated = _get_album_row(db, album_id=album_id)
+    updated = _get_album_row(db, album_id=album_id, owner_user_id=user.user_id)
     return _build_album_response(db, updated)
 
 
@@ -404,9 +405,15 @@ def update_album_endpoint(
     description="Delete an album and all subtype records.",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-def delete_album_endpoint(album_id: str, db: Session = Depends(get_db)) -> Response:
+def delete_album_endpoint(
+    album_id: str,
+    db: Session = Depends(get_db),
+    user: AppUser = Depends(require_authenticated_user),
+) -> Response:
     album_exists = db.execute(
-        select(albums.c.album_id).where(albums.c.album_id == album_id)
+        select(albums.c.album_id)
+        .where(albums.c.album_id == album_id)
+        .where(albums.c.owner_user_id == user.user_id)
     ).scalar_one_or_none()
     if album_exists is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Album not found")
@@ -426,14 +433,13 @@ def add_album_items_endpoint(
     album_id: str,
     body: AddAlbumItemsRequest,
     db: Session = Depends(get_db),
-    user_id_header: str | None = Header(default=None, alias="X-Photo-Org-User-Id"),
+    user: AppUser = Depends(require_authenticated_user),
 ) -> AddAlbumItemsResponse:
-    user_id = _resolve_user_id(user_id_header)
     normalized_photo_ids = _normalize_photo_ids(body.photo_ids)
     if not normalized_photo_ids:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="No valid photo IDs.")
 
-    album_row = _get_album_row(db, album_id=album_id)
+    album_row = _get_album_row(db, album_id=album_id, owner_user_id=user.user_id)
     if album_row["kind"] != "editable":
         _raise_saved_filter_membership_error()
 
@@ -474,7 +480,7 @@ def add_album_items_endpoint(
             insert(editable_album_items).values(
                 album_id=album_id,
                 photo_id=photo_id,
-                added_by_user_id=user_id,
+                added_by_user_id=user.user_id,
                 added_ts=now,
             )
         )
@@ -501,8 +507,13 @@ def add_album_items_endpoint(
     description="Remove a single photo reference from an editable album.",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-def remove_album_item_endpoint(album_id: str, photo_id: str, db: Session = Depends(get_db)) -> Response:
-    album_row = _get_album_row(db, album_id=album_id)
+def remove_album_item_endpoint(
+    album_id: str,
+    photo_id: str,
+    db: Session = Depends(get_db),
+    user: AppUser = Depends(require_authenticated_user),
+) -> Response:
+    album_row = _get_album_row(db, album_id=album_id, owner_user_id=user.user_id)
     if album_row["kind"] != "editable":
         _raise_saved_filter_membership_error()
 

--- a/apps/api/app/storage.py
+++ b/apps/api/app/storage.py
@@ -19,6 +19,8 @@ from photoorg_db_schema import (
     photo_tags,
     photos,
     saved_filter_album_rules,
+    user_role_assignments,
+    users,
     storage_source_aliases,
     storage_sources,
     watched_folders,

--- a/apps/api/tests/test_albums_and_exports_api.py
+++ b/apps/api/tests/test_albums_and_exports_api.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from zipfile import ZipFile
 
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, insert, inspect
+from sqlalchemy import create_engine, insert, inspect, select
 
 from app.dependencies import _get_session_factory
 from app.main import app
@@ -16,6 +16,7 @@ from app.storage import (
     photo_files,
     photos,
     saved_filter_album_rules,
+    users,
     watched_folders,
 )
 
@@ -153,6 +154,52 @@ def test_albums_support_saved_filter_kind_and_reject_duplicate_names(tmp_path, m
         "person_names": ["Inez"],
         "person_certainty_mode": "human_only",
     }
+
+
+def test_albums_cloudflare_access_scope_by_authenticated_email(tmp_path, monkeypatch):
+    monkeypatch.setenv("PHOTO_ORG_AUTH_MODE", "cloudflare_access")
+    client = _client(tmp_path, monkeypatch, "albums-cloudflare.db")
+
+    create_response = client.post(
+        "/api/v1/albums",
+        json={"name": "Weekend Favorites"},
+        headers={
+            "Cf-Access-Authenticated-User-Email": "owner@example.com",
+            "X-Photo-Org-User-Id": "spoofed-user",
+        },
+    )
+    assert create_response.status_code == 201
+    album_id = create_response.json()["album_id"]
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'albums-cloudflare.db'}", future=True)
+    with engine.connect() as connection:
+        owner_row = connection.execute(
+            select(users.c.user_id, users.c.email).where(users.c.email == "owner@example.com")
+        ).mappings().one()
+        album_row = connection.execute(
+            select(albums.c.owner_user_id).where(albums.c.album_id == album_id)
+        ).mappings().one()
+    assert album_row["owner_user_id"] == owner_row["user_id"]
+
+    owner_list_response = client.get(
+        "/api/v1/albums",
+        headers={"Cf-Access-Authenticated-User-Email": "owner@example.com"},
+    )
+    assert owner_list_response.status_code == 200
+    assert [album["album_id"] for album in owner_list_response.json()] == [album_id]
+
+    other_user_list_response = client.get(
+        "/api/v1/albums",
+        headers={"Cf-Access-Authenticated-User-Email": "other@example.com"},
+    )
+    assert other_user_list_response.status_code == 200
+    assert other_user_list_response.json() == []
+
+    other_user_detail_response = client.get(
+        f"/api/v1/albums/{album_id}",
+        headers={"Cf-Access-Authenticated-User-Email": "other@example.com"},
+    )
+    assert other_user_detail_response.status_code == 404
 
 
 def test_albums_detail_patch_delete_and_membership_guards(tmp_path, monkeypatch):

--- a/apps/api/tests/test_albums_and_exports_api.py
+++ b/apps/api/tests/test_albums_and_exports_api.py
@@ -297,7 +297,19 @@ def test_migration_creates_album_tables(tmp_path):
         album_columns = {column["name"] for column in inspector.get_columns(albums.name)}
         item_columns = {column["name"] for column in inspector.get_columns(editable_album_items.name)}
         rule_columns = {column["name"] for column in inspector.get_columns(saved_filter_album_rules.name)}
+        user_columns = {column["name"] for column in inspector.get_columns("users")}
+        role_columns = {column["name"] for column in inspector.get_columns("user_role_assignments")}
 
     assert {"album_id", "name", "owner_user_id", "kind", "created_ts", "updated_ts"} <= album_columns
     assert {"album_id", "photo_id", "added_by_user_id", "added_ts"} <= item_columns
     assert {"album_id", "filter_json", "updated_ts"} <= rule_columns
+    assert {
+        "user_id",
+        "auth_provider",
+        "auth_subject",
+        "email",
+        "display_name",
+        "created_ts",
+        "updated_ts",
+    } <= user_columns
+    assert {"user_id", "role", "created_ts", "updated_ts"} <= role_columns

--- a/apps/api/tests/test_auth_rbac.py
+++ b/apps/api/tests/test_auth_rbac.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+
+from app.dependencies import _get_session_factory
+from app.main import app
+from app.migrations import upgrade_database
+from app.storage import users
+
+
+def test_cloudflare_access_auto_provisions_user_without_roles(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'auth-rbac.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("PHOTO_ORG_AUTH_MODE", "cloudflare_access")
+    _get_session_factory.cache_clear()
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/albums",
+        headers={"Cf-Access-Authenticated-User-Email": "new.user@example.com"},
+    )
+
+    assert response.status_code == 200
+    engine = create_engine(database_url, future=True)
+    with engine.connect() as connection:
+        persisted = connection.execute(
+            select(users.c.email, users.c.auth_provider)
+        ).mappings().all()
+    assert persisted == [{"email": "new.user@example.com", "auth_provider": "cloudflare_access"}]

--- a/apps/api/tests/test_auth_rbac.py
+++ b/apps/api/tests/test_auth_rbac.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine, insert, select
 
 from app.dependencies import _get_session_factory
 from app.main import app
 from app.migrations import upgrade_database
-from app.storage import users
+from app.storage import faces, people, photos, users
 
 
 def test_cloudflare_access_auto_provisions_user_without_roles(tmp_path, monkeypatch):
@@ -29,3 +31,48 @@ def test_cloudflare_access_auto_provisions_user_without_roles(tmp_path, monkeypa
             select(users.c.email, users.c.auth_provider)
         ).mappings().all()
     assert persisted == [{"email": "new.user@example.com", "auth_provider": "cloudflare_access"}]
+
+
+def test_cloudflare_access_user_without_role_cannot_confirm_face(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'auth-rbac-face.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("PHOTO_ORG_AUTH_MODE", "cloudflare_access")
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        now = datetime(2026, 5, 25, 12, 0, tzinfo=UTC)
+        connection.execute(
+            insert(photos).values(
+                photo_id="photo-1",
+                sha256="sha256-photo-1",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        connection.execute(
+            insert(people).values(
+                person_id="person-1",
+                display_name="Jane Doe",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={"person_id": "person-1"},
+        headers={"Cf-Access-Authenticated-User-Email": "viewer@example.com"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Face validation role required"}

--- a/apps/api/tests/test_face_assignment_api.py
+++ b/apps/api/tests/test_face_assignment_api.py
@@ -12,7 +12,16 @@ from app.main import app
 from app.migrations import upgrade_database
 from app.routers import face_assignments as face_assignments_router
 from app.services import face_assignment as face_assignment_service
-from app.storage import face_labels, face_suggestions, faces, ingest_queue, people, photos
+from app.storage import (
+    face_labels,
+    face_suggestions,
+    faces,
+    ingest_queue,
+    people,
+    photos,
+    user_role_assignments,
+    users,
+)
 
 
 def _client(tmp_path, monkeypatch, filename: str) -> TestClient:
@@ -200,6 +209,56 @@ def test_face_assignment_api_rejects_missing_face_validation_role(tmp_path, monk
             select(faces.c.person_id).where(faces.c.face_id == "face-1")
         ).scalar_one_or_none()
     assert persisted_person_id is None
+
+
+def test_face_assignment_api_accepts_cloudflare_access_contributor_role(tmp_path, monkeypatch):
+    database_url = _database_url(tmp_path, "face-assign-cloudflare.db")
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("PHOTO_ORG_AUTH_MODE", "cloudflare_access")
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        now = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+        connection.execute(
+            insert(users).values(
+                user_id="user-1",
+                auth_provider="cloudflare_access",
+                auth_subject="contributor@example.com",
+                email="contributor@example.com",
+                display_name=None,
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        connection.execute(
+            insert(user_role_assignments).values(
+                user_id="user-1",
+                role="contributor",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(
+            insert(faces).values(
+                face_id="face-1",
+                photo_id="photo-1",
+                person_id=None,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={"person_id": "person-1"},
+        headers={"Cf-Access-Authenticated-User-Email": "contributor@example.com"},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["person_id"] == "person-1"
 
 
 def test_face_dismissal_api_marks_unassigned_face_as_dismissed_and_clears_suggestions(

--- a/apps/ui/vite.config.ts
+++ b/apps/ui/vite.config.ts
@@ -6,10 +6,15 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const apiProxyTarget =
     env.VITE_API_PROXY_TARGET || env.VITE_API_BASE_URL || "http://127.0.0.1:8000";
+  const allowedHosts = (env.VITE_ALLOWED_HOSTS || "")
+    .split(",")
+    .map((host) => host.trim())
+    .filter(Boolean);
 
   return {
     plugins: [react()],
     server: {
+      allowedHosts,
       proxy: {
         "/api": {
           target: apiProxyTarget,

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,6 +27,7 @@ services:
     environment:
       DATABASE_URL: ${PHOTO_ORG_DB_SERVICE_DATABASE_URL:-postgresql+psycopg://photoorg:photoorg@postgres:5432/photoorg}
       PHOTO_ORG_API_CORS_ALLOWED_ORIGINS: ${PHOTO_ORG_API_CORS_ALLOWED_ORIGINS:-http://127.0.0.1:5173,http://localhost:5173,https://127.0.0.1,https://localhost,https://photo.noead.com}
+      PHOTO_ORG_AUTH_MODE: ${PHOTO_ORG_AUTH_MODE:-legacy_headers}
       FACE_DETECT_SCALE_FACTOR: ${FACE_DETECT_SCALE_FACTOR:-1.1}
       FACE_DETECT_MIN_NEIGHBORS: ${FACE_DETECT_MIN_NEIGHBORS:-5}
       FACE_DETECT_MIN_SIZE: ${FACE_DETECT_MIN_SIZE:-60x60}

--- a/compose.yaml
+++ b/compose.yaml
@@ -26,7 +26,7 @@ services:
       dockerfile: apps/api/Dockerfile
     environment:
       DATABASE_URL: ${PHOTO_ORG_DB_SERVICE_DATABASE_URL:-postgresql+psycopg://photoorg:photoorg@postgres:5432/photoorg}
-      PHOTO_ORG_API_CORS_ALLOWED_ORIGINS: ${PHOTO_ORG_API_CORS_ALLOWED_ORIGINS:-http://127.0.0.1:5173,http://localhost:5173,https://127.0.0.1,https://localhost}
+      PHOTO_ORG_API_CORS_ALLOWED_ORIGINS: ${PHOTO_ORG_API_CORS_ALLOWED_ORIGINS:-http://127.0.0.1:5173,http://localhost:5173,https://127.0.0.1,https://localhost,https://photo.noead.com}
       FACE_DETECT_SCALE_FACTOR: ${FACE_DETECT_SCALE_FACTOR:-1.1}
       FACE_DETECT_MIN_NEIGHBORS: ${FACE_DETECT_MIN_NEIGHBORS:-5}
       FACE_DETECT_MIN_SIZE: ${FACE_DETECT_MIN_SIZE:-60x60}
@@ -66,6 +66,7 @@ services:
     environment:
       VITE_API_BASE_URL: ${PHOTO_ORG_UI_API_BASE_URL:-http://127.0.0.1:8000}
       VITE_API_PROXY_TARGET: ${PHOTO_ORG_UI_PROXY_TARGET:-http://db-service:8000}
+      VITE_ALLOWED_HOSTS: ${PHOTO_ORG_UI_ALLOWED_HOSTS:-photo.noead.com}
     depends_on:
       db-service:
         condition: service_healthy
@@ -81,7 +82,6 @@ services:
         condition: service_started
     ports:
       - "${PHOTO_ORG_HTTP_HOST_PORT:-80}:80"
-      - "${PHOTO_ORG_HTTPS_HOST_PORT:-443}:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data

--- a/docs/superpowers/plans/2026-05-25-cloudflare-db-rbac.md
+++ b/docs/superpowers/plans/2026-05-25-cloudflare-db-rbac.md
@@ -1,0 +1,567 @@
+# Cloudflare DB RBAC Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add database-backed global RBAC for Cloudflare-authenticated users, auto-provision user records on first access, and move album ownership plus protected endpoint authorization onto app user identities.
+
+**Architecture:** Introduce a durable `users` principal table and a `user_role_assignments` table, then resolve Cloudflare-authenticated requests to an app user before route authorization runs. Keep the first cut narrow by leaving existing album ownership columns structurally unchanged while changing their meaning for new writes from caller-provided strings to app `user_id` values.
+
+**Tech Stack:** FastAPI, SQLAlchemy Core, Alembic, pytest, SQLite test databases, PostgreSQL-compatible schema definitions
+
+---
+
+## File Structure
+
+- Create: `apps/api/alembic/versions/20260525_000001_add_users_and_rbac_tables.py`
+  Purpose: add `users` and `user_role_assignments`, plus constraints and indexes needed for global RBAC.
+- Create: `apps/api/tests/test_auth_rbac.py`
+  Purpose: focused request-resolution and role-enforcement tests for auto-provisioning and DB-backed authorization.
+- Modify: `packages/db-schema/photoorg_db_schema/schema.py`
+  Purpose: declare `users` and `user_role_assignments` in the code-owned schema.
+- Modify: `apps/api/app/auth.py`
+  Purpose: resolve Cloudflare identity into a durable app user and load DB roles.
+- Modify: `apps/api/app/dependencies.py`
+  Purpose: replace header-trust authorization with user and role dependencies backed by the DB.
+- Modify: `apps/api/app/routers/albums.py`
+  Purpose: scope album ownership and attribution by app `user_id`.
+- Modify: `apps/api/app/routers/face_assignments.py`
+  Purpose: keep face-labeling writes on contributor/admin DB roles.
+- Modify: `apps/api/app/routers/suggestions.py`
+  Purpose: keep suggestion confirmation writes on contributor/admin DB roles.
+- Modify: `apps/api/tests/test_albums_and_exports_api.py`
+  Purpose: verify album ownership uses DB identities and resource scoping remains correct.
+- Modify: `apps/api/tests/test_face_assignment_api.py`
+  Purpose: verify contributor/admin role enforcement uses DB role assignments.
+- Modify: `apps/api/tests/test_main.py`
+  Purpose: keep auth-mode and CORS-level tests aligned with the new dependencies if needed.
+- Modify: `compose.yaml`
+  Purpose: continue passing auth-mode env vars through the runtime container.
+- Modify: `.env.compose.example`
+  Purpose: document runtime env vars needed for Cloudflare-backed auth mode.
+
+### Task 1: Add RBAC Schema And Migration
+
+**Files:**
+- Create: `apps/api/alembic/versions/20260525_000001_add_users_and_rbac_tables.py`
+- Modify: `packages/db-schema/photoorg_db_schema/schema.py`
+- Test: `apps/api/tests/test_albums_and_exports_api.py`
+
+- [ ] **Step 1: Write the failing schema test expectations**
+
+Add the new table/column assertions near the existing album schema assertions in `apps/api/tests/test_albums_and_exports_api.py`:
+
+```python
+    user_columns = {column["name"] for column in inspector.get_columns("users")}
+    role_columns = {column["name"] for column in inspector.get_columns("user_role_assignments")}
+
+    assert {
+        "user_id",
+        "auth_provider",
+        "auth_subject",
+        "email",
+        "display_name",
+        "created_ts",
+        "updated_ts",
+    } <= user_columns
+    assert {"user_id", "role", "created_ts", "updated_ts"} <= role_columns
+```
+
+- [ ] **Step 2: Run the schema test to verify it fails**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_albums_and_exports_api.py -k schema -q
+```
+
+Expected: FAIL because `users` and `user_role_assignments` do not exist.
+
+- [ ] **Step 3: Add the schema definitions**
+
+Update `packages/db-schema/photoorg_db_schema/schema.py` with:
+
+```python
+users = Table(
+    "users",
+    metadata,
+    Column("user_id", String(36), primary_key=True),
+    Column("auth_provider", String, nullable=False),
+    Column("auth_subject", String, nullable=False, unique=True),
+    Column("email", String, nullable=False, unique=True),
+    Column("display_name", String),
+    Column("created_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    Column("updated_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+)
+
+user_role_assignments = Table(
+    "user_role_assignments",
+    metadata,
+    Column("user_id", String(36), ForeignKey("users.user_id", ondelete="CASCADE"), primary_key=True),
+    Column("role", String, primary_key=True),
+    Column("created_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    Column("updated_ts", TIMESTAMP(timezone=True), nullable=False, server_default=text("CURRENT_TIMESTAMP")),
+    CheckConstraint("role IN ('viewer', 'contributor', 'admin')", name="ck_user_role_assignments_role"),
+)
+
+Index("idx_users_email", users.c.email)
+Index("idx_user_role_assignments_role", user_role_assignments.c.role)
+```
+
+- [ ] **Step 4: Add the Alembic migration**
+
+Create `apps/api/alembic/versions/20260525_000001_add_users_and_rbac_tables.py`:
+
+```python
+"""add users and rbac tables
+
+Revision ID: 20260525_000001
+Revises: 20260508_000001
+Create Date: 2026-05-25 00:00:01
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260525_000001"
+down_revision = "20260508_000001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("user_id", sa.String(length=36), primary_key=True),
+        sa.Column("auth_provider", sa.String(), nullable=False),
+        sa.Column("auth_subject", sa.String(), nullable=False),
+        sa.Column("email", sa.String(), nullable=False),
+        sa.Column("display_name", sa.String(), nullable=True),
+        sa.Column("created_ts", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_ts", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.UniqueConstraint("auth_subject", name="uq_users_auth_subject"),
+        sa.UniqueConstraint("email", name="uq_users_email"),
+    )
+    op.create_index("idx_users_email", "users", ["email"])
+
+    op.create_table(
+        "user_role_assignments",
+        sa.Column("user_id", sa.String(length=36), sa.ForeignKey("users.user_id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("role", sa.String(), primary_key=True),
+        sa.Column("created_ts", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_ts", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.CheckConstraint("role IN ('viewer', 'contributor', 'admin')", name="ck_user_role_assignments_role"),
+    )
+    op.create_index("idx_user_role_assignments_role", "user_role_assignments", ["role"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_user_role_assignments_role", table_name="user_role_assignments")
+    op.drop_table("user_role_assignments")
+    op.drop_index("idx_users_email", table_name="users")
+    op.drop_table("users")
+```
+
+- [ ] **Step 5: Run the schema test to verify it passes**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_albums_and_exports_api.py -k schema -q
+```
+
+Expected: PASS with the new tables present.
+
+- [ ] **Step 6: Commit the schema slice**
+
+```bash
+git add packages/db-schema/photoorg_db_schema/schema.py apps/api/alembic/versions/20260525_000001_add_users_and_rbac_tables.py apps/api/tests/test_albums_and_exports_api.py
+git commit -m "feat: add database-backed user and role tables"
+```
+
+### Task 2: Resolve Cloudflare Identity To A DB User
+
+**Files:**
+- Modify: `apps/api/app/auth.py`
+- Modify: `apps/api/app/dependencies.py`
+- Create: `apps/api/tests/test_auth_rbac.py`
+
+- [ ] **Step 1: Write the failing user auto-provisioning test**
+
+Create `apps/api/tests/test_auth_rbac.py` with:
+
+```python
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, select
+
+from app.dependencies import _get_session_factory
+from app.main import app
+from app.migrations import upgrade_database
+from app.storage import users
+
+
+def test_cloudflare_access_auto_provisions_user_without_roles(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'auth-rbac.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("PHOTO_ORG_AUTH_MODE", "cloudflare_access")
+    _get_session_factory.cache_clear()
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/albums",
+        headers={"Cf-Access-Authenticated-User-Email": "new.user@example.com"},
+    )
+
+    assert response.status_code == 200
+    engine = create_engine(database_url, future=True)
+    with engine.connect() as connection:
+        persisted = connection.execute(
+            select(users.c.email, users.c.auth_provider)
+        ).mappings().all()
+    assert persisted == [{"email": "new.user@example.com", "auth_provider": "cloudflare_access"}]
+```
+
+- [ ] **Step 2: Run the auth test to verify it fails**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_auth_rbac.py -q
+```
+
+Expected: FAIL because the app does not yet create or load DB users.
+
+- [ ] **Step 3: Implement DB-backed identity resolution**
+
+Update `apps/api/app/auth.py` to add a resolved app-user model plus lookup/create helpers:
+
+```python
+@dataclass(frozen=True)
+class AppUser:
+    user_id: str
+    email: str
+    display_name: str | None
+    roles: frozenset[str]
+
+
+def get_or_create_cloudflare_user(db: Session, *, email: str, subject: str | None = None) -> AppUser:
+    normalized_email = _normalize_email(email)
+    auth_subject = (subject or normalized_email or "").strip().lower()
+    row = db.execute(
+        select(users).where(users.c.auth_subject == auth_subject)
+    ).mappings().one_or_none()
+    if row is None:
+        now = datetime.now(tz=UTC)
+        user_id = str(uuid4())
+        db.execute(
+            insert(users).values(
+                user_id=user_id,
+                auth_provider="cloudflare_access",
+                auth_subject=auth_subject,
+                email=normalized_email,
+                display_name=None,
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        db.commit()
+        row = db.execute(
+            select(users).where(users.c.user_id == user_id)
+        ).mappings().one()
+    assigned_roles = frozenset(
+        db.execute(
+            select(user_role_assignments.c.role).where(user_role_assignments.c.user_id == row["user_id"])
+        ).scalars().all()
+    )
+    return AppUser(
+        user_id=row["user_id"],
+        email=row["email"],
+        display_name=row["display_name"],
+        roles=assigned_roles,
+    )
+```
+
+- [ ] **Step 4: Replace the simple string dependency with app-user resolution**
+
+Update `apps/api/app/dependencies.py` to expose:
+
+```python
+def require_authenticated_user(
+    db: Session = Depends(get_db),
+    cloudflare_access_email: str | None = Header(default=None, alias=CF_ACCESS_AUTHENTICATED_USER_EMAIL_HEADER),
+) -> AppUser:
+    if get_auth_mode() == AUTH_MODE_CLOUDFLARE_ACCESS:
+        resolved_identity = resolve_cloudflare_access_user(cloudflare_access_email)
+        return get_or_create_cloudflare_user(db, email=resolved_identity.email)
+    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Legacy auth mode not supported in this plan.")
+```
+
+Then keep a compatibility wrapper:
+
+```python
+def require_authenticated_user_id(user: AppUser = Depends(require_authenticated_user)) -> str:
+    return user.user_id
+```
+
+- [ ] **Step 5: Run the auth test to verify it passes**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_auth_rbac.py -q
+```
+
+Expected: PASS with a persisted `users` row.
+
+- [ ] **Step 6: Commit the identity-resolution slice**
+
+```bash
+git add apps/api/app/auth.py apps/api/app/dependencies.py apps/api/tests/test_auth_rbac.py
+git commit -m "feat: resolve Cloudflare requests to app users"
+```
+
+### Task 3: Enforce DB Roles On Protected Endpoints
+
+**Files:**
+- Modify: `apps/api/app/dependencies.py`
+- Modify: `apps/api/app/routers/face_assignments.py`
+- Modify: `apps/api/app/routers/suggestions.py`
+- Modify: `apps/api/tests/test_face_assignment_api.py`
+- Modify: `apps/api/tests/test_auth_rbac.py`
+
+- [ ] **Step 1: Write the failing contributor-role test**
+
+Add to `apps/api/tests/test_auth_rbac.py`:
+
+```python
+def test_cloudflare_access_user_without_role_cannot_confirm_face(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'auth-rbac-face.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("PHOTO_ORG_AUTH_MODE", "cloudflare_access")
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        _insert_photo(connection, photo_id="photo-1")
+        _insert_person(connection, person_id="person-1", display_name="Jane Doe")
+        connection.execute(insert(faces).values(face_id="face-1", photo_id="photo-1", person_id=None))
+
+    client = TestClient(app)
+    response = client.post(
+        "/api/v1/faces/face-1/assignments",
+        json={"person_id": "person-1"},
+        headers={"Cf-Access-Authenticated-User-Email": "viewer@example.com"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Face validation role required"}
+```
+
+- [ ] **Step 2: Run the face auth tests to verify they fail correctly**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_auth_rbac.py apps/api/tests/test_face_assignment_api.py -k "cloudflare_access or role" -q
+```
+
+Expected: FAIL because DB role assignments are not yet consulted.
+
+- [ ] **Step 3: Implement DB role lookup and contributor/admin enforcement**
+
+Update `apps/api/app/dependencies.py`:
+
+```python
+ROLE_RANK = {
+    "viewer": 1,
+    "contributor": 2,
+    "admin": 3,
+}
+
+
+def require_role(required_role: str):
+    def dependency(user: AppUser = Depends(require_authenticated_user)) -> AppUser:
+        user_rank = max((ROLE_RANK[role] for role in user.roles), default=0)
+        required_rank = ROLE_RANK[required_role]
+        if user_rank < required_rank:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Face validation role required" if required_role == "contributor" else "Admin role required",
+            )
+        return user
+
+    return dependency
+
+
+def require_face_validation_role(_: AppUser = Depends(require_role("contributor"))) -> str:
+    return "contributor"
+```
+
+- [ ] **Step 4: Keep protected routers on the DB-backed dependency**
+
+Ensure `apps/api/app/routers/face_assignments.py` and `apps/api/app/routers/suggestions.py` still depend on `require_face_validation_role` and do not reintroduce header-based auth.
+
+- [ ] **Step 5: Run the face auth tests to verify they pass**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_auth_rbac.py apps/api/tests/test_face_assignment_api.py -k "cloudflare_access or role" -q
+```
+
+Expected: PASS, including no-role denial and contributor access.
+
+- [ ] **Step 6: Commit the authorization slice**
+
+```bash
+git add apps/api/app/dependencies.py apps/api/app/routers/face_assignments.py apps/api/app/routers/suggestions.py apps/api/tests/test_auth_rbac.py apps/api/tests/test_face_assignment_api.py
+git commit -m "feat: enforce db-backed roles on protected endpoints"
+```
+
+### Task 4: Move Album Ownership To App User IDs
+
+**Files:**
+- Modify: `apps/api/app/routers/albums.py`
+- Modify: `apps/api/tests/test_albums_and_exports_api.py`
+- Modify: `apps/api/tests/test_search_service.py`
+
+- [ ] **Step 1: Write the failing ownership test**
+
+Extend `apps/api/tests/test_albums_and_exports_api.py`:
+
+```python
+    engine = create_engine(f"sqlite:///{tmp_path / 'albums-cloudflare.db'}", future=True)
+    with engine.connect() as connection:
+        owner_row = connection.execute(
+            select(users.c.user_id, users.c.email).where(users.c.email == "owner@example.com")
+        ).mappings().one()
+        album_row = connection.execute(
+            select(albums.c.owner_user_id).where(albums.c.album_id == album_id)
+        ).mappings().one()
+    assert album_row["owner_user_id"] == owner_row["user_id"]
+```
+
+- [ ] **Step 2: Run the album tests to verify they fail**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_albums_and_exports_api.py -k cloudflare_access_scope_by_authenticated_email -q
+```
+
+Expected: FAIL because album ownership is still compared against email, not app `user_id`.
+
+- [ ] **Step 3: Update album endpoints to consume the resolved app user**
+
+In `apps/api/app/routers/albums.py`, replace plain `user_id` dependencies with the full app user where needed:
+
+```python
+from app.auth import AppUser
+from app.dependencies import require_authenticated_user
+
+
+def create_album_endpoint(
+    body: CreateAlbumRequest,
+    db: Session = Depends(get_db),
+    user: AppUser = Depends(require_authenticated_user),
+) -> AlbumResponse:
+    if _album_name_exists(db, owner_user_id=user.user_id, name=body.name):
+        ...
+    db.execute(
+        insert(albums).values(
+            album_id=album_id,
+            name=body.name,
+            owner_user_id=user.user_id,
+            kind=body.kind,
+            created_ts=now,
+            updated_ts=now,
+        )
+    )
+```
+
+Also update list/detail/update/delete/item-membership paths to scope by `user.user_id`, and write `editable_album_items.added_by_user_id=user.user_id`.
+
+- [ ] **Step 4: Update search-service tests that currently assume `demo-user`**
+
+Adjust `apps/api/tests/test_search_service.py` fixtures and expectations from `"demo-user"` to explicit app user ids such as `"user-1"` so they no longer depend on the old fallback identity semantics.
+
+- [ ] **Step 5: Run the album and search tests to verify they pass**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_albums_and_exports_api.py apps/api/tests/test_search_service.py -k "album or owner_user_id or added_by_user_id" -q
+```
+
+Expected: PASS with ownership stored as app `user_id`.
+
+- [ ] **Step 6: Commit the ownership slice**
+
+```bash
+git add apps/api/app/routers/albums.py apps/api/tests/test_albums_and_exports_api.py apps/api/tests/test_search_service.py
+git commit -m "feat: store album ownership by app user id"
+```
+
+### Task 5: Final Verification And Runtime Wiring
+
+**Files:**
+- Modify: `compose.yaml`
+- Modify: `.env.compose.example`
+- Test: `apps/api/tests/test_main.py`
+
+- [ ] **Step 1: Write or adjust the runtime configuration expectations**
+
+Add any needed assertions in `apps/api/tests/test_main.py` for the auth mode boundary, but keep the scope limited to config and dependency behavior rather than full RBAC integration.
+
+- [ ] **Step 2: Keep the runtime env vars documented and passed through**
+
+Ensure `compose.yaml` and `.env.compose.example` contain:
+
+```yaml
+PHOTO_ORG_AUTH_MODE: ${PHOTO_ORG_AUTH_MODE:-legacy_headers}
+PHOTO_ORG_AUTH_CONTRIBUTOR_EMAILS: ${PHOTO_ORG_AUTH_CONTRIBUTOR_EMAILS:-}
+PHOTO_ORG_AUTH_ADMIN_EMAILS: ${PHOTO_ORG_AUTH_ADMIN_EMAILS:-}
+```
+
+Note: these contributor/admin env vars should remain only if they are still needed during the transition. If the DB-backed implementation no longer depends on them, remove them here and in tests instead of carrying dead configuration.
+
+- [ ] **Step 3: Run the final impacted API test suite**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_auth_rbac.py apps/api/tests/test_albums_and_exports_api.py apps/api/tests/test_face_assignment_api.py apps/api/tests/test_face_suggestion_review_api.py apps/api/tests/test_main.py -q
+```
+
+Expected: PASS with all impacted RBAC and route tests green.
+
+- [ ] **Step 4: Run the migration-focused verification**
+
+Run:
+
+```bash
+uv run python -m pytest apps/api/tests/test_migrations.py apps/api/tests/test_schema_definition.py -q
+```
+
+Expected: PASS with the new tables included in the schema and migration chain.
+
+- [ ] **Step 5: Commit the runtime and verification slice**
+
+```bash
+git add compose.yaml .env.compose.example apps/api/tests/test_main.py
+git commit -m "chore: wire runtime config for db-backed rbac"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - DB identity abstraction: covered by Tasks 1 and 2.
+  - DB-backed global roles: covered by Tasks 1 and 3.
+  - Protected endpoint authorization: covered by Task 3.
+  - Ownership by app principal: covered by Task 4.
+  - Transitional runtime configuration and verification: covered by Task 5.
+- Placeholder scan:
+  - No `TODO`, `TBD`, or “similar to previous task” shortcuts remain.
+- Type consistency:
+  - The plan consistently uses `AppUser`, `users`, `user_role_assignments`, `owner_user_id`, and `added_by_user_id`.

--- a/docs/superpowers/specs/2026-05-25-cloudflare-db-rbac-design.md
+++ b/docs/superpowers/specs/2026-05-25-cloudflare-db-rbac-design.md
@@ -1,0 +1,197 @@
+# Cloudflare DB RBAC Design
+
+## Goal
+
+Replace header-based application authorization with database-backed global user roles for Cloudflare-authenticated users, while auto-provisioning user records on first access and preserving a narrow first implementation scope.
+
+## Scope
+
+This design covers:
+
+- database-backed user identity records
+- global role assignments stored in the database
+- Cloudflare-authenticated request resolution to an app user
+- route-level authorization for existing protected API surfaces
+- album ownership based on app user records
+
+This design does not cover:
+
+- team or group membership modeling
+- JWT validation of `Cf-Access-Jwt-Assertion`
+- an admin UI for managing users or roles
+- synchronization from Cloudflare or IdP groups into app roles
+
+## Current State
+
+The current app has no durable user or role model.
+
+- face-labeling permissions are enforced from `X-Face-Validation-Role`
+- album ownership and membership attribution use raw string fields such as `owner_user_id` and `added_by_user_id`
+- Cloudflare Access identity is not yet mapped to a database principal
+
+This means authenticated users can enter through Cloudflare, but the app still lacks an internal trust boundary for authorization and ownership.
+
+## Requirements
+
+The first implementation must satisfy these requirements:
+
+1. Cloudflare-authenticated users resolve to a durable app user record.
+2. First-time users are auto-created in the database with no implicit elevated privileges.
+3. Authorization decisions use database role assignments, not client-supplied headers.
+4. Roles are global per user, not scoped by team, album, or resource.
+5. Existing protected API surfaces must use the resolved app user and role set.
+6. Album ownership and attribution for new writes must use the app `user_id`.
+
+## Chosen Approach
+
+Use a `users` table plus a `user_role_assignments` table.
+
+This approach keeps identity and authorization separate:
+
+- the `users` table stores the durable principal
+- the `user_role_assignments` table stores zero or more global roles
+
+This is preferred over a single `users.role` column because the app already has more than one privilege tier and will likely accumulate more authorization checks over time. It is also preferred over a fully normalized `roles` catalog because the role set is currently small and stable.
+
+## Data Model
+
+### Users
+
+Add a `users` table with:
+
+- `user_id`: primary key
+- `auth_provider`: string, initially `cloudflare_access`
+- `auth_subject`: unique external identity key
+- `email`: unique normalized email
+- `display_name`: nullable display string
+- `created_ts`
+- `updated_ts`
+
+Identity resolution should prefer a stable external subject when one is available from the trusted Cloudflare identity boundary. If the first cut only has a trusted email available, email may temporarily serve as the unique identity key. The design should keep `auth_subject` distinct so the implementation can move away from email-as-identity without redesigning the table.
+
+### User Role Assignments
+
+Add a `user_role_assignments` table with:
+
+- `user_id`: foreign key to `users.user_id`
+- `role`: constrained string
+- `created_ts`
+- `updated_ts`
+
+The table should enforce uniqueness on `(user_id, role)`.
+
+The allowed role set for the first cut is fixed in code and constrained in the schema:
+
+- `viewer`
+- `contributor`
+- `admin`
+
+## Authorization Semantics
+
+Roles are global and cumulative:
+
+- `viewer`: read-only app usage such as browsing, searching, and reading owned albums
+- `contributor`: viewer capabilities plus face-labeling actions
+- `admin`: contributor capabilities plus admin/configuration actions
+
+The API authorization layer should expose dependencies along these lines:
+
+- `require_authenticated_user()`
+- `require_role("contributor")`
+- `require_role("admin")`
+
+These dependencies must resolve a database user first, then derive effective permissions from `user_role_assignments`.
+
+## Request Flow
+
+In `cloudflare_access` mode:
+
+1. Read trusted Cloudflare-authenticated identity metadata at the API boundary.
+2. Normalize the external identity.
+3. Look up an existing `users` row.
+4. If no row exists, create one automatically with no role assignments.
+5. Load that user’s roles from `user_role_assignments`.
+6. Attach the resolved app user to request processing.
+7. Route dependencies enforce required roles from the resolved app user.
+
+In this model, authentication and authorization are separate:
+
+- authentication determines who the user is
+- authorization determines what the user may do
+
+## Protected Surfaces
+
+### Albums
+
+Album APIs must stop trusting `X-Photo-Org-User-Id`.
+
+In `cloudflare_access` mode:
+
+- new albums store `owner_user_id` as the resolved app `user_id`
+- new album item rows store `added_by_user_id` as the resolved app `user_id`
+- album reads and mutations are scoped by the resolved app `user_id`
+
+For the first cut, `owner_user_id` and `added_by_user_id` remain string columns. Their meaning changes to “app user id” for new writes instead of “raw caller-provided string”.
+
+### Face Labeling
+
+Face-labeling APIs must stop trusting `X-Face-Validation-Role`.
+
+In `cloudflare_access` mode:
+
+- privileged write actions require `contributor` or `admin`
+- a user with no role assignments receives `403`
+
+### Admin Surfaces
+
+Any existing or future admin/configuration routes should require `admin`. This includes storage-source management and similar operational mutation surfaces once they are wired into the same dependency model.
+
+## Migration Strategy
+
+The first cut should not attempt a broad ownership backfill or a destructive schema rewrite.
+
+Instead:
+
+1. Add `users`
+2. Add `user_role_assignments`
+3. Keep `owner_user_id` and `added_by_user_id` as-is structurally
+4. Change runtime write semantics so new values store app `user_id`
+
+This keeps the migration low-risk and avoids coupling RBAC delivery to historical data cleanup.
+
+## Error Handling
+
+In `cloudflare_access` mode:
+
+- missing trusted identity: `403`
+- authenticated user with insufficient role: `403`
+- ownership-protected resource belonging to another user: `404`
+
+Invalid DB role values should be prevented by schema constraints and migration checks rather than handled permissively at runtime.
+
+## Compatibility
+
+The app may temporarily retain a `legacy_headers` mode for local development or transitional use, but the long-term target is to remove client-controlled authorization headers from application trust decisions.
+
+The first implementation should keep the auth mode boundary explicit so tests can cover both legacy and Cloudflare-backed behavior during the transition.
+
+## Testing
+
+The implementation must add or update tests for:
+
+- schema and migration coverage for `users` and `user_role_assignments`
+- first-request auto-provisioning of users
+- contributor/admin enforcement on protected write routes
+- no-role denial for privileged actions
+- album ownership and scoping via DB user ids
+- legacy-mode compatibility during the transition
+
+## Future Work
+
+This design intentionally leaves these items for later:
+
+- signed JWT validation for Cloudflare Access identity
+- group-based RBAC synchronization
+- role management APIs or UI
+- historical backfill of old ownership string values
+- richer capability modeling beyond the three initial global roles

--- a/packages/db-schema/photoorg_db_schema/__init__.py
+++ b/packages/db-schema/photoorg_db_schema/__init__.py
@@ -23,6 +23,8 @@ from .schema import (
     saved_filter_album_rules,
     storage_source_aliases,
     storage_sources,
+    user_role_assignments,
+    users,
     watched_folders,
     configure_embedding_column,
 )
@@ -53,5 +55,7 @@ __all__ = [
     "saved_filter_album_rules",
     "storage_source_aliases",
     "storage_sources",
+    "user_role_assignments",
+    "users",
     "watched_folders",
 ]

--- a/packages/db-schema/photoorg_db_schema/schema.py
+++ b/packages/db-schema/photoorg_db_schema/schema.py
@@ -347,6 +347,56 @@ ingest_queue = Table(
     Column("last_error", Text),
 )
 
+users = Table(
+    "users",
+    metadata,
+    Column("user_id", String(36), primary_key=True),
+    Column("auth_provider", String, nullable=False),
+    Column("auth_subject", String, nullable=False, unique=True),
+    Column("email", String, nullable=False, unique=True),
+    Column("display_name", String),
+    Column(
+        "created_ts",
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    ),
+    Column(
+        "updated_ts",
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    ),
+)
+
+user_role_assignments = Table(
+    "user_role_assignments",
+    metadata,
+    Column(
+        "user_id",
+        String(36),
+        ForeignKey("users.user_id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column("role", String, primary_key=True),
+    Column(
+        "created_ts",
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    ),
+    Column(
+        "updated_ts",
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    ),
+    CheckConstraint(
+        "role IN ('viewer', 'contributor', 'admin')",
+        name="ck_user_role_assignments_role",
+    ),
+)
+
 albums = Table(
     "albums",
     metadata,
@@ -429,6 +479,8 @@ Index("idx_ingest_run_files_ingest_run_id", ingest_run_files.c.ingest_run_id)
 Index("idx_ingest_run_files_ingest_queue_id", ingest_run_files.c.ingest_queue_id)
 Index("idx_ingest_run_files_run_id_outcome", ingest_run_files.c.ingest_run_id, ingest_run_files.c.outcome)
 Index("idx_ingest_queue_status_enqueued_ts", ingest_queue.c.status, ingest_queue.c.enqueued_ts)
+Index("idx_users_email", users.c.email)
+Index("idx_user_role_assignments_role", user_role_assignments.c.role)
 Index("idx_albums_owner_updated_ts", albums.c.owner_user_id, albums.c.updated_ts)
 Index("idx_editable_album_items_photo_id", editable_album_items.c.photo_id)
 Index(


### PR DESCRIPTION
## Summary
- configure the local tunnel origin and Caddy routing for photo.noead.com
- add Cloudflare-backed app user provisioning plus database-backed global RBAC tables and enforcement
- store album ownership and attribution by app user id while preserving legacy local auth compatibility

## Test Plan
- uv run python -m pytest apps/api/tests/test_auth_rbac.py apps/api/tests/test_albums_and_exports_api.py apps/api/tests/test_face_assignment_api.py apps/api/tests/test_face_suggestion_review_api.py apps/api/tests/test_main.py -q
- uv run python -m pytest apps/api/tests/test_migrations.py apps/api/tests/test_schema_definition.py -q