### PR TITLE
feat: default storage polling to incremental mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,8 +126,8 @@ Current high-value targets:
   - validate the checked-in `seed-corpus/` inventory and manifest
 - `make seed-corpus-load`
   - migrate and load the checked-in `seed-corpus/` into the local development database
-- `curl -sS -X POST http://127.0.0.1:<api-port>/api/v1/internal/storage-sources/poll -H 'Content-Type: application/json' -H 'X-Worker-Role: ingest-processor' -d '{"queue_process_limit":100}'`
-  - trigger the central polling loop and drain queued ingest work through the internal worker endpoint
+- `curl -sS -X POST http://127.0.0.1:<api-port>/api/v1/internal/storage-sources/poll -H 'Content-Type: application/json' -H 'X-Worker-Role: ingest-processor' -d '{"queue_process_limit":100,"poll_mode":"incremental"}'`
+  - trigger the central polling loop in incremental mode and drain queued ingest work through the internal worker endpoint
 - `uv run python apps/api/scripts/generate_openapi.py`
   - regenerate the generated OpenAPI YAML artifact at `apps/api/.generated/openapi.yaml` from the current FastAPI app
   - the API also serves the same runtime schema at `GET /openapi.yaml` and the Swagger UI docs at `GET /docs`
@@ -243,7 +243,8 @@ For missing-file reconciliation verification, run `uv run python -m pytest apps/
 That targeted suite exercises a temporary watched-folder fixture and simulated time so contributors can verify `active`, `missing`, `deleted`, and recovery transitions without bringing up the full worker stack.
 
 For the source-aware central polling loop, register a storage source plus watched folder first, then call `POST /api/v1/internal/storage-sources/poll` with `X-Worker-Role: ingest-processor`.
-That endpoint validates source markers before scanning, reconciles only enabled watched folders attached to registered storage sources, enqueues candidate work for downstream extraction, and drains the ingest queue to persistence-ready completion for that trigger request.
+That endpoint defaults to `poll_mode="incremental"`: it validates source markers, scans enabled watched folders attached to registered storage sources, enqueues candidate work for downstream extraction, and drains the ingest queue to persistence-ready completion for that trigger request.
+Use `poll_mode="full"` when you need missing-file reconciliation and deleted-path lifecycle updates in the same poll request.
 
 ### Automated Version Updates
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ The project is still being shaped and documented. The architecture, operational 
 
 The current Phase 0 development path now uses an API-owned persistence boundary for ingest work:
 
-- `poll-storage-sources` now performs discovery and candidate scheduling only
+- `poll-storage-sources` now defaults to incremental discovery and candidate scheduling only
+- `poll-storage-sources` accepts an explicit full-reconciliation mode when missing-file and deleted-path updates are needed
 - queued workers hash content and, when needed, run metadata extraction, thumbnail generation, and face detection before persistence
 - duplicate-content files reuse existing extracted artifacts by SHA instead of re-running full analysis
 - the API owns queue processing and domain-table mutation

--- a/apps/api/app/processing/ingest.py
+++ b/apps/api/app/processing/ingest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import importlib
 from datetime import datetime
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol
 
 from app.db.queue import IngestQueueStore
 from app.processing.ingest_common import IngestResult, iter_photo_files
@@ -78,10 +78,12 @@ def poll_registered_storage_sources(
     now: datetime | None = None,
     missing_file_grace_period_days: int | None = None,
     poll_chunk_size: int = 100,
+    poll_mode: Literal["incremental", "full"] = "incremental",
 ) -> IngestResult:
     return ingest_polling_module.poll_registered_storage_sources(
         database_url=database_url,
         now=now,
         missing_file_grace_period_days=missing_file_grace_period_days,
         poll_chunk_size=poll_chunk_size,
+        poll_mode=poll_mode,
     )

--- a/apps/api/app/processing/ingest_polling.py
+++ b/apps/api/app/processing/ingest_polling.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from stat import S_ISDIR
-from typing import Callable, Iterable, Iterator
+from typing import Callable, Iterable, Iterator, Literal
 
 from sqlalchemy import select
 from sqlalchemy.engine import Connection
@@ -33,6 +33,9 @@ from app.services.file_reconciliation import (
 from app.services.source_registration import SourceRegistrationError, read_source_marker
 from app.services.thumbnails import generate_thumbnail
 from app.storage import create_db_engine, photo_files, storage_source_aliases, watched_folders
+
+PollMode = Literal["incremental", "full"]
+
 
 @dataclass(frozen=True)
 class RegisteredWatchedFolderTarget:
@@ -106,8 +109,10 @@ def poll_registered_storage_sources(
     now: datetime | None = None,
     missing_file_grace_period_days: int | None = None,
     poll_chunk_size: int = 100,
+    poll_mode: PollMode = "incremental",
 ) -> IngestResult:
     _validate_chunk_size(poll_chunk_size)
+    _validate_poll_mode(poll_mode)
     result = IngestResult()
     at = now if now is not None else utc_now()
     grace_period_days = resolve_missing_file_grace_period_days(missing_file_grace_period_days)
@@ -150,7 +155,9 @@ def poll_registered_storage_sources(
                     alias_root=alias_root,
                     relative_path=target.relative_path,
                 )
-                observed_relative_paths: set[str] = set()
+                observed_relative_paths: set[str] | None = (
+                    set() if poll_mode == "full" else None
+                )
                 touched_photo_ids: set[str] = set()
                 try:
                     _validate_scan_root(scan_root)
@@ -190,19 +197,22 @@ def poll_registered_storage_sources(
                         result.updated += outcome.updated
                         result.errors.extend(outcome.error_messages)
                     with engine.begin() as connection:
-                        _finalize_watched_folder_scan(
-                            connection,
-                            watched_folder_id=target.watched_folder_id,
-                            observed_relative_paths=observed_relative_paths,
-                            touched_photo_ids=touched_photo_ids,
-                            now=at,
-                            missing_file_grace_period_days=grace_period_days,
-                        )
-                        record_watched_folder_scan_success(
-                            connection,
-                            watched_folder_id=target.watched_folder_id,
-                            now=at,
-                        )
+                        if poll_mode == "full":
+                            assert observed_relative_paths is not None
+                            _finalize_full_watched_folder_scan(
+                                connection,
+                                watched_folder_id=target.watched_folder_id,
+                                observed_relative_paths=observed_relative_paths,
+                                touched_photo_ids=touched_photo_ids,
+                                now=at,
+                                missing_file_grace_period_days=grace_period_days,
+                            )
+                        else:
+                            _finalize_incremental_watched_folder_scan(
+                                connection,
+                                watched_folder_id=target.watched_folder_id,
+                                now=at,
+                            )
                 except Exception as exc:
                     with engine.begin() as connection:
                         record_watched_folder_scan_failure(
@@ -262,6 +272,11 @@ def _validate_chunk_size(chunk_size: int) -> None:
         raise ValueError("chunk_size must be at least 1")
 
 
+def _validate_poll_mode(poll_mode: PollMode) -> None:
+    if poll_mode not in {"incremental", "full"}:
+        raise ValueError(f"unsupported poll mode: {poll_mode}")
+
+
 def _process_watched_folder_chunk(
     connection: Connection,
     *,
@@ -271,7 +286,7 @@ def _process_watched_folder_chunk(
     canonical_path_for_relative_path: Callable[[str], str],
     reuse_existing_photo_by_sha: bool,
     now: datetime,
-    observed_relative_paths: set[str],
+    observed_relative_paths: set[str] | None,
     queue_store: IngestQueueStore | None = None,
     storage_source_id: str | None = None,
 ) -> tuple[WatchedFolderPollOutcome, set[str]]:
@@ -285,7 +300,8 @@ def _process_watched_folder_chunk(
     for photo_path in photo_paths:
         scanned += 1
         relative_path = relative_photo_path(source_root, photo_path)
-        observed_relative_paths.add(relative_path)
+        if observed_relative_paths is not None:
+            observed_relative_paths.add(relative_path)
         if reuse_existing_photo_by_sha:
             assert queue_store is not None
             assert storage_source_id is not None
@@ -382,7 +398,20 @@ def _process_watched_folder_chunk(
     )
 
 
-def _finalize_watched_folder_scan(
+def _finalize_incremental_watched_folder_scan(
+    connection: Connection,
+    *,
+    watched_folder_id: str,
+    now: datetime,
+) -> None:
+    record_watched_folder_scan_success(
+        connection,
+        watched_folder_id=watched_folder_id,
+        now=now,
+    )
+
+
+def _finalize_full_watched_folder_scan(
     connection: Connection,
     *,
     watched_folder_id: str,
@@ -401,6 +430,11 @@ def _finalize_watched_folder_scan(
         )
     )
     refresh_photo_deleted_timestamps(connection, photo_ids=touched_photo_ids, now=now)
+    record_watched_folder_scan_success(
+        connection,
+        watched_folder_id=watched_folder_id,
+        now=now,
+    )
 
 
 def _reconcile_watched_folder_root(
@@ -448,7 +482,7 @@ def _reconcile_watched_folder_root(
         now=now,
         observed_relative_paths=observed_relative_paths,
     )
-    _finalize_watched_folder_scan(
+    _finalize_full_watched_folder_scan(
         connection,
         watched_folder_id=watched_folder_id,
         observed_relative_paths=observed_relative_paths,

--- a/apps/api/app/routers/ingest_queue.py
+++ b/apps/api/app/routers/ingest_queue.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.orm import Session
@@ -68,6 +70,10 @@ class TriggerStorageSourcePollingRequest(BaseModel):
     drain_queue: bool = Field(
         default=True,
         description="When false, only scan and enqueue candidates without draining queued ingest work.",
+    )
+    poll_mode: Literal["incremental", "full"] = Field(
+        default="incremental",
+        description="Select incremental discovery or full missing-file reconciliation.",
     )
 
 
@@ -279,6 +285,7 @@ def poll_storage_sources_endpoint(
     result = trigger_storage_source_polling(
         queue_process_limit=body.queue_process_limit,
         drain_queue=body.drain_queue,
+        poll_mode=body.poll_mode,
     )
     return TriggerStorageSourcePollingResponse(
         scanned=result.scanned,

--- a/apps/api/app/services/storage_source_polling.py
+++ b/apps/api/app/services/storage_source_polling.py
@@ -41,9 +41,13 @@ def trigger_storage_source_polling(
     database_url: str | Path | None = None,
     queue_process_limit: int = 100,
     drain_queue: bool = True,
+    poll_mode: str = "incremental",
 ) -> TriggerStorageSourcePollingResult:
     initial_photo_count = _count_photos(database_url)
-    poll_result = poll_registered_storage_sources(database_url=database_url)
+    poll_result = poll_registered_storage_sources(
+        database_url=database_url,
+        poll_mode=poll_mode,
+    )
 
     queue_processed = 0
     queue_failed = 0

--- a/apps/api/tests/test_ingest.py
+++ b/apps/api/tests/test_ingest.py
@@ -215,11 +215,13 @@ def test_ingest_facade_poll_registered_storage_sources_delegates_to_polling_modu
         now=None,
         missing_file_grace_period_days=None,
         poll_chunk_size=100,
+        poll_mode="incremental",
     ):
         assert database_url == f"sqlite:///{tmp_path / 'facade-delegation.db'}"
         assert now is None
         assert missing_file_grace_period_days is None
         assert poll_chunk_size == 100
+        assert poll_mode == "incremental"
         return sentinel_result
 
     fake_module.poll_registered_storage_sources = fake_poll_registered_storage_sources
@@ -1341,6 +1343,7 @@ def test_poll_registered_storage_sources_reassesses_existing_locations_for_same_
         database_url=db_url,
         now=now + timedelta(minutes=5),
         missing_file_grace_period_days=0,
+        poll_mode="full",
     )
 
     assert result.errors == []

--- a/apps/api/tests/test_ingest_polling.py
+++ b/apps/api/tests/test_ingest_polling.py
@@ -8,10 +8,11 @@ from sqlalchemy import create_engine, func, select
 
 from app.db.queue import IngestQueueStore
 from app.migrations import upgrade_database
+from app.services.ingest_queue_processor import process_pending_ingest_queue
 from app.services.source_registration import MARKER_FILENAME, write_source_marker
 from app.services.storage_sources import attach_storage_source_alias, create_storage_source
 from app.services.watched_folders import create_watched_folder
-from app.storage import photos, storage_sources, watched_folders
+from app.storage import photo_files, photos, storage_sources, watched_folders
 from photoorg_db_schema import ingest_runs
 
 pytest.importorskip("PIL")
@@ -277,6 +278,7 @@ def test_poll_registered_storage_sources_rolls_back_candidate_queue_rows_when_ch
         database_url=database_url,
         now=now,
         poll_chunk_size=2,
+        poll_mode="full",
     )
 
     assert result.errors == [f"watched_folder:{watched_folder['watched_folder_id']}: forced chunk failure"]
@@ -494,6 +496,7 @@ def test_poll_registered_storage_sources_records_failed_outcome_for_late_reconci
         database_url=database_url,
         now=now,
         poll_chunk_size=2,
+        poll_mode="full",
     )
 
     with engine.connect() as connection:
@@ -613,10 +616,214 @@ def test_poll_registered_storage_sources_defers_missing_file_reconciliation_unti
         database_url=database_url,
         now=now,
         poll_chunk_size=1,
+        poll_mode="full",
     )
 
     assert result.scanned == 3
     assert reconciliation_calls == [{"first.jpg", "third.jpg", "fourth.jpg"}]
+
+
+def test_poll_registered_storage_sources_incremental_mode_skips_missing_reconciliation(tmp_path):
+    from app.processing.ingest_polling import poll_registered_storage_sources
+
+    database_url = f"sqlite:///{tmp_path / 'poll-incremental-skip-reconcile.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 6, 8, 12, 0, tzinfo=UTC)
+
+    root = tmp_path / "source-root"
+    watched = root / "imports"
+    watched.mkdir(parents=True)
+    first_photo = watched / "photo_000.jpg"
+    second_photo = watched / "photo_001.jpg"
+    _write_test_image(first_photo)
+    _write_test_image(second_photo)
+
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Source",
+            marker_filename=MARKER_FILENAME,
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            now=now,
+        )
+        watched_folder = create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            watched_path=watched.as_posix(),
+            display_name="Imports",
+            now=now,
+        )
+        write_source_marker(root, storage_source_id=source["storage_source_id"])
+
+    poll_registered_storage_sources(database_url=database_url, now=now, poll_mode="full")
+    first_pass = process_pending_ingest_queue(database_url, limit=10)
+    second_pass = process_pending_ingest_queue(database_url, limit=10)
+    assert first_pass.processed == 2
+    assert second_pass.processed == 2
+    second_photo.unlink()
+
+    later = now.replace(hour=13)
+    result = poll_registered_storage_sources(
+        database_url=database_url,
+        now=later,
+        poll_mode="incremental",
+    )
+
+    assert result.errors == []
+    with engine.connect() as connection:
+        row = connection.execute(
+            select(
+                photo_files.c.lifecycle_state,
+                photo_files.c.missing_ts,
+                photo_files.c.deleted_ts,
+            ).where(
+                photo_files.c.watched_folder_id == watched_folder["watched_folder_id"],
+                photo_files.c.relative_path == "photo_001.jpg",
+            )
+        ).mappings().one()
+    assert row["lifecycle_state"] == "active"
+    assert row["missing_ts"] is None
+    assert row["deleted_ts"] is None
+
+
+def test_poll_registered_storage_sources_full_mode_marks_missing_files(tmp_path):
+    from app.processing.ingest_polling import poll_registered_storage_sources
+
+    database_url = f"sqlite:///{tmp_path / 'poll-full-reconcile.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 6, 8, 12, 0, tzinfo=UTC)
+
+    root = tmp_path / "source-root"
+    watched = root / "imports"
+    watched.mkdir(parents=True)
+    first_photo = watched / "photo_000.jpg"
+    second_photo = watched / "photo_001.jpg"
+    _write_test_image(first_photo)
+    _write_test_image(second_photo)
+
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Source",
+            marker_filename=MARKER_FILENAME,
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            now=now,
+        )
+        watched_folder = create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            watched_path=watched.as_posix(),
+            display_name="Imports",
+            now=now,
+        )
+        write_source_marker(root, storage_source_id=source["storage_source_id"])
+
+    poll_registered_storage_sources(database_url=database_url, now=now, poll_mode="full")
+    first_pass = process_pending_ingest_queue(database_url, limit=10)
+    second_pass = process_pending_ingest_queue(database_url, limit=10)
+    assert first_pass.processed == 2
+    assert second_pass.processed == 2
+    second_photo.unlink()
+
+    later = now.replace(hour=13)
+    result = poll_registered_storage_sources(
+        database_url=database_url,
+        now=later,
+        poll_mode="full",
+        missing_file_grace_period_days=0,
+    )
+
+    assert result.errors == []
+    with engine.connect() as connection:
+        row = connection.execute(
+            select(
+                photo_files.c.lifecycle_state,
+                photo_files.c.missing_ts,
+                photo_files.c.deleted_ts,
+            ).where(
+                photo_files.c.watched_folder_id == watched_folder["watched_folder_id"],
+                photo_files.c.relative_path == "photo_001.jpg",
+            )
+        ).mappings().one()
+    assert row["lifecycle_state"] == "deleted"
+    assert row["missing_ts"] == later.replace(tzinfo=None)
+    assert row["deleted_ts"] == later.replace(tzinfo=None)
+
+
+def test_poll_registered_storage_sources_defaults_to_incremental_mode(tmp_path):
+    from app.processing.ingest_polling import poll_registered_storage_sources
+
+    database_url = f"sqlite:///{tmp_path / 'poll-default-incremental.db'}"
+    upgrade_database(database_url)
+    engine = create_engine(database_url, future=True)
+    now = datetime(2026, 6, 8, 14, 0, tzinfo=UTC)
+
+    root = tmp_path / "source-root"
+    watched = root / "imports"
+    watched.mkdir(parents=True)
+    first_photo = watched / "photo_000.jpg"
+    second_photo = watched / "photo_001.jpg"
+    _write_test_image(first_photo)
+    _write_test_image(second_photo)
+
+    with engine.begin() as connection:
+        source = create_storage_source(
+            connection,
+            display_name="Source",
+            marker_filename=MARKER_FILENAME,
+            marker_version=1,
+            now=now,
+        )
+        attach_storage_source_alias(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            now=now,
+        )
+        watched_folder = create_watched_folder(
+            connection,
+            storage_source_id=source["storage_source_id"],
+            alias_path=root.as_posix(),
+            watched_path=watched.as_posix(),
+            display_name="Imports",
+            now=now,
+        )
+        write_source_marker(root, storage_source_id=source["storage_source_id"])
+
+    poll_registered_storage_sources(database_url=database_url, now=now, poll_mode="full")
+    first_pass = process_pending_ingest_queue(database_url, limit=10)
+    second_pass = process_pending_ingest_queue(database_url, limit=10)
+    assert first_pass.processed == 2
+    assert second_pass.processed == 2
+    second_photo.unlink()
+
+    later = now.replace(hour=15)
+    poll_registered_storage_sources(database_url=database_url, now=later)
+
+    with engine.connect() as connection:
+        row = connection.execute(
+            select(photo_files.c.lifecycle_state).where(
+                photo_files.c.watched_folder_id == watched_folder["watched_folder_id"],
+                photo_files.c.relative_path == "photo_001.jpg",
+            )
+        ).scalar_one()
+    assert row == "active"
 
 
 def test_reconcile_directory_processes_a_watched_folder_end_to_end(tmp_path):

--- a/apps/api/tests/test_ingest_queue_api.py
+++ b/apps/api/tests/test_ingest_queue_api.py
@@ -329,9 +329,11 @@ def test_poll_storage_sources_endpoint_forwards_queue_process_limit(
         *,
         queue_process_limit: int = 100,
         drain_queue: bool = True,
+        poll_mode: str = "incremental",
     ):
         captured["queue_process_limit"] = queue_process_limit
         captured["drain_queue"] = drain_queue
+        captured["poll_mode"] = poll_mode
         return Result()
 
     monkeypatch.setattr(
@@ -346,7 +348,11 @@ def test_poll_storage_sources_endpoint_forwards_queue_process_limit(
     )
 
     assert response.status_code == 200
-    assert captured == {"queue_process_limit": 333, "drain_queue": False}
+    assert captured == {
+        "queue_process_limit": 333,
+        "drain_queue": False,
+        "poll_mode": "incremental",
+    }
     assert response.json() == {
         "scanned": 10,
         "enqueued": 7,
@@ -357,6 +363,100 @@ def test_poll_storage_sources_endpoint_forwards_queue_process_limit(
         "retryable_errors": 2,
         "error_count": 4,
         "poll_errors": ["marker mismatch"],
+    }
+
+
+def test_poll_storage_sources_endpoint_defaults_to_incremental_mode(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, object] = {}
+
+    class Result:
+        scanned = 1
+        enqueued = 1
+        inserted = 0
+        updated = 0
+        queue_processed = 0
+        queue_failed = 0
+        queue_retryable_errors = 0
+        poll_errors = ()
+        error_count = 0
+
+    def fake_trigger_storage_source_polling(
+        *,
+        queue_process_limit: int = 100,
+        drain_queue: bool = True,
+        poll_mode: str = "incremental",
+    ):
+        captured["queue_process_limit"] = queue_process_limit
+        captured["drain_queue"] = drain_queue
+        captured["poll_mode"] = poll_mode
+        return Result()
+
+    monkeypatch.setattr(
+        "app.routers.ingest_queue.trigger_storage_source_polling",
+        fake_trigger_storage_source_polling,
+    )
+
+    response = client.post(
+        "/api/v1/internal/storage-sources/poll",
+        headers={"X-Worker-Role": "ingest-processor"},
+        json={},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "queue_process_limit": 100,
+        "drain_queue": True,
+        "poll_mode": "incremental",
+    }
+
+
+def test_poll_storage_sources_endpoint_forwards_explicit_full_mode(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: dict[str, object] = {}
+
+    class Result:
+        scanned = 10
+        enqueued = 7
+        inserted = 3
+        updated = 2
+        queue_processed = 5
+        queue_failed = 1
+        queue_retryable_errors = 2
+        poll_errors = ("marker mismatch",)
+        error_count = 4
+
+    def fake_trigger_storage_source_polling(
+        *,
+        queue_process_limit: int = 100,
+        drain_queue: bool = True,
+        poll_mode: str = "incremental",
+    ):
+        captured["queue_process_limit"] = queue_process_limit
+        captured["drain_queue"] = drain_queue
+        captured["poll_mode"] = poll_mode
+        return Result()
+
+    monkeypatch.setattr(
+        "app.routers.ingest_queue.trigger_storage_source_polling",
+        fake_trigger_storage_source_polling,
+    )
+
+    response = client.post(
+        "/api/v1/internal/storage-sources/poll",
+        headers={"X-Worker-Role": "ingest-processor"},
+        json={"queue_process_limit": 333, "drain_queue": False, "poll_mode": "full"},
+    )
+
+    assert response.status_code == 200
+    assert captured == {
+        "queue_process_limit": 333,
+        "drain_queue": False,
+        "poll_mode": "full",
     }
 
 

--- a/apps/api/tests/test_storage_source_polling_service.py
+++ b/apps/api/tests/test_storage_source_polling_service.py
@@ -103,3 +103,43 @@ def test_trigger_storage_source_polling_can_skip_queue_draining(monkeypatch):
     assert result.queue_retryable_errors == 0
     assert result.poll_errors == ()
     assert result.error_count == 0
+
+
+def test_trigger_storage_source_polling_forwards_poll_mode(monkeypatch):
+    captured: dict[str, object] = {}
+    photo_counts = iter([11, 11])
+
+    def fake_poll_registered_storage_sources(**kwargs):
+        captured["database_url"] = kwargs.get("database_url")
+        captured["poll_mode"] = kwargs.get("poll_mode")
+        return type(
+            "PollResult",
+            (),
+            {
+                "scanned": 4,
+                "enqueued": 4,
+                "updated": 0,
+                "errors": [],
+            },
+        )()
+
+    monkeypatch.setattr(
+        polling_service,
+        "poll_registered_storage_sources",
+        fake_poll_registered_storage_sources,
+    )
+    monkeypatch.setattr(
+        polling_service,
+        "_count_photos",
+        lambda database_url=None: next(photo_counts),
+    )
+
+    result = polling_service.trigger_storage_source_polling(
+        queue_process_limit=77,
+        drain_queue=False,
+        poll_mode="full",
+    )
+
+    assert captured["poll_mode"] == "full"
+    assert result.scanned == 4
+    assert result.enqueued == 4


### PR DESCRIPTION
## Summary
- default internal storage-source polling to incremental discovery mode
- add explicit full reconciliation mode for callers that need missing-file updates
- cover the new contract and behavior with API, service, poller, and facade tests

## Test Plan
- [x] uv run --group test python -m pytest apps/api/tests/test_storage_source_polling_service.py -q
- [x] uv run --group test python -m pytest apps/api/tests/test_ingest_queue_api.py -k "poll_storage_sources_endpoint" -q
- [x] uv run --group test python -m pytest apps/api/tests/test_ingest_polling.py -q
- [x] uv run --group test python -m pytest apps/api/tests/test_ingest.py -k "poll_registered_storage_sources" -q