### PR TITLE
Add RBAC operations admin surface

### DIFF
--- a/apps/api/app/auth.py
+++ b/apps/api/app/auth.py
@@ -28,6 +28,15 @@ class AppUser:
     roles: frozenset[str]
 
 
+@dataclass(frozen=True)
+class AppCapabilities:
+    add_to_album: bool
+    export: bool
+    review_faces: bool
+    manage_roles: bool
+    manage_sources: bool
+
+
 def normalize_email(value: str | None) -> str | None:
     candidate = (value or "").strip().lower()
     return candidate if candidate else None
@@ -92,4 +101,18 @@ def get_or_create_cloudflare_user(
         email=row["email"],
         display_name=row["display_name"],
         roles=assigned_roles,
+    )
+
+
+def derive_capabilities(user: AppUser) -> AppCapabilities:
+    user_rank = max(
+        ({"viewer": 1, "contributor": 2, "admin": 3}.get(role, 0) for role in user.roles),
+        default=0,
+    )
+    return AppCapabilities(
+        add_to_album=True,
+        export=True,
+        review_faces=user_rank >= 2,
+        manage_roles=user_rank >= 3,
+        manage_sources=user_rank >= 3,
     )

--- a/apps/api/app/dependencies.py
+++ b/apps/api/app/dependencies.py
@@ -110,7 +110,7 @@ def require_face_validation_role(
 
 def require_authenticated_user(
     db: Session = Depends(get_db),
-    user_id: str | None = Header(default=None, alias=USER_ID_HEADER),
+    authenticated_user_id_header: str | None = Header(default=None, alias=USER_ID_HEADER),
     cloudflare_access_email: str | None = Header(
         default=None, alias=CF_ACCESS_AUTHENTICATED_USER_EMAIL_HEADER
     ),
@@ -119,7 +119,7 @@ def require_authenticated_user(
         resolved_identity = resolve_cloudflare_access_identity(cloudflare_access_email)
         return get_or_create_cloudflare_user(db, email=resolved_identity.email)
 
-    candidate = (user_id or "").strip() or "demo-user"
+    candidate = (authenticated_user_id_header or "").strip() or "demo-user"
     return AppUser(
         user_id=candidate,
         email="",

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routers.face_assignments import router as face_assignments_router
+from app.routers.admin import router as admin_router
 from app.routers.albums import router as albums_router
 from app.routers.exports import router as exports_router
 from app.routers.ingest_queue import router as ingest_queue_router
@@ -31,6 +32,10 @@ def create_app() -> FastAPI:
             "models in this repository and checked in as generated output."
         ),
         openapi_tags=[
+            {
+                "name": "admin",
+                "description": "Session identity and application role management workflows.",
+            },
             {
                 "name": "photos",
                 "description": "Browse and inspect photo records and metadata.",
@@ -89,6 +94,7 @@ def create_app() -> FastAPI:
 
     app.include_router(ingest_queue_router, prefix="/api/v1")
     app.include_router(operations_router, prefix="/api/v1")
+    app.include_router(admin_router, prefix="/api/v1")
     app.include_router(face_assignments_router, prefix="/api/v1")
     app.include_router(people_router, prefix="/api/v1")
     app.include_router(photos_router, prefix="/api/v1")

--- a/apps/api/app/routers/admin.py
+++ b/apps/api/app/routers/admin.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import delete, insert, select, update
+from sqlalchemy.orm import Session
+
+from app.auth import AppUser, derive_capabilities
+from app.dependencies import get_db, require_authenticated_user, require_role
+from app.storage import user_role_assignments, users
+
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+RoleName = Literal["viewer", "contributor", "admin"]
+
+
+class SessionCapabilitiesResponse(BaseModel):
+    add_to_album: bool
+    export: bool
+    review_faces: bool
+    manage_roles: bool
+    manage_sources: bool
+
+
+class SessionIdentityResponse(BaseModel):
+    user_id: str
+    email: str
+    display_name: str | None
+    roles: list[RoleName]
+    capabilities: SessionCapabilitiesResponse
+
+
+class AdminUserResponse(BaseModel):
+    user_id: str
+    auth_provider: str
+    auth_subject: str
+    email: str
+    display_name: str | None
+    roles: list[RoleName]
+    created_ts: datetime
+    updated_ts: datetime
+
+
+class UpdateUserRolesRequest(BaseModel):
+    roles: list[RoleName]
+
+
+def _sorted_roles(values: set[str] | frozenset[str] | list[str]) -> list[RoleName]:
+    ordered = sorted(set(values), key=lambda role: {"viewer": 1, "contributor": 2, "admin": 3}[role])
+    return ordered  # type: ignore[return-value]
+
+
+def _build_session_identity_response(user: AppUser) -> SessionIdentityResponse:
+    capabilities = derive_capabilities(user)
+    return SessionIdentityResponse(
+        user_id=user.user_id,
+        email=user.email,
+        display_name=user.display_name,
+        roles=_sorted_roles(user.roles),
+        capabilities=SessionCapabilitiesResponse(
+            add_to_album=capabilities.add_to_album,
+            export=capabilities.export,
+            review_faces=capabilities.review_faces,
+            manage_roles=capabilities.manage_roles,
+            manage_sources=capabilities.manage_sources,
+        ),
+    )
+
+
+def _load_admin_user(db: Session, user_id: str) -> AdminUserResponse:
+    row = db.execute(select(users).where(users.c.user_id == user_id)).mappings().one_or_none()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    roles = db.execute(
+        select(user_role_assignments.c.role).where(user_role_assignments.c.user_id == user_id)
+    ).scalars().all()
+    return AdminUserResponse(
+        user_id=row["user_id"],
+        auth_provider=row["auth_provider"],
+        auth_subject=row["auth_subject"],
+        email=row["email"],
+        display_name=row["display_name"],
+        roles=_sorted_roles(roles),
+        created_ts=row["created_ts"],
+        updated_ts=row["updated_ts"],
+    )
+
+
+@router.get(
+    "/session",
+    summary="Get current session",
+    description="Return the authenticated application user, assigned roles, and derived UI capabilities.",
+    response_model=SessionIdentityResponse,
+)
+def get_current_session_endpoint(
+    user: AppUser = Depends(require_authenticated_user),
+) -> SessionIdentityResponse:
+    return _build_session_identity_response(user)
+
+
+@router.get(
+    "/users",
+    summary="List users",
+    description="Return provisioned application users and their assigned roles.",
+    response_model=list[AdminUserResponse],
+    responses={status.HTTP_403_FORBIDDEN: {"description": "Admin role required"}},
+)
+def list_users_endpoint(
+    db: Session = Depends(get_db),
+    _: AppUser = Depends(require_role("admin")),
+) -> list[AdminUserResponse]:
+    rows = db.execute(select(users).order_by(users.c.email.asc(), users.c.user_id.asc())).mappings().all()
+    return [_load_admin_user(db, row["user_id"]) for row in rows]
+
+
+@router.put(
+    "/users/{user_id}/roles",
+    summary="Replace user roles",
+    description="Replace the assigned roles for one application user.",
+    response_model=AdminUserResponse,
+    responses={
+        status.HTTP_403_FORBIDDEN: {"description": "Admin role required"},
+        status.HTTP_404_NOT_FOUND: {"description": "User not found"},
+    },
+)
+def replace_user_roles_endpoint(
+    user_id: str,
+    body: UpdateUserRolesRequest,
+    db: Session = Depends(get_db),
+    _: AppUser = Depends(require_role("admin")),
+) -> AdminUserResponse:
+    existing = db.execute(select(users.c.user_id).where(users.c.user_id == user_id)).scalar_one_or_none()
+    if existing is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    now = datetime.now(tz=UTC)
+    db.execute(delete(user_role_assignments).where(user_role_assignments.c.user_id == user_id))
+    for role in _sorted_roles(body.roles):
+        db.execute(
+            insert(user_role_assignments).values(
+                user_id=user_id,
+                role=role,
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+    db.execute(update(users).where(users.c.user_id == user_id).values(updated_ts=now))
+    db.commit()
+    return _load_admin_user(db, user_id)

--- a/apps/api/tests/test_auth_rbac.py
+++ b/apps/api/tests/test_auth_rbac.py
@@ -8,7 +8,7 @@ from sqlalchemy import create_engine, insert, select
 from app.dependencies import _get_session_factory
 from app.main import app
 from app.migrations import upgrade_database
-from app.storage import faces, people, photos, users
+from app.storage import faces, people, photos, user_role_assignments, users
 
 
 def test_cloudflare_access_auto_provisions_user_without_roles(tmp_path, monkeypatch):
@@ -76,3 +76,167 @@ def test_cloudflare_access_user_without_role_cannot_confirm_face(tmp_path, monke
 
     assert response.status_code == 403
     assert response.json() == {"detail": "Face validation role required"}
+
+
+def test_cloudflare_access_session_endpoint_returns_roles_and_capabilities(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'auth-rbac-session.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("PHOTO_ORG_AUTH_MODE", "cloudflare_access")
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        now = datetime(2026, 5, 25, 12, 0, tzinfo=UTC)
+        connection.execute(
+            insert(users).values(
+                user_id="admin-user",
+                auth_provider="cloudflare_access",
+                auth_subject="admin@example.com",
+                email="admin@example.com",
+                display_name="Admin User",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        connection.execute(
+            insert(user_role_assignments).values(
+                user_id="admin-user",
+                role="admin",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/admin/session",
+        headers={"Cf-Access-Authenticated-User-Email": "admin@example.com"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "user_id": "admin-user",
+        "email": "admin@example.com",
+        "display_name": "Admin User",
+        "roles": ["admin"],
+        "capabilities": {
+            "add_to_album": True,
+            "export": True,
+            "review_faces": True,
+            "manage_roles": True,
+            "manage_sources": True,
+        },
+    }
+
+
+def test_cloudflare_access_admin_can_list_and_replace_user_roles(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'auth-rbac-admin.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("PHOTO_ORG_AUTH_MODE", "cloudflare_access")
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        now = datetime(2026, 5, 25, 12, 0, tzinfo=UTC)
+        connection.execute(
+            insert(users).values(
+                [
+                    {
+                        "user_id": "admin-user",
+                        "auth_provider": "cloudflare_access",
+                        "auth_subject": "admin@example.com",
+                        "email": "admin@example.com",
+                        "display_name": "Admin User",
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                    {
+                        "user_id": "viewer-user",
+                        "auth_provider": "cloudflare_access",
+                        "auth_subject": "viewer@example.com",
+                        "email": "viewer@example.com",
+                        "display_name": None,
+                        "created_ts": now,
+                        "updated_ts": now,
+                    },
+                ]
+            )
+        )
+        connection.execute(
+            insert(user_role_assignments).values(
+                user_id="admin-user",
+                role="admin",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+
+    client = TestClient(app)
+
+    list_response = client.get(
+        "/api/v1/admin/users",
+        headers={"Cf-Access-Authenticated-User-Email": "admin@example.com"},
+    )
+
+    assert list_response.status_code == 200
+    assert [row["user_id"] for row in list_response.json()] == ["admin-user", "viewer-user"]
+    assert list_response.json()[1]["roles"] == []
+
+    update_response = client.put(
+        "/api/v1/admin/users/viewer-user/roles",
+        json={"roles": ["viewer", "contributor"]},
+        headers={"Cf-Access-Authenticated-User-Email": "admin@example.com"},
+    )
+
+    assert update_response.status_code == 200
+    assert update_response.json()["roles"] == ["viewer", "contributor"]
+
+    with engine.connect() as connection:
+        roles = connection.execute(
+            select(user_role_assignments.c.role).where(
+                user_role_assignments.c.user_id == "viewer-user"
+            )
+        ).scalars().all()
+    assert roles == ["contributor", "viewer"] or roles == ["viewer", "contributor"]
+
+
+def test_cloudflare_access_non_admin_cannot_manage_roles(tmp_path, monkeypatch):
+    database_url = f"sqlite:///{tmp_path / 'auth-rbac-non-admin.db'}"
+    upgrade_database(database_url)
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("PHOTO_ORG_AUTH_MODE", "cloudflare_access")
+    _get_session_factory.cache_clear()
+
+    engine = create_engine(database_url, future=True)
+    with engine.begin() as connection:
+        now = datetime(2026, 5, 25, 12, 0, tzinfo=UTC)
+        connection.execute(
+            insert(users).values(
+                user_id="contributor-user",
+                auth_provider="cloudflare_access",
+                auth_subject="contributor@example.com",
+                email="contributor@example.com",
+                display_name=None,
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+        connection.execute(
+            insert(user_role_assignments).values(
+                user_id="contributor-user",
+                role="contributor",
+                created_ts=now,
+                updated_ts=now,
+            )
+        )
+
+    client = TestClient(app)
+    response = client.get(
+        "/api/v1/admin/users",
+        headers={"Cf-Access-Authenticated-User-Email": "contributor@example.com"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Admin role required"}

--- a/apps/api/tests/test_main.py
+++ b/apps/api/tests/test_main.py
@@ -78,6 +78,10 @@ class TestHealthEndpoint:
         ]["400"]["description"] == "Watched folder validation failed"
         assert "/api/v1/operations/activity" in schema["paths"]
         assert "/api/v1/operations/activity/history" in schema["paths"]
+        assert "/api/v1/admin/session" in schema["paths"]
+        assert "/api/v1/admin/users" in schema["paths"]
+        assert "/api/v1/admin/users/{user_id}/roles" in schema["paths"]
+        assert any(tag["name"] == "admin" for tag in schema["tags"])
         assert any(tag["name"] == "operations" for tag in schema["tags"])
         watched_folder_mutation_responses = schema["paths"][
             "/api/v1/storage-sources/{storage_source_id}/watched-folders/{watched_folder_id}"

--- a/apps/ui/src/app/AppRouter.tsx
+++ b/apps/ui/src/app/AppRouter.tsx
@@ -7,7 +7,7 @@ import {
   useNavigate,
   useLocation
 } from "react-router-dom";
-import { useState } from "react";
+import { startTransition, useEffect, useState } from "react";
 import { NuqsAdapter } from "nuqs/adapters/react-router/v6";
 import { AppShell } from "./AppShell";
 import {
@@ -22,7 +22,9 @@ import { NotFoundPage } from "../pages/NotFoundPage";
 import { PeopleManagementRoutePage } from "../pages/PeopleManagementRoutePage";
 import { SuggestionsRoutePage } from "../pages/SuggestionsRoutePage";
 import { AlbumsRoutePage } from "../pages/AlbumsRoutePage";
+import { OperationsRoutePage } from "../pages/OperationsRoutePage";
 import {
+  fetchCurrentSessionIdentity,
   resolveInitialSessionIdentity,
   type SessionIdentity
 } from "../session/sessionIdentity";
@@ -66,9 +68,35 @@ export function AppRouteTree({ initialSessionIdentity }: AppRouteTreeProps = {})
     if (initialSessionIdentity !== undefined) {
       return initialSessionIdentity;
     }
-
+    if (typeof window !== "undefined" && window.__PHOTO_ORG_SESSION__ === undefined) {
+      return null;
+    }
     return resolveInitialSessionIdentity();
   });
+
+  useEffect(() => {
+    if (initialSessionIdentity !== undefined) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    fetchCurrentSessionIdentity(controller.signal)
+      .then((resolvedIdentity) => {
+        startTransition(() => {
+          setSessionIdentity(resolvedIdentity);
+        });
+      })
+      .catch(() => {
+        if (controller.signal.aborted) {
+          return;
+        }
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [initialSessionIdentity]);
 
   return (
     <Routes>
@@ -95,6 +123,8 @@ export function AppRouteTree({ initialSessionIdentity }: AppRouteTreeProps = {})
                 <PeopleManagementRoutePage />
               ) : route.key === "suggestions" ? (
                 <SuggestionsRoutePage />
+              ) : route.key === "operations" ? (
+                <OperationsRoutePage sessionIdentity={sessionIdentity} />
               ) : (
                 <PrimaryRoutePage route={route} />
               )

--- a/apps/ui/src/app/AppShell.test.tsx
+++ b/apps/ui/src/app/AppShell.test.tsx
@@ -11,9 +11,13 @@ const TEST_SESSION_IDENTITY: SessionIdentity = {
   userId: "test-operator",
   displayName: "Avery Operator",
   email: "avery.operator@example.com",
+  roles: ["admin"],
   capabilities: {
     addToAlbum: true,
-    export: true
+    export: true,
+    reviewFaces: true,
+    manageRoles: true,
+    manageSources: true
   }
 };
 
@@ -75,7 +79,8 @@ const ROUTES_WITH_PRIMARY_PAGE_FEEDBACK = PRIMARY_ROUTE_DEFINITIONS.filter(
     route.key !== "library" &&
     route.key !== "albums" &&
     route.key !== "labeling" &&
-    route.key !== "suggestions"
+    route.key !== "suggestions" &&
+    route.key !== "operations"
 );
 
 describe("App shell", () => {
@@ -198,39 +203,19 @@ describe("App shell", () => {
     }
   );
 
-  it("transitions from route error to ready on retry for primary-placeholder routes", async () => {
-    const user = userEvent.setup();
-    renderAtPath("/operations?demoState=error");
+  it("hides the Operations nav entry for non-admin sessions", () => {
+    renderAtPath("/library", {
+      ...TEST_SESSION_IDENTITY,
+      roles: ["viewer"],
+      capabilities: {
+        ...TEST_SESSION_IDENTITY.capabilities,
+        manageRoles: false,
+        manageSources: false,
+        reviewFaces: false
+      }
+    });
 
-    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", {
-        name: "Could not load Operations",
-        level: 2
-      })
-    ).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Retry" }));
-
-    expect(screen.getByRole("heading", { name: "Operations", level: 1 })).toBeInTheDocument();
-    expect(screen.getByText("Operations is ready.")).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Dismiss notification" }));
-    expect(screen.queryByText("Operations is ready.")).not.toBeInTheDocument();
-  });
-
-  it("does not reset feedback state when unrelated query params change", async () => {
-    const user = userEvent.setup();
-    renderAtPathWithQueryBump("/operations?demoState=error&panel=primary");
-
-    await user.click(screen.getByRole("button", { name: "Retry" }));
-    expect(screen.getByText("Operations is ready.")).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Bump query" }));
-
-    expect(screen.getByRole("heading", { name: "Operations", level: 1 })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
-    expect(screen.getByText("Operations is ready.")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Operations" })).not.toBeInTheDocument();
   });
 
   it("renders only Library as the discovery workflow route", async () => {

--- a/apps/ui/src/app/AppShell.tsx
+++ b/apps/ui/src/app/AppShell.tsx
@@ -128,7 +128,12 @@ export function AppShell({
 
       <nav aria-label="Primary" className="shell-nav">
         <ul>
-          {PRIMARY_ROUTE_DEFINITIONS.map((route) => {
+          {PRIMARY_ROUTE_DEFINITIONS.filter((route) => {
+            if (route.key !== "operations") {
+              return true;
+            }
+            return sessionIdentity?.capabilities.manageRoles ?? false;
+          }).map((route) => {
             const isActive = route.key === navigationState.activeRoute.key;
             const routeTarget = route.key === "library" ? rememberedLibraryUrl : route.path;
 

--- a/apps/ui/src/pages/AlbumsRoutePage.test.tsx
+++ b/apps/ui/src/pages/AlbumsRoutePage.test.tsx
@@ -537,7 +537,7 @@ describe("AlbumsRoutePage", () => {
   it("exports album photos into a selected folder one file at a time", async () => {
     const user = userEvent.setup();
     const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
-    let releaseFirstWrite: (() => void) | null = null;
+    let releaseFirstWrite: () => void = () => {};
     const firstWritePending = new Promise<void>((resolve) => {
       releaseFirstWrite = resolve;
     });
@@ -649,7 +649,7 @@ describe("AlbumsRoutePage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Exporting 0 of 2 photos to "AlbumExports".')).toBeInTheDocument();
 
-    releaseFirstWrite?.();
+    releaseFirstWrite();
 
     await waitFor(() => {
       expect(showDirectoryPickerSpy).toHaveBeenCalledTimes(1);

--- a/apps/ui/src/pages/LibraryRoutePage.test.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.test.tsx
@@ -1869,7 +1869,7 @@ describe("LibraryRoutePage", () => {
     await user.click(screen.getByRole("link", { name: "Back to library" }));
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Page 3" })).toHaveAttribute(
+      expect(screen.getByRole("button", { name: "Bottom page 3" })).toHaveAttribute(
         "aria-current",
         "page"
       );

--- a/apps/ui/src/pages/LibraryRoutePage.test.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.test.tsx
@@ -266,7 +266,14 @@ describe("LibraryRoutePage", () => {
       userId: "operator-1",
       displayName: "Operator One",
       email: "op1@photo-org.local",
-      capabilities: { addToAlbum: true, export: true }
+      roles: ["admin"],
+      capabilities: {
+        addToAlbum: true,
+        export: true,
+        reviewFaces: true,
+        manageRoles: true,
+        manageSources: true
+      }
     };
   });
 

--- a/apps/ui/src/pages/LibraryRoutePage.tsx
+++ b/apps/ui/src/pages/LibraryRoutePage.tsx
@@ -1031,10 +1031,7 @@ export function LibraryRoutePage() {
             pageSize,
             nextPageSize
           );
-          setPageSize(nextPageSize);
-          window.setTimeout(() => {
-            setPage(nextPage);
-          }, 0);
+          setPage(nextPage, false, nextPageSize);
         }}
         onSelectPage={(pageNumber) => {
           handleSelectPage(pageNumber);

--- a/apps/ui/src/pages/OperationsRoutePage.test.tsx
+++ b/apps/ui/src/pages/OperationsRoutePage.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { OperationsRoutePage } from "./OperationsRoutePage";
+import type { SessionIdentity } from "../session/sessionIdentity";
+
+const ADMIN_SESSION: SessionIdentity = {
+  userId: "admin-user",
+  displayName: "Admin User",
+  email: "admin@example.com",
+  roles: ["admin"],
+  capabilities: {
+    addToAlbum: true,
+    export: true,
+    reviewFaces: true,
+    manageRoles: true,
+    manageSources: true
+  }
+};
+
+describe("OperationsRoutePage", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("blocks non-admin sessions from role management", () => {
+    render(
+      <OperationsRoutePage
+        sessionIdentity={{
+          ...ADMIN_SESSION,
+          roles: ["viewer"],
+          capabilities: {
+            ...ADMIN_SESSION.capabilities,
+            manageRoles: false,
+            manageSources: false,
+            reviewFaces: false
+          }
+        }}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "Admin access required", level: 2 })).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("loads users and saves updated role assignments", async () => {
+    const user = userEvent.setup();
+    fetchMock.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/v1/admin/users" && (!init || init.method === undefined)) {
+        return {
+          ok: true,
+          json: async () => [
+            {
+              user_id: "viewer-user",
+              auth_provider: "cloudflare_access",
+              auth_subject: "viewer@example.com",
+              email: "viewer@example.com",
+              display_name: null,
+              roles: ["viewer"],
+              created_ts: "2026-05-25T12:00:00Z",
+              updated_ts: "2026-05-25T12:00:00Z"
+            }
+          ]
+        } as Response;
+      }
+      if (url === "/api/v1/admin/users/viewer-user/roles" && init?.method === "PUT") {
+        expect(JSON.parse(String(init.body))).toEqual({ roles: ["viewer", "contributor"] });
+        return {
+          ok: true,
+          json: async () => ({
+            user_id: "viewer-user",
+            auth_provider: "cloudflare_access",
+            auth_subject: "viewer@example.com",
+            email: "viewer@example.com",
+            display_name: null,
+            roles: ["viewer", "contributor"],
+            created_ts: "2026-05-25T12:00:00Z",
+            updated_ts: "2026-05-25T12:01:00Z"
+          })
+        } as Response;
+      }
+      throw new Error(`Unhandled fetch: ${url}`);
+    });
+
+    render(<OperationsRoutePage sessionIdentity={ADMIN_SESSION} />);
+
+    expect(await screen.findByRole("heading", { name: "Users and roles", level: 2 })).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Contributor" })).not.toBeChecked();
+
+    await user.click(screen.getByRole("checkbox", { name: "Contributor" }));
+    await user.click(screen.getByRole("button", { name: "Save roles for viewer@example.com" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("checkbox", { name: "Contributor" })).toBeChecked();
+    });
+  });
+});

--- a/apps/ui/src/pages/OperationsRoutePage.tsx
+++ b/apps/ui/src/pages/OperationsRoutePage.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useMemo, useState } from "react";
+import type { SessionIdentity } from "../session/sessionIdentity";
+import {
+  fetchAdminUsers,
+  replaceAdminUserRoles,
+  type AdminUserRecord
+} from "./operations/operationsApi";
+
+const ROLE_OPTIONS = [
+  { role: "viewer", label: "Viewer" },
+  { role: "contributor", label: "Contributor" },
+  { role: "admin", label: "Admin" }
+] as const;
+
+interface OperationsRoutePageProps {
+  sessionIdentity: SessionIdentity | null;
+}
+
+export function OperationsRoutePage({ sessionIdentity }: OperationsRoutePageProps) {
+  const canManageRoles = sessionIdentity?.capabilities.manageRoles ?? false;
+  const [users, setUsers] = useState<AdminUserRecord[]>([]);
+  const [draftRolesByUserId, setDraftRolesByUserId] = useState<Record<string, string[]>>({});
+  const [busyByUserId, setBusyByUserId] = useState<Record<string, boolean>>({});
+  const [errorByUserId, setErrorByUserId] = useState<Record<string, string>>({});
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(canManageRoles);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    if (!canManageRoles) {
+      setUsers([]);
+      setDraftRolesByUserId({});
+      setBusyByUserId({});
+      setErrorByUserId({});
+      setLoadError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setIsLoading(true);
+    setLoadError(null);
+
+    fetchAdminUsers(controller.signal)
+      .then((payload) => {
+        setUsers(payload);
+        setDraftRolesByUserId(
+          Object.fromEntries(payload.map((user) => [user.user_id, user.roles]))
+        );
+        setIsLoading(false);
+      })
+      .catch((caughtError: unknown) => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        setLoadError(
+          caughtError instanceof Error ? caughtError.message : "Could not load users."
+        );
+        setIsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [canManageRoles, reloadToken]);
+
+  const sortedUsers = useMemo(
+    () => [...users].sort((left, right) => left.email.localeCompare(right.email, "en-US")),
+    [users]
+  );
+
+  function toggleRole(userId: string, role: string) {
+    setDraftRolesByUserId((current) => {
+      const activeRoles = new Set(current[userId] ?? []);
+      if (activeRoles.has(role)) {
+        activeRoles.delete(role);
+      } else {
+        activeRoles.add(role);
+      }
+      return {
+        ...current,
+        [userId]: ROLE_OPTIONS.map((option) => option.role).filter((candidate) =>
+          activeRoles.has(candidate)
+        )
+      };
+    });
+    setErrorByUserId((current) => ({ ...current, [userId]: "" }));
+  }
+
+  async function saveRoles(userId: string) {
+    setBusyByUserId((current) => ({ ...current, [userId]: true }));
+    setErrorByUserId((current) => ({ ...current, [userId]: "" }));
+    try {
+      const updated = await replaceAdminUserRoles(userId, draftRolesByUserId[userId] ?? []);
+      setUsers((current) => current.map((user) => (user.user_id === userId ? updated : user)));
+      setDraftRolesByUserId((current) => ({ ...current, [userId]: updated.roles }));
+    } catch (caughtError) {
+      setErrorByUserId((current) => ({
+        ...current,
+        [userId]: caughtError instanceof Error ? caughtError.message : "Could not update roles."
+      }));
+    } finally {
+      setBusyByUserId((current) => ({ ...current, [userId]: false }));
+    }
+  }
+
+  return (
+    <section aria-labelledby="page-title" className="page operations-page">
+      <div className="people-management-header">
+        <h1 id="page-title">Operations</h1>
+        <p>Manage application roles for authenticated users and inspect current admin access.</p>
+      </div>
+
+      {!canManageRoles ? (
+        <div className="feedback-panel feedback-panel-error">
+          <h2>Admin access required</h2>
+          <p>You do not have permission to manage application roles.</p>
+        </div>
+      ) : null}
+
+      {canManageRoles && loadError ? (
+        <div className="feedback-panel feedback-panel-error">
+          <h2>Could not load users</h2>
+          <p>{loadError}</p>
+          <button type="button" onClick={() => setReloadToken((current) => current + 1)}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {canManageRoles && !loadError && isLoading ? (
+        <div className="feedback-panel feedback-panel-loading" role="status" aria-live="polite">
+          Loading role administration.
+        </div>
+      ) : null}
+
+      {canManageRoles && !loadError && !isLoading ? (
+        <>
+          <section aria-labelledby="operations-session-heading" className="feedback-panel">
+            <h2 id="operations-session-heading">Current session</h2>
+            <p>{sessionIdentity?.email ?? "Session unavailable"}</p>
+            <p>Roles: {sessionIdentity?.roles.join(", ") || "none"}</p>
+          </section>
+
+          <section aria-labelledby="operations-users-heading">
+            <h2 id="operations-users-heading">Users and roles</h2>
+            {sortedUsers.length === 0 ? (
+              <div className="feedback-panel">
+                <p>No authenticated users have been provisioned yet.</p>
+              </div>
+            ) : (
+              <ul className="people-management-list" aria-label="Role-managed users">
+                {sortedUsers.map((user) => {
+                  const draftRoles = draftRolesByUserId[user.user_id] ?? [];
+                  const isBusy = busyByUserId[user.user_id] ?? false;
+                  const rowError = errorByUserId[user.user_id] ?? "";
+                  return (
+                    <li key={user.user_id} className="people-management-card">
+                      <div className="people-management-summary">
+                        <div>
+                          <h3>{user.display_name ?? user.email}</h3>
+                          <p>{user.email}</p>
+                          <p>Provider: {user.auth_provider}</p>
+                        </div>
+                      </div>
+                      <div role="group" aria-label={`Roles for ${user.email}`}>
+                        {ROLE_OPTIONS.map((option) => (
+                          <label key={option.role}>
+                            <input
+                              type="checkbox"
+                              checked={draftRoles.includes(option.role)}
+                              disabled={isBusy}
+                              onChange={() => toggleRole(user.user_id, option.role)}
+                            />
+                            {option.label}
+                          </label>
+                        ))}
+                      </div>
+                      {rowError ? <p role="alert">{rowError}</p> : null}
+                      <button
+                        type="button"
+                        disabled={isBusy}
+                        onClick={() => {
+                          void saveRoles(user.user_id);
+                        }}
+                      >
+                        {isBusy ? "Saving..." : `Save roles for ${user.email}`}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/ui/src/pages/library/useLibraryUrlSync.ts
+++ b/apps/ui/src/pages/library/useLibraryUrlSync.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import type { Location, NavigateFunction } from "react-router-dom";
 import type { LibraryViewRouteState } from "../libraryRouteState";
+import { DEFAULT_SEARCH_PAGE_LIMIT } from "./libraryPageSize";
 import { buildLibraryUrlQuery } from "./libraryRouteSearchState";
 import { saveLastLibraryUrl, saveLibraryViewState } from "./libraryRouteMemory";
 import type {
@@ -67,12 +68,19 @@ export function useLibraryUrlSync({
   const lastAppliedParsedUrlStateSignatureRef = useRef<string | null>(parsedUrlStateSignature);
   const shouldRestoreInitialViewStateRef = useRef(shouldRestoreInitialViewState);
 
-  function setPage(pageNumber: number, replace = false) {
+  function setPage(pageNumber: number, replace = false, nextPageSize?: number) {
     const nextParams = new URLSearchParams(location.search);
     if (pageNumber <= 1) {
       nextParams.delete("page");
     } else {
       nextParams.set("page", String(pageNumber));
+    }
+    if (nextPageSize === undefined) {
+      // Preserve the current page-size query parameter when only paging changes.
+    } else if (nextPageSize <= 0 || nextPageSize === DEFAULT_SEARCH_PAGE_LIMIT) {
+      nextParams.delete("pageSize");
+    } else {
+      nextParams.set("pageSize", String(nextPageSize));
     }
 
     const nextSearch = nextParams.toString();

--- a/apps/ui/src/pages/operations/operationsApi.ts
+++ b/apps/ui/src/pages/operations/operationsApi.ts
@@ -1,0 +1,42 @@
+import { readErrorDetail } from "../face-labeling/faceLabelingErrors";
+
+export type AdminUserRecord = {
+  user_id: string;
+  auth_provider: string;
+  auth_subject: string;
+  email: string;
+  display_name: string | null;
+  roles: string[];
+  created_ts: string;
+  updated_ts: string;
+};
+
+async function errorMessage(response: Response, fallback: string): Promise<string> {
+  const detail = await readErrorDetail(response);
+  return detail ?? fallback;
+}
+
+export async function fetchAdminUsers(signal?: AbortSignal): Promise<AdminUserRecord[]> {
+  const response = await fetch("/api/v1/admin/users", { signal });
+  if (!response.ok) {
+    throw new Error(await errorMessage(response, `Admin users request failed (${response.status})`));
+  }
+  return (await response.json()) as AdminUserRecord[];
+}
+
+export async function replaceAdminUserRoles(
+  userId: string,
+  roles: string[]
+): Promise<AdminUserRecord> {
+  const response = await fetch(`/api/v1/admin/users/${userId}/roles`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ roles })
+  });
+  if (!response.ok) {
+    throw new Error(await errorMessage(response, `Role update failed (${response.status})`));
+  }
+  return (await response.json()) as AdminUserRecord;
+}

--- a/apps/ui/src/pages/shared/BrowsePagination.tsx
+++ b/apps/ui/src/pages/shared/BrowsePagination.tsx
@@ -55,7 +55,7 @@ export function BrowsePagination({
         onPageChange={({ selected }) => onPageChange(selected + 1)}
         pageLabelBuilder={(page) => `[${page}]`}
         ariaLabelBuilder={(page, isSelected) => (
-          pageAriaLabelBuilder ? pageAriaLabelBuilder(page, isSelected) : `Page ${page}`
+          pageAriaLabelBuilder ? pageAriaLabelBuilder(page, Boolean(isSelected)) : `Page ${page}`
         )}
         previousAriaLabel={previousAriaLabel}
         nextAriaLabel={nextAriaLabel}

--- a/apps/ui/src/routes/routeDefinitions.ts
+++ b/apps/ui/src/routes/routeDefinitions.ts
@@ -73,7 +73,7 @@ export const PRIMARY_ROUTE_DEFINITIONS: PrimaryRouteDefinition[] = [
     path: "/operations",
     navLabel: "Operations",
     title: "Operations",
-    description: "Operational admin workflow surface placeholder.",
+    description: "Operational role management and admin workflow surface.",
     handoff: baseHandoffExpectation
   }
 ];

--- a/apps/ui/src/session/sessionIdentity.test.ts
+++ b/apps/ui/src/session/sessionIdentity.test.ts
@@ -17,14 +17,28 @@ describe("sessionIdentity", () => {
       userId: "operator-1",
       displayName: "Operator One",
       email: "op1@photo-org.local",
-      capabilities: { addToAlbum: true, export: false }
+      roles: ["viewer", "contributor"],
+      capabilities: {
+        addToAlbum: true,
+        export: false,
+        reviewFaces: true,
+        manageRoles: false,
+        manageSources: false
+      }
     };
 
     expect(resolveInitialSessionIdentity()).toEqual({
       userId: "operator-1",
       displayName: "Operator One",
       email: "op1@photo-org.local",
-      capabilities: { addToAlbum: true, export: false }
+      roles: ["viewer", "contributor"],
+      capabilities: {
+        addToAlbum: true,
+        export: false,
+        reviewFaces: true,
+        manageRoles: false,
+        manageSources: false
+      }
     });
   });
 
@@ -33,7 +47,14 @@ describe("sessionIdentity", () => {
       userId: "operator-1",
       displayName: "Operator One",
       email: "op1@photo-org.local",
-      capabilities: { addToAlbum: "yes", export: false }
+      roles: ["viewer"],
+      capabilities: {
+        addToAlbum: "yes",
+        export: false,
+        reviewFaces: false,
+        manageRoles: false,
+        manageSources: false
+      }
     };
 
     expect(resolveInitialSessionIdentity()).toBeNull();

--- a/apps/ui/src/session/sessionIdentity.ts
+++ b/apps/ui/src/session/sessionIdentity.ts
@@ -1,12 +1,16 @@
 export interface SessionCapabilities {
   addToAlbum: boolean;
   export: boolean;
+  reviewFaces: boolean;
+  manageRoles: boolean;
+  manageSources: boolean;
 }
 
 export interface SessionIdentity {
   userId: string;
   displayName: string;
   email: string;
+  roles: string[];
   capabilities: SessionCapabilities;
 }
 
@@ -14,9 +18,13 @@ export const DEMO_SESSION_IDENTITY: SessionIdentity = {
   userId: "demo-operator",
   displayName: "Demo Operator",
   email: "operator@photo-org.local",
+  roles: ["admin"],
   capabilities: {
     addToAlbum: true,
-    export: true
+    export: true,
+    reviewFaces: true,
+    manageRoles: true,
+    manageSources: true
   }
 };
 
@@ -24,6 +32,7 @@ interface SessionIdentityBootstrapShape {
   userId?: unknown;
   displayName?: unknown;
   email?: unknown;
+  roles?: unknown;
   capabilities?: unknown;
 }
 
@@ -47,6 +56,8 @@ function isSessionIdentity(value: unknown): value is SessionIdentity {
     candidate.displayName.length > 0 &&
     typeof candidate.email === "string" &&
     candidate.email.length > 0 &&
+    Array.isArray(candidate.roles) &&
+    candidate.roles.every((role) => typeof role === "string") &&
     isSessionCapabilities(candidate.capabilities)
   );
 }
@@ -59,8 +70,39 @@ function isSessionCapabilities(value: unknown): value is SessionCapabilities {
   const candidate = value as Record<string, unknown>;
   return (
     typeof candidate.addToAlbum === "boolean" &&
-    typeof candidate.export === "boolean"
+    typeof candidate.export === "boolean" &&
+    typeof candidate.reviewFaces === "boolean" &&
+    typeof candidate.manageRoles === "boolean" &&
+    typeof candidate.manageSources === "boolean"
   );
+}
+
+function adaptSessionIdentityPayload(payload: {
+  user_id: string;
+  display_name: string | null;
+  email: string;
+  roles: string[];
+  capabilities: {
+    add_to_album: boolean;
+    export: boolean;
+    review_faces: boolean;
+    manage_roles: boolean;
+    manage_sources: boolean;
+  };
+}): SessionIdentity {
+  return {
+    userId: payload.user_id,
+    displayName: payload.display_name ?? payload.email,
+    email: payload.email,
+    roles: payload.roles,
+    capabilities: {
+      addToAlbum: payload.capabilities.add_to_album,
+      export: payload.capabilities.export,
+      reviewFaces: payload.capabilities.review_faces,
+      manageRoles: payload.capabilities.manage_roles,
+      manageSources: payload.capabilities.manage_sources
+    }
+  };
 }
 
 export function resolveInitialSessionIdentity(): SessionIdentity | null {
@@ -79,4 +121,29 @@ export function resolveInitialSessionIdentity(): SessionIdentity | null {
   }
 
   return null;
+}
+
+export async function fetchCurrentSessionIdentity(signal?: AbortSignal): Promise<SessionIdentity | null> {
+  const response = await fetch("/api/v1/admin/session", { signal });
+  if (response.status === 401 || response.status === 403) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Session request failed (${response.status})`);
+  }
+  return adaptSessionIdentityPayload(
+    (await response.json()) as {
+      user_id: string;
+      display_name: string | null;
+      email: string;
+      roles: string[];
+      capabilities: {
+        add_to_album: boolean;
+        export: boolean;
+        review_faces: boolean;
+        manage_roles: boolean;
+        manage_sources: boolean;
+      };
+    }
+  );
 }

--- a/apps/ui/tests/e2e/journeys/app-shell-journeys.spec.ts
+++ b/apps/ui/tests/e2e/journeys/app-shell-journeys.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from "@playwright/test";
+import { bootstrapAdminSession } from "../support/session";
 
 interface ShellViewport {
   label: string;
@@ -183,6 +184,7 @@ test("JRN-P2-shared-feedback-surfaces @journey @smoke", async ({ page }) => {
 });
 
 test("JRN-P2-responsive-shell-layout @journey @smoke", async ({ page }) => {
+  await bootstrapAdminSession(page);
   await page.goto("/library");
 
   for (const viewport of RESPONSIVE_VIEWPORTS) {

--- a/apps/ui/tests/e2e/support/session.ts
+++ b/apps/ui/tests/e2e/support/session.ts
@@ -1,0 +1,43 @@
+import type { Page } from "@playwright/test";
+
+const ADMIN_SESSION_PAYLOAD = {
+  userId: "admin-user",
+  displayName: "Admin User",
+  email: "admin@example.com",
+  roles: ["admin"],
+  capabilities: {
+    addToAlbum: true,
+    export: true,
+    reviewFaces: true,
+    manageRoles: true,
+    manageSources: true
+  }
+};
+
+const ADMIN_SESSION_API_RESPONSE = {
+  user_id: "admin-user",
+  display_name: "Admin User",
+  email: "admin@example.com",
+  roles: ["admin"],
+  capabilities: {
+    add_to_album: true,
+    export: true,
+    review_faces: true,
+    manage_roles: true,
+    manage_sources: true
+  }
+};
+
+export async function bootstrapAdminSession(page: Page) {
+  await page.addInitScript((payload) => {
+    window.__PHOTO_ORG_SESSION__ = payload;
+  }, ADMIN_SESSION_PAYLOAD);
+
+  await page.route("**/api/v1/admin/session", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ADMIN_SESSION_API_RESPONSE)
+    });
+  });
+}

--- a/apps/ui/tests/e2e/technical/navigation-state.spec.ts
+++ b/apps/ui/tests/e2e/technical/navigation-state.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { expectPrimaryLinkActive } from "../support/navAsserts";
+import { bootstrapAdminSession } from "../support/session";
 
 test("technical: deep-link query state renders expected route shell @technical", async ({ page }) => {
   await page.goto("/library?query=lake");
@@ -13,6 +14,7 @@ test("technical: deep-link query state renders expected route shell @technical",
 test(
   "technical: browser back and forward keep shell mounted with route-local content @technical",
   async ({ page }) => {
+    await bootstrapAdminSession(page);
     await page.goto("/library");
 
     const banner = page.getByRole("banner");


### PR DESCRIPTION
## Summary
- add backend admin/session APIs for DB-backed RBAC user and role management
- add an Operations admin UI for viewing users and editing assigned roles
- fix library page-size navigation state persistence and associated UI test/build issues

## Verification
- `uv run python -m pytest apps/api/tests/test_auth_rbac.py apps/api/tests/test_main.py -q`
- `npm --prefix apps/ui test -- src/session/sessionIdentity.test.ts src/app/AppShell.test.tsx src/pages/OperationsRoutePage.test.tsx src/routes/routeDefinitions.test.ts`
- `npm --prefix apps/ui run build`